### PR TITLE
Resolving KNN hang issue for SIFT features.

### DIFF
--- a/bin/match_features
+++ b/bin/match_features
@@ -42,14 +42,14 @@ def match(imagepair):
         print "Discarding based of preemptive matches {0} < {1}".format(len(matches_pre), preemptive_threshold)
         return
 
-    # symetric matching
+    # symmetric matching
     t = time.time()
     p1, f1 = features.read_feature(data.feature_file(im1))
-    i1 = cv2.flann_Index()
-    i1.load(f1.astype(np.float32), data.feature_index_file(im1))
+    i1 = features.load_flann_index(f1, data.feature_index_file(im1))
+
     p2, f2 = features.read_feature(data.feature_file(im2))
-    i2 = cv2.flann_Index()
-    i2.load(f2.astype(np.float32), data.feature_index_file(im2))
+    i2 = features.load_flann_index(f2, data.feature_index_file(im2))
+
     matches = features.match_symmetric(f1, i1, f2, i2, data.config)
     if len(matches) < robust_matching_min_match:
         return

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -153,14 +153,24 @@ def read_feature(featurefile):
     return s['points'], s['descriptors']
 
 
-def build_flann_index(f, index_file, config):
-    f = f.astype(np.float32)
+def build_flann_index(features, index_file, config):
+    if features.dtype.type is not np.float32:
+        features = features.astype(np.float32)
+
     flann_params = dict(algorithm=2,
                         branching=config['flann_branching'],
                         iterations=config['flann_iterations'])
-    index = cv2.flann_Index(f, flann_params)
+    index = cv2.flann_Index(features, flann_params)
     index.save(index_file)
 
+def load_flann_index(features, index_file):
+    if features.dtype.type is not np.float32:
+        features = features.astype(np.float32)
+
+    index = cv2.flann_Index()
+    index.load(features, index_file)
+
+    return index
 
 def match_lowe(index, f2, config):
     f2 = f2.astype(np.float32)


### PR DESCRIPTION
After the changes for the AKAZE features the SIFT feature matching no longer worked for me for the Berlin data set. The KNN search in the features.match_lowe function hanged indefinitely. I narrowed it down to the [ced8152](https://github.com/mapillary/OpenSfM/commit/ced8152a4c1a65ad6f67be36ab989dbf81397a86) commit and changed the code to avoid converting values that are already float32 to float32 in connection to the FLANN index calls. After that the SIFT feature matching works for me again.
