### PR TITLE
Plot inliers

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -16,3 +16,4 @@ mv -vf $1/camera_models.json $trash
 mv -vf $1/reference_lla.json $trash
 mv -vf $1/profile.log $trash
 mv -vf $1/navigation_graph.json $trash
+mv -vf $1/plot_inliers $trash

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -9,7 +9,8 @@ from opensfm import features
 from opensfm import matching
 from opensfm import io
 
-def plot_matches(sub, im1, im2, p1, p2, line_color, point_color):
+
+def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
     image = np.zeros((max(h1,h2), w1+w2, 3), dtype=im1.dtype)
@@ -18,43 +19,27 @@ def plot_matches(sub, im1, im2, p1, p2, line_color, point_color):
 
     p1 = features.denormalized_image_coordinates(p1, w1, h1)
     p2 = features.denormalized_image_coordinates(p2, w2, h2)
-    pl.imshow(image)
+    plot.imshow(image)
     for a, b in zip(p1, p2):
-        pl.plot([a[0], b[0] + w1], [a[1], b[1]], line_color)
+        plot.plot([a[0], b[0] + w1], [a[1], b[1]], line_format)
 
-    sub.plot(p1[:,0], p1[:,1], point_color)
-    sub.plot(p2[:,0] + w1, p2[:,1], point_color)
+    plot.plot(p1[:,0], p1[:,1], point_format)
+    plot.plot(p2[:,0] + w1, p2[:,1], point_format)
 
-def plot_sub(fig, rows, columns, index, title, im1, im2, p1, p2, line_color, point_color, data):
-    sub = fig.add_subplot(rows, columns, index)
-    sub.axis('off')
-    sub.text(0.5, 0.9,
-             title,
-             horizontalalignment='center',
-             fontsize=12,
-             transform = sub.transAxes)
 
-    plot_matches(sub, data.image_as_array(im1), data.image_as_array(im2), p1, p2, line_color, point_color)
+def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format, data):
+    subplot = figure.add_subplot(rows, columns, index)
+    subplot.axis('off')
+    subplot.text(0.5, 0.9,
+                 title,
+                 horizontalalignment='center',
+                 fontsize=12,
+                 transform = subplot.transAxes)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Plot inlier and outlier matches between images')
-    parser.add_argument('dataset',
-                        help='path to the data set to be processed')
-    parser.add_argument('image1',
-                        help='name of the first image to show')
-    parser.add_argument('image2',
-                        help='name of the second image to show')
-    parser.add_argument('--save_figs',
-                        help='save figures instead of showing them',
-                        action='store_true')
+    plot_matches(subplot, data.image_as_array(im1), data.image_as_array(im2), p1, p2, line_format, point_format)
 
-    args = parser.parse_args()
-    data = dataset.DataSet(args.dataset)
-    images = data.images()
 
-    im1 = args.image1
-    im2 = args.image2
-
+def plot_symmetric_matches(im1, im2, data, save_figs=False):
     p1, f1 = data.load_features(im1)
     i1 = data.load_feature_index(im1, f1)
 
@@ -92,8 +77,8 @@ if __name__ == "__main__":
     for match in symmetric_matches:
 
         found = False
-        for rmatch in robust_matches:
-            if np.array_equal(match, rmatch):
+        for robust_match in robust_matches:
+            if np.array_equal(match, robust_match):
                 found = True
                 break
 
@@ -112,10 +97,29 @@ if __name__ == "__main__":
 
     pl.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 
-    if args.save_figs:
+    if save_figs:
         p = args.dataset + '/plot_inliers'
         io.mkdir_p(p)
         pl.savefig(p + '/' + im1 + '_' + im2 + '.jpg', dpi=100)
         pl.close()
     else:
         pl.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Plot inlier and outlier matches between images')
