### PR TITLE
Added set-e to run_all

### DIFF
--- a/bin/run_all
+++ b/bin/run_all
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 bin/focal_from_exif $1
 bin/detect_features $1
 bin/match_features $1


### PR DESCRIPTION
If one of steps (focal_from_exif, detect_features, ...) in run_all shell script fails, it will fail, instead of continuing with inconsistent state.
