### PR TITLE
Using correct image for initial texture.

### DIFF
--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -620,7 +620,7 @@
                 imagePlaneCamera = camera_lines[0];
                 var shot = imagePlaneCamera.reconstruction.shots[imagePlaneCamera.shot_id];
                 var cam = imagePlaneCamera.reconstruction.cameras[shot.camera];
-                var imageTexture = THREE.ImageUtils.loadTexture(imageURL(shot_id));
+                var imageTexture = THREE.ImageUtils.loadTexture(imageURL(imagePlaneCamera.shot_id));
                 imageMaterial = new THREE.ShaderMaterial({
                     side: THREE.DoubleSide,
                     transparent: true,
@@ -648,7 +648,7 @@
                 imagePlane.visible = false;
 
                 imagePlaneCameraOld = camera_lines[0];
-                var imageTextureOld = THREE.ImageUtils.loadTexture(imageURL(shot_id));
+                var imageTextureOld = THREE.ImageUtils.loadTexture(imageURL(imagePlaneCameraOld.shot_id));
 
                 imageMaterialOld = new THREE.ShaderMaterial({
                     // map: imageTexture,


### PR DESCRIPTION
Previously the last image in the reconstruction list was used in the initial texture causing an image shown in the wrong image plane. See an example when initially choosing camera 3 for the berlin dataset in the image below:

![wrong-init-texture](https://cloud.githubusercontent.com/assets/2492302/5515571/6da9e178-8870-11e4-8671-bf28020aa641.jpg)

Now the correct images for the initial image planes are choosen.