+    parser.add_argument('dataset',
+                        help='path to the data set to be processed')
+    parser.add_argument('image1',
+                        help='name of the first image to show')
+    parser.add_argument('image2',
+                        help='name of the second image to show')
+    parser.add_argument('--save_figs',
+                        help='save figures instead of showing them',
+                        action='store_true')
+
+    args = parser.parse_args()
+    data_set = dataset.DataSet(args.dataset)
+
+    plot_symmetric_matches(args.image1, args.image2, data_set, args.save_figs)
+

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+import argparse
+import matplotlib.pyplot as pl
+import numpy as np
+
+from opensfm import dataset
+from opensfm import features
+from opensfm import matching
+from opensfm import io
+
+def plot_matches(sub, im1, im2, p1, p2, line_color, point_color):
+    h1, w1, c = im1.shape
+    h2, w2, c = im2.shape
+    image = np.zeros((max(h1,h2), w1+w2, 3), dtype=im1.dtype)
+    image[0:h1, 0:w1, :] = im1
+    image[0:h2, w1:(w1+w2), :] = im2
+
+    p1 = features.denormalized_image_coordinates(p1, w1, h1)
+    p2 = features.denormalized_image_coordinates(p2, w2, h2)
+    pl.imshow(image)
+    for a, b in zip(p1, p2):
+        pl.plot([a[0], b[0] + w1], [a[1], b[1]], line_color)
+
+    sub.plot(p1[:,0], p1[:,1], point_color)
+    sub.plot(p2[:,0] + w1, p2[:,1], point_color)
+
+def plot_sub(fig, rows, columns, index, title, im1, im2, p1, p2, line_color, point_color, data):
+    sub = fig.add_subplot(rows, columns, index)
+    sub.axis('off')
+    sub.text(0.5, 0.9,
+             title,
+             horizontalalignment='center',
+             fontsize=12,
+             transform = sub.transAxes)
+
+    plot_matches(sub, data.image_as_array(im1), data.image_as_array(im2), p1, p2, line_color, point_color)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Plot inlier and outlier matches between images')
+    parser.add_argument('dataset',
+                        help='path to the data set to be processed')
+    parser.add_argument('image1',
+                        help='name of the first image to show')
+    parser.add_argument('image2',
+                        help='name of the second image to show')
+    parser.add_argument('--save_figs',
+                        help='save figures instead of showing them',
+                        action='store_true')
+
+    args = parser.parse_args()
+    data = dataset.DataSet(args.dataset)
+    images = data.images()
+
+    im1 = args.image1
+    im2 = args.image2
+
+    p1, f1 = data.load_features(im1)
+    i1 = data.load_feature_index(im1, f1)
+
+    p2, f2 = data.load_features(im2)
+    i2 = data.load_feature_index(im2, f2)
+
+    symmetric_matches = matching.match_symmetric(f1, i1, f2, i2, data.config)
+
+    s_matches1 = p1[symmetric_matches[:,0]]
+    s_matches2 = p2[symmetric_matches[:,1]]
+
+    fig = pl.figure(figsize=(20, 10))
+    fig.suptitle('Matches: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+
+    plot_sub(fig, 3, 1, 1,
+             'Number of symmetric matches: ' + str(symmetric_matches.shape[0]),
+             im1, im2,
+             s_matches1, s_matches2,
+             'c', 'ob',
+             data)
+
+    robust_matches = matching.robust_match(p1, p2, symmetric_matches, data.config)
+
+    r_matches1 = p1[robust_matches[:,0]]
+    r_matches2 = p2[robust_matches[:,1]]
+
+    plot_sub(fig, 3, 1, 2,
+             'Number of robust matching inliers: ' + str(robust_matches.shape[0]),
+             im1, im2,
+             r_matches1, r_matches2,
+             'g', 'oy',
+             data)
+
+    outliers = np.empty((0,2), int)
+    for match in symmetric_matches:
+
+        found = False
+        for rmatch in robust_matches:
+            if np.array_equal(match, rmatch):
+                found = True
+                break
+
+        if not found:
+            outliers = np.vstack((outliers, match))
+
+    outliers1 = p1[outliers[:,0]]
+    outliers2 = p2[outliers[:,1]]
+
+    plot_sub(fig, 3, 1, 3,
+             'Number of robust matching outliers: ' + str(outliers.shape[0]),
+             im1, im2,
+             outliers1, outliers2,
+             'r', 'om',
+             data)
+
+    pl.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
+
+    if args.save_figs:
+        p = args.dataset + '/plot_inliers'
+        io.mkdir_p(p)
+        pl.savefig(p + '/' + im1 + '_' + im2 + '.jpg', dpi=100)
+        pl.close()
+    else:
+        pl.show()

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -59,7 +59,7 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(20, 10))
+    fig = pl.figure(figsize=(12, 12))
     fig.suptitle('Matches: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
 
     # Calculate symmetric matches and plot.
@@ -122,7 +122,6 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     if save_figs:
         p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
-        fig.set_size_inches(12, 12)
         fig.savefig(p + '/' + im1 + '_' + im2 + '_matches.jpg', dpi=100)
         pl.close()
     else:
@@ -134,7 +133,7 @@ def plot_tracks(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(20, 10))
+    fig = pl.figure(figsize=(12, 12))
     fig.suptitle('Tracks: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
 
     # Retrieve tracks and robust matches from file and plot tracks corresponding to
@@ -242,7 +241,6 @@ def plot_tracks(im1, im2, data, save_figs=False):
     if save_figs:
         p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
-        fig.set_size_inches(12, 12)
         fig.savefig(p + '/' + im1 + '_' + im2 + '_tracks.jpg', dpi=100)
         pl.close()
     else:

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -8,18 +8,23 @@ from opensfm import dataset
 from opensfm import features
 from opensfm import matching
 from opensfm import io
+from opensfm import csfm
 
 
-def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
+def show_images(plot, im1, im2):
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
     image = np.zeros((max(h1,h2), w1+w2, 3), dtype=im1.dtype)
     image[0:h1, 0:w1, :] = im1
     image[0:h2, w1:(w1+w2), :] = im2
+    plot.imshow(image)
 
+
+def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
+    h1, w1, c = im1.shape
+    h2, w2, c = im2.shape
     p1 = features.denormalized_image_coordinates(p1, w1, h1)
     p2 = features.denormalized_image_coordinates(p2, w2, h2)
-    plot.imshow(image)
     for a, b in zip(p1, p2):
         plot.plot([a[0], b[0] + w1], [a[1], b[1]], line_format)
 
@@ -27,7 +32,7 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     plot.plot(p2[:,0] + w1, p2[:,1], point_format)
 
 
-def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format, data):
+def create_subplot(figure, rows, columns, index, title):
     subplot = figure.add_subplot(rows, columns, index)
     subplot.axis('off')
     subplot.text(0.5, 0.9,
@@ -36,7 +41,19 @@ def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format,
                  fontsize=12,
                  transform = subplot.transAxes)
 
-    plot_matches(subplot, data.image_as_array(im1), data.image_as_array(im2), p1, p2, line_format, point_format)
+    return subplot
+
+
+def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format, data):
+    subplot = create_subplot(figure, rows, columns, index, title)
+
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    show_images(subplot, im1_array, im2_array)
+    plot_matches(subplot, im1_array, im2_array, p1, p2, line_format, point_format)
+
+    return subplot
 
 
 def plot_symmetric_matches(im1, im2, data, save_figs=False):
@@ -101,7 +118,106 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
         p = args.dataset + '/plot_inliers'
         io.mkdir_p(p)
         fig.set_size_inches(12, 12)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '.jpg', dpi=100)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '_matches.jpg', dpi=100)
