### PR TITLE
Grayscale conversion

### DIFF
--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -182,7 +182,7 @@ def extract_features_hahog(image, config):
 def extract_features(color_image, config):
     assert len(color_image.shape) == 3
     color_image = resized_image(color_image, config)
-    image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    image = cv2.cvtColor(color_image, cv2.COLOR_RGB2GRAY)
 
     feature_type = config.get('feature_type','SIFT').upper()
     if feature_type == 'SIFT':


### PR DESCRIPTION
When image arrays are loaded in the dataset the default OpenCV color format **BGR** is reversed to **RGB.** When images are converted to grayscale for feature extraction the conversion code COLOR_**BGR**2GRAY is used.

The OpenCV docs state that "In case of a transformation to-from RGB color space, the order of the channels should be specified explicitly (RGB or BGR)". Since the grayscale conversion uses different weights for the color channels the correct conversion code should be COLOR_**RGB**2GRAY.

This affects the feature extraction and in the end the final reconstruction.

References:

* [cvtColor](http://docs.opencv.org/modules/imgproc/doc/miscellaneous_transformations.html#cvtcolor)
* [imread](http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#imread)