### PR TITLE
Moving mode transition improvements

### DIFF
--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -832,11 +832,14 @@
                     }
 
                     if (imagePlaneCamera !== undefined) {
-                        imagePlaneCameraOld = imagePlaneCamera;
-                        imageMaterialOld.uniforms.projectorTex.value = imageMaterial.uniforms.projectorTex.value;
-                        imageMaterialOld.uniforms.projectorMat.value = imageMaterial.uniforms.projectorMat.value;
+                        if (imagePlaneCameraOld === undefined || imagePlaneCamera.shot_id !== cameraObject.shot_id) {
+                            imagePlaneCameraOld = imagePlaneCamera;
+                            imageMaterialOld.uniforms.projectorTex.value = imageMaterial.uniforms.projectorTex.value;
+                            imageMaterialOld.uniforms.projectorMat.value = imageMaterial.uniforms.projectorMat.value;
 
-                        imagePlaneOld.geometry = imagePlaneGeo(imagePlaneCameraOld.reconstruction, imagePlaneCameraOld.shot_id);
+                            imagePlaneOld.geometry = imagePlaneGeo(imagePlaneCameraOld.reconstruction, imagePlaneCameraOld.shot_id);
+                        }
+
                         options.imagePlaneOpacity = 1;
                         imagePlaneOld.visible = true;
                     }


### PR DESCRIPTION
I have made two improvements on specific moving mode transition cases.
1. Making image planes show up when going to walk mode by selecting the same camera in orbit mode multiple times in a row. Previously no image planes were shown when selecting the same camera twice or more.
2. When the selected camera is the same as the previously selected one it is not necessary to overwrite the old image plane camera for a better appearance (avoiding duplicated image plane).

For more info see the commit messages.