+        pl.close()
+    else:
+        pl.show()
+
+
+def plot_tracks(im1, im2, data, save_figs=False):
+    graph = data.load_tracks_graph()
+
+    p1, features1 = data.load_features(im1)
+    p2, features2 = data.load_features(im2)
+    p1 = np.array(p1[:, :2], np.float64)
+    p2 = np.array(p2[:, :2], np.float64)
+
+    if data_set.matches_exists(im1, im2):
+        robust_matches = data_set.load_matches(im1, im2)
+    elif data_set.matches_exists(im2, im1):
+        loaded_matches = data_set.load_matches(im2, im1)
+        robust_matches = loaded_matches[:, [1, 0]]
+    else:
+        robust_matches = np.empty((0,2), int)
+
+    t1, t2 = graph[im1], graph[im2]
+
+    track_matches = []
+    for track in t1:
+        if track in t2:
+            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id']]))
+
+    track_matches = np.array(track_matches)
+
+    if track_matches.shape[0] < 8:
+        print 'Not enough tracks: ' + str(track_matches.shape[0])
+        return
+
+    track_points1 = p1[track_matches[:,0]]
+    track_points2 = p2[track_matches[:,1]]
+
+    fig = pl.figure(figsize=(20, 10))
+    fig.suptitle('Tracks: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+
+    non_robust_tracks = np.empty((0,2), int)
+    for match in track_matches:
+
+        found = False
+        for robust_match in robust_matches:
+            if np.array_equal(match, robust_match):
+                found = True
+                break
+
+        if not found:
+            non_robust_tracks = np.vstack((non_robust_tracks, match))
+
+    non_robust_tracks1 = p1[non_robust_tracks[:,0]]
+    non_robust_tracks2 = p2[non_robust_tracks[:,1]]
+
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    tracks_subplot = plot_sub(fig, 2, 1, 1,
+             'Common tracks: ' + str(track_matches.shape[0]) + '. Robust match tracks: ' +
+             str(robust_matches.shape[0]) + '. Non robust match tracks: ' + str(non_robust_tracks.shape[0]),
+             im1, im2,
+             track_points1, track_points2,
+             'c', 'ob',
+             data_set)
+    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'r', 'om')
+
+    f1 = data_set.load_exif(im1)['focal_ratio']
+    f2 = data_set.load_exif(im2)['focal_ratio']
+
+    threshold = data_set.config.get('five_point_algo_threshold', 0.006)
+    R, t, inliers = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold)
+
+    inliers1 = track_points1[inliers, :]
+    inliers2 = track_points2[inliers, :]
+
+    mask = np.ones(track_points1.shape[0],dtype=bool)
+    mask[inliers] = False
+    outliers1 = track_points1[mask]
+    outliers2 = track_points2[mask]
+
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    subplot3 = plot_sub(fig, 2, 1, 2,
+             'Inliers in CSfM two view reconstruction: ' + str(len(inliers)) + '. Outliers: ' + str(mask.sum()),
+             im1, im2,
+             inliers1, inliers2,
+             'c', 'ob',
+             data_set)
+    plot_matches(subplot3, im1_array, im2_array, outliers1, outliers2, 'r', 'om')
+
+    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
+
+    if save_figs:
+        p = args.dataset + '/plot_inliers'
+        io.mkdir_p(p)
+        fig.set_size_inches(12, 12)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '_tracks.jpg', dpi=100)
         pl.close()
     else:
         pl.show()
@@ -123,4 +239,13 @@ if __name__ == "__main__":
     data_set = dataset.DataSet(args.dataset)
 
     plot_symmetric_matches(args.image1, args.image2, data_set, args.save_figs)
+    plot_tracks(args.image1, args.image2, data_set, args.save_figs)
+
+
+
+
+
+
+
+
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -54,7 +54,7 @@ def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format,
     return subplot
 
 
-def plot_symmetric_matches(im1, im2, data, save_figs=False):
+def create_matches_figure(im1, im2, data, save_figs=False):
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
@@ -128,7 +128,7 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
         pl.show()
 
 
-def plot_tracks(im1, im2, data, save_figs=False):
+def create_tracks_figure(im1, im2, data, save_figs=False):
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
@@ -262,8 +262,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     data_set = dataset.DataSet(args.dataset)
 
-    plot_symmetric_matches(args.image1, args.image2, data_set, args.save_figs)
-    plot_tracks(args.image1, args.image2, data_set, args.save_figs)
+    create_matches_figure(args.image1, args.image2, data_set, args.save_figs)
+    create_tracks_figure(args.image1, args.image2, data_set, args.save_figs)
 
 
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -71,6 +71,10 @@ def create_matches_figure(im1, im2, data, save_figs=False):
 
     symmetric_matches = matching.match_symmetric(f1, i1, f2, i2, data.config)
 
+    if symmetric_matches.shape[0] < 8:
+        print 'Not enough matches for eight point algorithm: ' + str(symmetric_matches.shape[0])
+        return
+
     s_matches1 = p1[symmetric_matches[:,0]]
     s_matches2 = p2[symmetric_matches[:,1]]
 
@@ -162,8 +166,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
 
     track_matches = np.array(track_matches)
 
-    if track_matches.shape[0] < 8:
-        print 'Not enough tracks: ' + str(track_matches.shape[0])
+    if track_matches.shape[0] < 5:
+        print 'Not enough tracks for five point algorithm: ' + str(track_matches.shape[0])
         return
 
     track_points1 = p1[track_matches[:,0]]

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -234,10 +234,10 @@ def plot_tracks(im1, im2, data, save_figs=False):
              'CSfM two view reconstruction inliers: ' + str(len(inliers_t)) + '. Outliers: ' + str(mask.sum()) +
               '. Threshold: ' + '%.4f' % threshold_t,
              im1, im2,
-             outliers_t1, outliers_t2,
-             'r', 'om',
+             inliers_t1, inliers_t2,
+             'c', 'ob',
              data)
