### PR TITLE
Saving walk moving mode options when changing to orbit mode.

### DIFF
--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -750,6 +750,7 @@
                     for (var i = 0; i < camera_lines.length; ++i) {
                         if (camera_lines[i].shot_id.indexOf(urlParams.img) > -1) {
                             setImagePlaneCamera(camera_lines[i]);
+                            setShowThumbnail(true);
                             break;
                         }
                     }
@@ -799,9 +800,6 @@
                 var shot_id = cameraObject.shot_id;
                 var shot = r['shots'][shot_id];
                 var image_url = imageURL(shot_id);
-                if (jQuery.isEmptyObject(savedOptions)) {
-                    setShowThumbnail(true)
-                }
                 if (selectedCamera !== undefined) {
                     selectedCamera.material.linewidth = 1;
                     selectedCamera.material.color = options.cameraColor;


### PR DESCRIPTION
I think it would be nice if the walk moving mode options are saved in the same way as the orbit mode options to avoid having to set the options every time the walk mode state is entered.

Also fixing bug that occured when the hash contained 'img'. The show thumbnail value that was set when the savedOptions was an empty object was overwritten by later calls in the init method.