-    plot_matches(subplot3, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
+    plot_matches(subplot3, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -60,7 +60,9 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     im2_array = data.image_as_array(im2)
 
     fig = pl.figure(figsize=(12, 12))
-    fig.suptitle('Matches: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+
+    fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
+                 fontsize=14, fontweight='bold')
 
     # Calculate symmetric matches and plot.
     p1, f1 = data.load_features(im1)
@@ -79,7 +81,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     s_matches2 = p2[symmetric_matches[:,1]]
 
     plot_sub(fig, 3, 1, 1,
-             'Number of symmetric matches: ' + str(symmetric_matches.shape[0]),
+             'Number of symmetric matches: {0}'.format(symmetric_matches.shape[0]),
              im1_array, im2_array,
              s_matches1, s_matches2,
              'c', 'ob')
@@ -92,8 +94,8 @@ def create_matches_figure(im1, im2, data, save_figs=False):
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
     plot_sub(fig, 3, 1, 2,
-             'Number of robust matching inliers: ' + str(robust_matches.shape[0]) +
-             '. Threshold: ' + '%.4f' % threshold,
+             'Number of robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
+                 robust_matches.shape[0], threshold),
              im1_array, im2_array,
              r_matches1, r_matches2,
              'g', 'oy')
@@ -115,8 +117,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     outliers2 = p2[outliers[:,1]]
 
     plot_sub(fig, 3, 1, 3,
-             'Number of robust matching outliers: ' + str(outliers.shape[0]) +
-             '. Threshold: ' + '%.4f' % threshold,
+             'Number of robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
              im1_array, im2_array,
              outliers1, outliers2,
              'r', 'om')
@@ -138,7 +139,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     im2_array = data.image_as_array(im2)
 
     fig = pl.figure(figsize=(12, 12))
-    fig.suptitle('Tracks: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+    fig.suptitle('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
+                 fontsize=14, fontweight='bold')
 
     # Retrieve tracks and robust matches from file and plot tracks corresponding to
     # robust matches and tracks not corresponding to robust matches in different colors.
@@ -188,12 +190,13 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     non_robust_tracks1 = p1[non_robust_tracks[:,0]]
     non_robust_tracks2 = p2[non_robust_tracks[:,1]]
 
-    tracks_subplot = plot_sub(fig, 3, 1, 1,
-             'Common tracks: ' + str(track_matches.shape[0]) + '. Robust match tracks: ' +
-             str(robust_matches.shape[0]) + '. Non robust match tracks: ' + str(non_robust_tracks.shape[0]),
-             im1_array, im2_array,
-             track_points1, track_points2,
-             'c', 'ob')
+    title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
+        track_matches.shape[0],
+        track_matches.shape[0] - non_robust_tracks.shape[0],
+        robust_matches.shape[0],
+        non_robust_tracks.shape[0])
+
+    tracks_subplot = plot_sub(fig, 3, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -208,13 +211,10 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_h1 = track_points1[~inliers_h, :]
     outliers_h2 = track_points2[~inliers_h, :]
 
-    homography_subplot = plot_sub(fig, 3, 1, 2,
-             'OpenCV find homography inliers: ' + str(inliers_h.sum()) + '. Outliers: ' + str((~inliers_h).sum()) +
-             '. Outlier ratio: ' + '%.3f' % (float((~inliers_h).sum()) / track_matches.shape[0]) +
-             '. Threshold: ' + '%.4f' % threshold_h,
-             im1_array, im2_array,
-             outliers_h1, outliers_h2,
-             'r', 'om')
+    title_h = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
+        inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / track_matches.shape[0], threshold_h)
+
+    homography_subplot = plot_sub(fig, 3, 1, 2, title_h, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(homography_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
     # Plot inliers and outliers of the tracks from csfm two view reconstruction.
@@ -227,17 +227,15 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     inliers_t1 = track_points1[inliers_t, :]
     inliers_t2 = track_points2[inliers_t, :]
 
-    mask = np.ones(track_points1.shape[0],dtype=bool)
-    mask[inliers_t] = False
-    outliers_t1 = track_points1[mask, :]
-    outliers_t2 = track_points2[mask, :]
+    outliers_t = np.ones(track_points1.shape[0],dtype=bool)
+    outliers_t[inliers_t] = False
+    outliers_t1 = track_points1[outliers_t, :]
+    outliers_t2 = track_points2[outliers_t, :]
 
-    two_view_subplot = plot_sub(fig, 3, 1, 3,
-             'CSfM two view reconstruction inliers: ' + str(len(inliers_t)) + '. Outliers: ' + str(mask.sum()) +
-              '. Threshold: ' + '%.4f' % threshold_t,
-             im1_array, im2_array,
-             inliers_t1, inliers_t2,
-             'c', 'ob')
+    title_t = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
+        len(inliers_t), outliers_t.sum(), threshold_t)
+
+    two_view_subplot = plot_sub(fig, 3, 1, 3, title_t, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(two_view_subplot , im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -95,12 +95,13 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
              'r', 'om',
              data)
 
-    pl.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 
     if save_figs:
         p = args.dataset + '/plot_inliers'
         io.mkdir_p(p)
-        pl.savefig(p + '/' + im1 + '_' + im2 + '.jpg', dpi=100)
+        fig.set_size_inches(12, 12)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '.jpg', dpi=100)
         pl.close()
     else:
         pl.show()

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -15,7 +15,7 @@ from opensfm import csfm
 def show_images(plot, im1, im2):
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
-    image = np.zeros((max(h1,h2), w1+w2, 3), dtype=im1.dtype)
+    image = np.zeros((max(h1, h2), w1+w2, 3), dtype=im1.dtype)
     image[0:h1, 0:w1, :] = im1
     image[0:h2, w1:(w1+w2), :] = im2
     plot.imshow(image)
@@ -27,8 +27,8 @@ def plot_points(plot, im1, im2, p1, p2, point_format1='ob', point_format2='ob'):
     p1d = features.denormalized_image_coordinates(p1, w1, h1)
     p2d = features.denormalized_image_coordinates(p2, w2, h2)
 
-    plot.plot(p1d[:,0], p1d[:,1], point_format1)
-    plot.plot(p2d[:,0] + w1, p2d[:,1], point_format2)
+    plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
+    plot.plot(p2d[:, 0] + w1, p2d[:, 1], point_format2)
 
 
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
@@ -49,7 +49,7 @@ def create_subplot(figure, rows, columns, index, title):
                  title,
                  horizontalalignment='center',
                  fontsize=12,
-                 transform = subplot.transAxes)
+                 transform=subplot.transAxes)
 
     return subplot
 
@@ -98,31 +98,31 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     features_title = 'Features: {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
     plot_points_sub(fig, 4, 1, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
 
-    s_matches1 = p1[symmetric_matches[:,0]]
-    s_matches2 = p2[symmetric_matches[:,1]]
+    s_matches1 = p1[symmetric_matches[:, 0]]
+    s_matches2 = p2[symmetric_matches[:, 1]]
 
     plot_matches_sub(fig, 4, 1, 2,
-             'Symmetric matches: {0}'.format(symmetric_matches.shape[0]),
-             im1_array, im2_array,
-             s_matches1, s_matches2,
-             'c', 'ob')
+                     'Symmetric matches: {0}'.format(symmetric_matches.shape[0]),
+                     im1_array, im2_array,
+                     s_matches1, s_matches2,
+                     'c', 'ob')
 
     # Calculate robust matches and plot inliers.
     robust_matches = matching.robust_match(p1, p2, symmetric_matches, data.config)
 
-    r_matches1 = p1[robust_matches[:,0]]
-    r_matches2 = p2[robust_matches[:,1]]
+    r_matches1 = p1[robust_matches[:, 0]]
+    r_matches2 = p2[robust_matches[:, 1]]
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
     plot_matches_sub(fig, 4, 1, 3,
-             'Robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
-                 robust_matches.shape[0], threshold),
-             im1_array, im2_array,
-             r_matches1, r_matches2,
-             'g', 'oy')
+                     'Robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
+                         robust_matches.shape[0], threshold),
+                     im1_array, im2_array,
+                     r_matches1, r_matches2,
+                     'g', 'oy')
 
     # Retrieve and plot robust match outliers.
-    outliers = np.empty((0,2), int)
+    outliers = np.empty((0, 2), int)
     for match in symmetric_matches:
 
         found = False
@@ -134,14 +134,14 @@ def create_matches_figure(im1, im2, data, save_figs=False):
         if not found:
             outliers = np.vstack((outliers, match))
 
-    outliers1 = p1[outliers[:,0]]
-    outliers2 = p2[outliers[:,1]]
+    outliers1 = p1[outliers[:, 0]]
+    outliers2 = p2[outliers[:, 1]]
 
     plot_matches_sub(fig, 4, 1, 4,
-             'Robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
-             im1_array, im2_array,
-             outliers1, outliers2,
-             'r', 'om')
+                     'Robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
+                     im1_array, im2_array,
+                     outliers1, outliers2,
+                     'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
 
@@ -178,7 +178,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         loaded_matches = data.load_matches(im2, im1)
         robust_matches = loaded_matches[:, [1, 0]]
     else:
-        robust_matches = np.empty((0,2), int)
+        robust_matches = np.empty((0, 2), int)
 
     t1, t2 = graph[im1], graph[im2]
 
@@ -193,10 +193,10 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         print 'Not enough tracks for five point algorithm: ' + str(track_matches.shape[0])
         return
 
-    track_points1 = p1[track_matches[:,0]]
-    track_points2 = p2[track_matches[:,1]]
+    track_points1 = p1[track_matches[:, 0]]
+    track_points2 = p2[track_matches[:, 1]]
 
-    non_robust_tracks = np.empty((0,2), int)
+    non_robust_tracks = np.empty((0, 2), int)
     for match in track_matches:
 
         found = False
@@ -208,8 +208,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         if not found:
             non_robust_tracks = np.vstack((non_robust_tracks, match))
 
-    non_robust_tracks1 = p1[non_robust_tracks[:,0]]
-    non_robust_tracks2 = p2[non_robust_tracks[:,1]]
+    non_robust_tracks1 = p1[non_robust_tracks[:, 0]]
+    non_robust_tracks2 = p2[non_robust_tracks[:, 1]]
 
     tracks_title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
         track_matches.shape[0],
@@ -217,7 +217,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         robust_matches.shape[0],
         non_robust_tracks.shape[0])
 
-    tracks_subplot = plot_matches_sub(fig, 3, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
+    tracks_subplot = plot_matches_sub(
+        fig, 3, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -248,7 +249,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     inliers_t1 = track_points1[inliers_t, :]
     inliers_t2 = track_points2[inliers_t, :]
 
-    outliers_t = np.ones(track_points1.shape[0],dtype=bool)
+    outliers_t = np.ones(track_points1.shape[0], dtype=bool)
     outliers_t[inliers_t] = False
     outliers_t1 = track_points1[outliers_t, :]
     outliers_t2 = track_points2[outliers_t, :]
@@ -257,7 +258,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         len(inliers_t), outliers_t.sum(), threshold_t)
 
     t_subplot = plot_matches_sub(fig, 3, 1, 3, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
-    plot_matches(t_subplot , im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
+    plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
 
@@ -287,12 +288,3 @@ if __name__ == "__main__":
 
     create_matches_figure(args.image1, args.image2, data_set, args.save_figs)
     create_tracks_figure(args.image1, args.image2, data_set, args.save_figs)
-
-
-
-
-
-
-
-
-

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -3,6 +3,7 @@
 import argparse
 import matplotlib.pyplot as pl
 import numpy as np
+import cv2
 
 from opensfm import dataset
 from opensfm import features
@@ -83,8 +84,10 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     r_matches1 = p1[robust_matches[:,0]]
     r_matches2 = p2[robust_matches[:,1]]
 
+    threshold = data.config.get('robust_matching_threshold', 0.006)
     plot_sub(fig, 3, 1, 2,
-             'Number of robust matching inliers: ' + str(robust_matches.shape[0]),
+             'Number of robust matching inliers: ' + str(robust_matches.shape[0]) +
+             '. Threshold: ' + '%.4f' % threshold,
              im1, im2,
              r_matches1, r_matches2,
              'g', 'oy',
@@ -106,7 +109,8 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     outliers2 = p2[outliers[:,1]]
 
     plot_sub(fig, 3, 1, 3,
-             'Number of robust matching outliers: ' + str(outliers.shape[0]),
+             'Number of robust matching outliers: ' + str(outliers.shape[0]) +
+             '. Threshold: ' + '%.4f' % threshold,
              im1, im2,
              outliers1, outliers2,
              'r', 'om',
@@ -115,7 +119,7 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 
     if save_figs:
-        p = args.dataset + '/plot_inliers'
+        p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
         fig.set_size_inches(12, 12)
         fig.savefig(p + '/' + im1 + '_' + im2 + '_matches.jpg', dpi=100)
@@ -132,10 +136,10 @@ def plot_tracks(im1, im2, data, save_figs=False):
     p1 = np.array(p1[:, :2], np.float64)
     p2 = np.array(p2[:, :2], np.float64)
 
-    if data_set.matches_exists(im1, im2):
-        robust_matches = data_set.load_matches(im1, im2)
-    elif data_set.matches_exists(im2, im1):
-        loaded_matches = data_set.load_matches(im2, im1)
+    if data.matches_exists(im1, im2):
+        robust_matches = data.load_matches(im1, im2)
+    elif data.matches_exists(im2, im1):
+        loaded_matches = data.load_matches(im2, im1)
         robust_matches = loaded_matches[:, [1, 0]]
     else:
         robust_matches = np.empty((0,2), int)
@@ -177,44 +181,68 @@ def plot_tracks(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    tracks_subplot = plot_sub(fig, 2, 1, 1,
+    tracks_subplot = plot_sub(fig, 3, 1, 1,
              'Common tracks: ' + str(track_matches.shape[0]) + '. Robust match tracks: ' +
              str(robust_matches.shape[0]) + '. Non robust match tracks: ' + str(non_robust_tracks.shape[0]),
              im1, im2,
              track_points1, track_points2,
              'c', 'ob',
-             data_set)
-    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'r', 'om')
+             data)
+    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
-    f1 = data_set.load_exif(im1)['focal_ratio']
-    f2 = data_set.load_exif(im2)['focal_ratio']
+    # Plot inliers and outliers from OpenCV find homography
+    threshold_h = data.config.get('homography_threshold', 0.004)
+    H, inliers_h = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
 
-    threshold = data_set.config.get('five_point_algo_threshold', 0.006)
-    R, t, inliers = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold)
+    inliers_h = np.array(np.squeeze(inliers_h), np.bool)
 
-    inliers1 = track_points1[inliers, :]
-    inliers2 = track_points2[inliers, :]
+    inliers_h1 = track_points1[inliers_h, :]
+    inliers_h2 = track_points2[inliers_h, :]
 
-    mask = np.ones(track_points1.shape[0],dtype=bool)
-    mask[inliers] = False
-    outliers1 = track_points1[mask]
-    outliers2 = track_points2[mask]
+    outliers_h1 = track_points1[~inliers_h, :]
+    outliers_h2 = track_points2[~inliers_h, :]
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    subplot3 = plot_sub(fig, 2, 1, 2,
-             'Inliers in CSfM two view reconstruction: ' + str(len(inliers)) + '. Outliers: ' + str(mask.sum()),
+    subplot3 = plot_sub(fig, 3, 1, 2,
+             'OpenCV find homography inliers: ' + str(inliers_h.sum()) + '. Outliers: ' + str((~inliers_h).sum()) +
+             '. Outlier ratio: ' + '%.3f' % (float((~inliers_h).sum()) / track_matches.shape[0]) +
+             '. Threshold: ' + '%.4f' % threshold_h,
              im1, im2,
-             inliers1, inliers2,
-             'c', 'ob',
-             data_set)
-    plot_matches(subplot3, im1_array, im2_array, outliers1, outliers2, 'r', 'om')
+             outliers_h1, outliers_h2,
+             'r', 'om',
+             data)
+    plot_matches(subplot3, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
+
+    # Plot inliers and outliers from csfm two view reconstruction
+    f1 = data.load_exif(im1)['focal_ratio']
+    f2 = data.load_exif(im2)['focal_ratio']
+
+    threshold_t = data.config.get('five_point_algo_threshold', 0.006)
+    R, t, inliers_t = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold_t)
+
+    inliers_t1 = track_points1[inliers_t, :]
+    inliers_t2 = track_points2[inliers_t, :]
+
+    mask = np.ones(track_points1.shape[0],dtype=bool)
+    mask[inliers_t] = False
+    outliers_t1 = track_points1[mask, :]
+    outliers_t2 = track_points2[mask, :]
+
+    subplot3 = plot_sub(fig, 3, 1, 3,
+             'CSfM two view reconstruction inliers: ' + str(len(inliers_t)) + '. Outliers: ' + str(mask.sum()) +
+              '. Threshold: ' + '%.4f' % threshold_t,
+             im1, im2,
+             outliers_t1, outliers_t2,
+             'r', 'om',
+             data)
+    plot_matches(subplot3, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 
     if save_figs:
-        p = args.dataset + '/plot_inliers'
+        p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
         fig.set_size_inches(12, 12)
         fig.savefig(p + '/' + im1 + '_' + im2 + '_tracks.jpg', dpi=100)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -127,7 +127,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     if save_figs:
         p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '_matches.jpg', dpi=100)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_matches.jpg', dpi=100)
         pl.close()
     else:
         pl.show()
@@ -243,7 +243,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     if save_figs:
         p = data.data_path + '/plot_inliers'
         io.mkdir_p(p)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '_tracks.jpg', dpi=100)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_tracks.jpg', dpi=100)
         pl.close()
     else:
         pl.show()

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -45,19 +45,24 @@ def create_subplot(figure, rows, columns, index, title):
     return subplot
 
 
-def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format, data):
+def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
     subplot = create_subplot(figure, rows, columns, index, title)
 
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
-    show_images(subplot, im1_array, im2_array)
-    plot_matches(subplot, im1_array, im2_array, p1, p2, line_format, point_format)
+    show_images(subplot, im1, im2)
+    plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
 
     return subplot
 
 
 def plot_symmetric_matches(im1, im2, data, save_figs=False):
+
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    fig = pl.figure(figsize=(20, 10))
+    fig.suptitle('Matches: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+
+    # Calculate symmetric matches and plot.
     p1, f1 = data.load_features(im1)
     i1 = data.load_feature_index(im1, f1)
 
@@ -69,16 +74,13 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     s_matches1 = p1[symmetric_matches[:,0]]
     s_matches2 = p2[symmetric_matches[:,1]]
 
-    fig = pl.figure(figsize=(20, 10))
-    fig.suptitle('Matches: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
-
     plot_sub(fig, 3, 1, 1,
              'Number of symmetric matches: ' + str(symmetric_matches.shape[0]),
-             im1, im2,
+             im1_array, im2_array,
              s_matches1, s_matches2,
-             'c', 'ob',
-             data)
+             'c', 'ob')
 
+    # Calculate robust matches and plot inliers.
     robust_matches = matching.robust_match(p1, p2, symmetric_matches, data.config)
 
     r_matches1 = p1[robust_matches[:,0]]
@@ -88,11 +90,11 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     plot_sub(fig, 3, 1, 2,
              'Number of robust matching inliers: ' + str(robust_matches.shape[0]) +
              '. Threshold: ' + '%.4f' % threshold,
-             im1, im2,
+             im1_array, im2_array,
              r_matches1, r_matches2,
-             'g', 'oy',
-             data)
+             'g', 'oy')
 
+    # Retrieve and plot robust match outliers.
     outliers = np.empty((0,2), int)
     for match in symmetric_matches:
 
@@ -111,10 +113,9 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
     plot_sub(fig, 3, 1, 3,
              'Number of robust matching outliers: ' + str(outliers.shape[0]) +
              '. Threshold: ' + '%.4f' % threshold,
-             im1, im2,
+             im1_array, im2_array,
              outliers1, outliers2,
-             'r', 'om',
-             data)
+             'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 
@@ -129,6 +130,15 @@ def plot_symmetric_matches(im1, im2, data, save_figs=False):
 
 
 def plot_tracks(im1, im2, data, save_figs=False):
+
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    fig = pl.figure(figsize=(20, 10))
+    fig.suptitle('Tracks: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
+
+    # Retrieve tracks and robust matches from file and plot tracks corresponding to
+    # robust matches and tracks not corresponding to robust matches in different colors.
     graph = data.load_tracks_graph()
 
     p1, features1 = data.load_features(im1)
@@ -160,9 +170,6 @@ def plot_tracks(im1, im2, data, save_figs=False):
     track_points1 = p1[track_matches[:,0]]
     track_points2 = p2[track_matches[:,1]]
 
-    fig = pl.figure(figsize=(20, 10))
-    fig.suptitle('Tracks: ' + im1 + ' - ' + im2, fontsize=14, fontweight='bold')
-
     non_robust_tracks = np.empty((0,2), int)
     for match in track_matches:
 
@@ -178,19 +185,15 @@ def plot_tracks(im1, im2, data, save_figs=False):
     non_robust_tracks1 = p1[non_robust_tracks[:,0]]
     non_robust_tracks2 = p2[non_robust_tracks[:,1]]
 
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
     tracks_subplot = plot_sub(fig, 3, 1, 1,
              'Common tracks: ' + str(track_matches.shape[0]) + '. Robust match tracks: ' +
              str(robust_matches.shape[0]) + '. Non robust match tracks: ' + str(non_robust_tracks.shape[0]),
-             im1, im2,
+             im1_array, im2_array,
              track_points1, track_points2,
-             'c', 'ob',
-             data)
+             'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
-    # Plot inliers and outliers from OpenCV find homography
+    # Plot inliers and outliers of the tracks from OpenCV find homography.
     threshold_h = data.config.get('homography_threshold', 0.004)
     H, inliers_h = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
 
@@ -202,20 +205,16 @@ def plot_tracks(im1, im2, data, save_figs=False):
     outliers_h1 = track_points1[~inliers_h, :]
     outliers_h2 = track_points2[~inliers_h, :]
 
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
-    subplot3 = plot_sub(fig, 3, 1, 2,
+    homography_subplot = plot_sub(fig, 3, 1, 2,
              'OpenCV find homography inliers: ' + str(inliers_h.sum()) + '. Outliers: ' + str((~inliers_h).sum()) +
              '. Outlier ratio: ' + '%.3f' % (float((~inliers_h).sum()) / track_matches.shape[0]) +
              '. Threshold: ' + '%.4f' % threshold_h,
-             im1, im2,
+             im1_array, im2_array,
              outliers_h1, outliers_h2,
-             'r', 'om',
-             data)
-    plot_matches(subplot3, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
+             'r', 'om')
+    plot_matches(homography_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
-    # Plot inliers and outliers from csfm two view reconstruction
+    # Plot inliers and outliers of the tracks from csfm two view reconstruction.
     f1 = data.load_exif(im1)['focal_ratio']
     f2 = data.load_exif(im2)['focal_ratio']
 
@@ -230,14 +229,13 @@ def plot_tracks(im1, im2, data, save_figs=False):
     outliers_t1 = track_points1[mask, :]
     outliers_t2 = track_points2[mask, :]
 
-    subplot3 = plot_sub(fig, 3, 1, 3,
+    two_view_subplot = plot_sub(fig, 3, 1, 3,
              'CSfM two view reconstruction inliers: ' + str(len(inliers_t)) + '. Outliers: ' + str(mask.sum()) +
               '. Threshold: ' + '%.4f' % threshold_t,
-             im1, im2,
+             im1_array, im2_array,
              inliers_t1, inliers_t2,
-             'c', 'ob',
-             data)
-    plot_matches(subplot3, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
+             'c', 'ob')
+    plot_matches(two_view_subplot , im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -21,16 +21,25 @@ def show_images(plot, im1, im2):
     plot.imshow(image)
 
 
+def plot_points(plot, im1, im2, p1, p2, point_format1='ob', point_format2='ob'):
+    h1, w1, c = im1.shape
+    h2, w2, c = im2.shape
+    p1d = features.denormalized_image_coordinates(p1, w1, h1)
+    p2d = features.denormalized_image_coordinates(p2, w2, h2)
+
+    plot.plot(p1d[:,0], p1d[:,1], point_format1)
+    plot.plot(p2d[:,0] + w1, p2d[:,1], point_format2)
+
+
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
-    p1 = features.denormalized_image_coordinates(p1, w1, h1)
-    p2 = features.denormalized_image_coordinates(p2, w2, h2)
-    for a, b in zip(p1, p2):
+    p1d = features.denormalized_image_coordinates(p1, w1, h1)
+    p2d = features.denormalized_image_coordinates(p2, w2, h2)
+    for a, b in zip(p1d, p2d):
         plot.plot([a[0], b[0] + w1], [a[1], b[1]], line_format)
 
-    plot.plot(p1[:,0], p1[:,1], point_format)
-    plot.plot(p2[:,0] + w1, p2[:,1], point_format)
+    plot_points(plot, im1, im2, p1, p2, point_format, point_format)
 
 
 def create_subplot(figure, rows, columns, index, title):
@@ -45,7 +54,16 @@ def create_subplot(figure, rows, columns, index, title):
     return subplot
 
 
-def plot_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
+def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
+    subplot = create_subplot(figure, rows, columns, index, title)
+
+    show_images(subplot, im1, im2)
+    plot_points(subplot, im1, im2, p1, p2, point_format1, point_format2)
+
+    return subplot
+
+
+def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
     subplot = create_subplot(figure, rows, columns, index, title)
 
     show_images(subplot, im1, im2)
@@ -59,7 +77,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(12, 12))
+    fig = pl.figure(figsize=(12, 18))
 
     fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=14, fontweight='bold')
@@ -77,11 +95,14 @@ def create_matches_figure(im1, im2, data, save_figs=False):
         print 'Not enough matches for eight point algorithm: ' + str(symmetric_matches.shape[0])
         return
 
+    features_title = 'Features: {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
+    plot_points_sub(fig, 4, 1, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
+
     s_matches1 = p1[symmetric_matches[:,0]]
     s_matches2 = p2[symmetric_matches[:,1]]
 
-    plot_sub(fig, 3, 1, 1,
-             'Number of symmetric matches: {0}'.format(symmetric_matches.shape[0]),
+    plot_matches_sub(fig, 4, 1, 2,
+             'Symmetric matches: {0}'.format(symmetric_matches.shape[0]),
              im1_array, im2_array,
              s_matches1, s_matches2,
              'c', 'ob')
@@ -93,8 +114,8 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     r_matches2 = p2[robust_matches[:,1]]
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
-    plot_sub(fig, 3, 1, 2,
-             'Number of robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
+    plot_matches_sub(fig, 4, 1, 3,
+             'Robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
                  robust_matches.shape[0], threshold),
              im1_array, im2_array,
              r_matches1, r_matches2,
@@ -116,13 +137,13 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     outliers1 = p1[outliers[:,0]]
     outliers2 = p2[outliers[:,1]]
 
-    plot_sub(fig, 3, 1, 3,
-             'Number of robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
+    plot_matches_sub(fig, 4, 1, 4,
+             'Robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
              im1_array, im2_array,
              outliers1, outliers2,
              'r', 'om')
 
-    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -190,13 +211,13 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     non_robust_tracks1 = p1[non_robust_tracks[:,0]]
     non_robust_tracks2 = p2[non_robust_tracks[:,1]]
 
-    title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
+    tracks_title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
         track_matches.shape[0],
         track_matches.shape[0] - non_robust_tracks.shape[0],
         robust_matches.shape[0],
         non_robust_tracks.shape[0])
 
-    tracks_subplot = plot_sub(fig, 3, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
+    tracks_subplot = plot_matches_sub(fig, 3, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -211,11 +232,11 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_h1 = track_points1[~inliers_h, :]
     outliers_h2 = track_points2[~inliers_h, :]
 
-    title_h = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
+    h_title = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
         inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / track_matches.shape[0], threshold_h)
 
-    homography_subplot = plot_sub(fig, 3, 1, 2, title_h, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
-    plot_matches(homography_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
+    h_subplot = plot_matches_sub(fig, 3, 1, 2, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
+    plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
     # Plot inliers and outliers of the tracks from csfm two view reconstruction.
     f1 = data.load_exif(im1)['focal_ratio']
@@ -232,13 +253,13 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_t1 = track_points1[outliers_t, :]
     outliers_t2 = track_points2[outliers_t, :]
 
-    title_t = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
+    t_title = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
         len(inliers_t), outliers_t.sum(), threshold_t)
 
-    two_view_subplot = plot_sub(fig, 3, 1, 3, title_t, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
-    plot_matches(two_view_subplot , im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
+    t_subplot = plot_matches_sub(fig, 3, 1, 3, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
+    plot_matches(t_subplot , im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
-    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.99, top=0.96, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'


### PR DESCRIPTION
To visualize the results for some of the algorithms that includes or excludes feature matches along the pipeline I have created some functions that plot inliers and outliers. 

Two images from a data set needs to specified when running the file but since functions have been extracted a loop can easily be created to plot a number of image combinations.

Because the algorithms are actually run using loaded features and tracks the figures are not created instantly.

The results for two images in the Berlin data set can be seen below:

##### Features and symmetric matches as well as inliers and outliers of robust matches for image 01 and 03:

![01 jpg_03 jpg_sift_matches](https://cloud.githubusercontent.com/assets/2492302/6962980/1aa8a980-d93a-11e4-890f-100aedb15cda.jpg)

##### Common tracks (corresponding and not corresponding to robust matches) as well as inliers and outliers of OpenCV find homography and CSfM two view reconstruction:

![01 jpg_03 jpg_sift_tracks](https://cloud.githubusercontent.com/assets/2492302/6962986/2d5bd188-d93a-11e4-9b9f-87829b94d862.jpg)