### PR TITLE
Plot inlier improvements and reprojections

### DIFF
--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -548,8 +548,8 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
 
     title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}.\n'\
         .format(tracks.shape[0], rec_tracks.shape[0]) + \
-            'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
-        .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
+            'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
+        .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
     rec_plot = create_subplot(fig, 2, 1, 2, title,
                               im1_array.shape[1] + im2_array.shape[1],
@@ -603,8 +603,8 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     triangulated_points = p[non_rec_tracks[succeeded, 1]]
     excluded_points = p[non_rec_tracks[~succeeded, 1]]
 
-    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
-        .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
+    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
+        .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
     non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1], im_array.shape[0])
     non_rec_plot.imshow(im_array)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -94,17 +94,25 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     plot_points(plot, im1, p1, point_format, im2, p2, point_format)
 
 
-def create_subplot(figure, rows, columns, index, title, width, height, font_size=12):
-    """ Creates a subplot with the supplied width. """
+def create_subplot(figure, rows, columns, index, title, x_lim, y_lim, font_size=12, axis=False, aspect=None, grid=False):
+    """ Creates a subplot. """
     subplot = figure.add_subplot(rows, columns, index)
-    subplot.axis('off')
-    pl.xlim(0, width)
-    pl.ylim(height, 0)
+    pl.xlim(x_lim[0], x_lim[1])
+    pl.ylim(y_lim[0], y_lim[1])
     subplot.text(0.5, 1.04,
                  title,
                  horizontalalignment='center',
                  fontsize=font_size,
                  transform=subplot.transAxes)
+
+    if not axis:
+        subplot.axis('off')
+
+    if aspect is not None:
+        subplot.set_aspect(aspect)
+
+    if grid:
+        pl.grid(b=True, which='major', color='0.3')
 
     return subplot
 
@@ -122,7 +130,7 @@ def create_four_figure(title, single_column):
 def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
     """ Creates a subplot with the images and plots the points in each image. """
     subplot = create_subplot(figure, rows, columns, index, title,
-                             im1.shape[1] + im2.shape[1], np.max([im1.shape[0], im2.shape[0]]))
+                             (0, im1.shape[1] + im2.shape[1]), (np.max([im1.shape[0], im2.shape[0]]), 0))
 
     show_images(subplot, im1, im2)
     plot_points(subplot, im1, p1, point_format1, im2, p2, point_format2)
@@ -133,7 +141,7 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
 def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
     """ Creates a subplot with the images and plots the points as matches. """
     subplot = create_subplot(figure, rows, columns, index, title,
-                             im1.shape[1] + im2.shape[1], np.max([im1.shape[0], im2.shape[0]]))
+                             (0, im1.shape[1] + im2.shape[1]), (np.max([im1.shape[0], im2.shape[0]]), 0))
 
     show_images(subplot, im1, im2)
     plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
@@ -141,14 +149,15 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
     return subplot
 
 
-def display_figure(figure, save_figs, data=None, file_name=''):
+def display_figure(figure, save_figs, data=None, file_name='',
+                   left=0.01, bottom=0.01, right=0.99, top=0.93, wspace=0.04, hspace=0.14):
     """ Displays or saves a figure. """
-    figure.subplots_adjust(left=0.01,
-                           bottom=0.01,
-                           right=0.99,
-                           top=0.93 if save_figs else 0.91,
-                           wspace=0.04,
-                           hspace=0.14)
+    figure.subplots_adjust(left=left,
+                           bottom=bottom,
+                           right=right,
+                           top=top if save_figs else top - 0.02,
+                           wspace=wspace,
+                           hspace=hspace)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -176,6 +185,28 @@ def reproject_tracks(im, tracks, reconstruction):
         p.append(reconstruct.reproject(camera, shot, point))
 
     return np.array(p) if len(p) else np.empty((0, 2), int)
+
+
+def reprojection_errors(reprojections, observations, scale):
+    """ Calculates reprojection errors with respect to observations.
+    :param reprojections: The reprojections.
+    :param observations: The observations.
+    :param scale: The scale for the errors.
+    :return: The scaled errors, mean, standard deviation, minimum error norm and maximum error norm.
+    """
+
+    if not len(reprojections):
+        return np.empty((0, 2), np.float), np.zeros((2,), np.float), np.zeros((2.), np.float), 0, 0
+
+    errors = scale * np.subtract(reprojections, observations)
+    mean = np.mean(errors, axis=0)
+    std = np.std(errors, axis=0)
+
+    errors_norm = np.linalg.norm(errors, axis=1)
+    min_norm = np.min(errors_norm)
+    max_norm = np.max(errors_norm)
+
+    return errors, mean, std, min_norm, max_norm
 
 
 def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
@@ -514,7 +545,7 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
             'Bootstrap failed. Less than {0} points. Triangulation threshold: {1} ({2:.1f} - {3:.1f} pixels).'.format(
                 data.config.get('five_point_algo_min_inliers', 50), threshold, pixels1, pixels2) +\
             'Min ray angle: {0}.'.format(data.config.get('triangulation_min_ray_angle', 2.0))
-        create_subplot(fw.figure, fw.rows, fw.cols, index, failed_title, 100, 100)
+        create_subplot(fw.figure, fw.rows, fw.cols, index, failed_title, (0, 100), (0, 100))
 
 
 def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
@@ -563,8 +594,8 @@ def plot_reconstructed_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec
         .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
     subplot = create_subplot(fw.figure, fw.rows, fw.cols, index, title,
-                             ip.im1_array.shape[1] + ip.im2_array.shape[1],
-                             np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]),
+                             (0, ip.im1_array.shape[1] + ip.im2_array.shape[1]),
+                             (np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]), 0),
                              15)
 
     show_images(subplot, ip.im1_array, ip.im2_array)
@@ -597,8 +628,8 @@ def plot_reprojected_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_t
         .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
     subplot = create_subplot(fw.figure, fw.rows, fw.cols, index, title,
-                             ip.im1_array.shape[1] + ip.im2_array.shape[1],
-                             np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]),
+                             (0, ip.im1_array.shape[1] + ip.im2_array.shape[1]),
+                             (np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]), 0),
                              font_size=15)
     show_images(subplot, ip.im1_array, ip.im2_array)
     plot_points(subplot, ip.im1_array, rec_track_points1, 'ob', ip.im2_array, rec_track_points2, 'ob')
@@ -665,7 +696,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
     rec_title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
         .format(tracks.shape[0], rec_tracks.shape[0])
 
-    rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 1, rec_title, im_array.shape[1], im_array.shape[0])
+    rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 1, rec_title, (0, im_array.shape[1]), (im_array.shape[0], 0))
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
@@ -681,7 +712,8 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
         'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
-    non_rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 2, non_rec_title, im_array.shape[1], im_array.shape[0])
+    non_rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 2, non_rec_title,
+                                  (0, im_array.shape[1]), (im_array.shape[0], 0))
     non_rec_plot.imshow(im_array)
     plot_points(non_rec_plot, im_array, triangulated_points, 'om')
     plot_points(non_rec_plot, im_array, excluded_points, 'or')
@@ -692,7 +724,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
 
 def create_reprojection_error_figure(im, data, save_figs=False, single_column=False):
     fig = pl.figure(figsize=(9, 18) if single_column else (18, 9))
-    fig.suptitle('Reprojection error distribution ({0}): {1}'.format(data.feature_type().upper(), im),
+    fig.suptitle('Reprojection error distribution in pixels ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
     fw = FigureWrapper(fig, 2 if single_column else 1, 1 if single_column else 2)
 
@@ -711,88 +743,48 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
         return
 
     rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
-    rec_track_points = p[rec_tracks[:, 1]]
+    rec_points = p[rec_tracks[:, 1]]
 
-    rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
-
-    s = np.max(im_array.shape[:2])
-
-    rec_errors = s * np.subtract(rec_track_points, rp)
-    rec_mean_error = np.mean(rec_errors, axis=0)
-    rec_std_error = np.std(rec_errors, axis=0)
-
-    rec_errors_norm = np.linalg.norm(rec_errors, axis=1)
-    rec_min_error = np.min(rec_errors_norm)
-    rec_max_error = np.max(rec_errors_norm)
+    reproj_rec = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
 
     min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
     succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
-    reprojected = reproject_tracks(im, non_rec_tracks[succeeded, 0], reconstruction)
+    reproj_non = reproject_tracks(im, non_rec_tracks[succeeded, 0], reconstruction)
 
-    triangulated_points = p[non_rec_tracks[succeeded, 1]]
+    triang_non = p[non_rec_tracks[succeeded, 1]]
 
-    non_rec_errors = s * np.subtract(reprojected, triangulated_points)
-    non_rec_mean_error = np.mean(non_rec_errors, axis=0)
-    non_rec_std_error = np.std(non_rec_errors, axis=0)
+    scale = np.max(im_array.shape[:2])
+    rec_errors, rec_mean, rec_std, rec_min, rec_max = reprojection_errors(reproj_rec, rec_points, scale)
+    non_errors, non_mean, non_std, non_min, non_max = reprojection_errors(reproj_non, triang_non, scale)
 
-    non_rec_errors_norm = np.linalg.norm(non_rec_errors, axis=1)
-    non_rec_min_error = np.min(non_rec_errors_norm)
-    non_rec_max_error = np.max(non_rec_errors_norm)
-
-    axis_max = np.max(np.abs(np.vstack((rec_errors, non_rec_errors)))) + 1
-
-    rec_sub = fig.add_subplot(fw.rows, fw.cols, 1)
-    pl.xlim(-axis_max, axis_max)
-    pl.ylim(-axis_max, axis_max)
+    axis_max = np.max(np.abs(np.vstack((rec_errors, non_errors)))) + 1
 
     title = 'Reconstructed track errors: {0}.'.format(rec_tracks.shape[0])
-    error_title = " Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max dist: {4:.1f}. Min dist: {5:.1f}."
-    rec_sub.text(0.5, 1.04,
-                 title + error_title.format(rec_mean_error[0], rec_mean_error[1], rec_std_error[0], rec_std_error[1],
-                                            rec_max_error, rec_min_error),
-                 horizontalalignment='center',
-                 fontsize=12,
-                 transform=rec_sub.transAxes)
-    rec_sub.set_aspect('equal')
+    error_title = " Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max norm: {4:.1f}. Min norm: {5:.1f}."
 
-    pl.grid(b=True, which='major', color='0.3')
+    rec_sub = create_subplot(
+        fw.figure, fw.rows, fw.cols, 1,
+        title + error_title.format(rec_mean[0], rec_mean[1], rec_std[0], rec_std[1], rec_max, rec_min),
+        (-axis_max, axis_max), (-axis_max, axis_max),
+        aspect='equal', axis=True, grid=True)
 
-    rec_sub.plot(np.array([0]), np.array([0]), '+k')
+    zero = np.array([0])
+    rec_sub.plot(zero, zero, '+k')
     rec_sub.plot(rec_errors[:, 0], rec_errors[:, 1], 'ob')
 
+    title = 'Failed track errors: {0} / {1}.'.format(np.sum(succeeded), non_rec_tracks.shape[0])
 
-    non_rec_sub = fig.add_subplot(fw.rows, fw.cols, 2)
-    pl.xlim(-axis_max, axis_max)
-    pl.ylim(-axis_max, axis_max)
+    non_rec_sub = create_subplot(
+        fw.figure, fw.rows, fw.cols, 2,
+        title + error_title.format(non_mean[0], non_mean[1], non_std[0], non_std[1], non_max, non_min),
+        (-axis_max, axis_max), (-axis_max, axis_max),
+        aspect='equal', axis=True, grid=True)
 
-    title = 'Failed track errors (re-triangulated): {0} / {1}.'.format(np.sum(succeeded), non_rec_tracks.shape[0])
-    non_rec_sub.text(0.5, 1.04,
-                     title + error_title.format(non_rec_mean_error[0], non_rec_mean_error[1], non_rec_std_error[0],
-                                                non_rec_std_error[1], non_rec_max_error, non_rec_min_error),
-                     horizontalalignment='center',
-                     fontsize=12,
-                     transform=non_rec_sub.transAxes)
-    non_rec_sub.set_aspect('equal')
-    pl.grid(b=True, which='major', color='0.3')
+    non_rec_sub.plot(zero, zero, '+k')
+    non_rec_sub.plot(non_errors[:, 0], non_errors[:, 1], 'om')
 
-    non_rec_sub.plot(np.array([0]), np.array([0]), '+k')
-    non_rec_sub.plot(non_rec_errors[:, 0], non_rec_errors[:, 1], 'om')
-
-    fig.subplots_adjust(left=0.01,
-                        bottom=0.05,
-                        right=0.99,
-                        top=0.88,
-                        wspace=0.04,
-                        hspace=0.14)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        fig.savefig(p + '/' + '{0}_{1}_error_dist.jpg'.format(im, data.feature_type()), dpi=100)
-        pl.close()
-    else:
-        pl.show()
-
+    display_figure(fig, save_figs, data, '{0}_{1}_error_dist.jpg'.format(im, data.feature_type()),
+                   bottom=0.05, top=0.91 if single_column else 0.86, hspace=0.2)
 
 
 if __name__ == "__main__":

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -73,15 +73,16 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     plot_points(plot, im1, p1, point_format, im2, p2, point_format)
 
 
-def create_subplot(figure, rows, columns, index, title, width):
+def create_subplot(figure, rows, columns, index, title, width, height, font_size=12):
     """ Creates a subplot with the supplied width. """
     subplot = figure.add_subplot(rows, columns, index)
     subplot.axis('off')
     pl.xlim(0, width)
-    subplot.text(0.5, 0.9,
+    pl.ylim(height, 0)
+    subplot.text(0.5, 1.04,
                  title,
                  horizontalalignment='center',
-                 fontsize=12,
+                 fontsize=font_size,
                  transform=subplot.transAxes)
 
     return subplot
@@ -89,7 +90,8 @@ def create_subplot(figure, rows, columns, index, title, width):
 
 def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
     """ Creates a subplot with the images and plots the points in each image. """
-    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
+    subplot = create_subplot(figure, rows, columns, index, title,
+                             im1.shape[1] + im2.shape[1], np.max([im1.shape[0], im2.shape[0]]))
 
     show_images(subplot, im1, im2)
     plot_points(subplot, im1, p1, point_format1, im2, p2, point_format2)
@@ -99,7 +101,8 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
 
 def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
     """ Creates a subplot with the images and plots the points as matches. """
-    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
+    subplot = create_subplot(figure, rows, columns, index, title,
+                             im1.shape[1] + im2.shape[1], np.max([im1.shape[0], im2.shape[0]]))
 
     show_images(subplot, im1, im2)
     plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
@@ -109,7 +112,7 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
 
 def display_figure(figure, save_figs, data=None, file_name=''):
     """ Displays or saves a figure. """
-    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
+    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.96, wspace=0.04, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -470,7 +473,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
                 data.config.get('five_point_algo_min_inliers', 50),
                 data.config.get('triangulation_threshold', 0.004),
                 data.config.get('triangulation_min_ray_angle', 2.0))
-        create_subplot(fig, 2, 2, 4, failed_title, 100)
+        create_subplot(fig, 2, 2, 4, failed_title, 100, 100)
 
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_tracks.jpg'.format(im1, im2, data.feature_type()))
 
@@ -507,8 +510,12 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
         'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}. All loaded.'\
         .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
-    t_subplot = \
-        plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
+    t_subplot = create_subplot(fig, 2, 1, 1, title,
+                               im1_array.shape[1] + im2_array.shape[1],
+                               np.max([im1_array.shape[0], im2_array.shape[0]]),
+                               15)
+    show_images(t_subplot, im1_array, im2_array)
+    plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, non_rec_track_points1, non_rec_track_points2, 'r', 'om')
 
     # Reproject reconstructed tracks. Triangulate rejected tracks and plot min ray angle removals and successfully
@@ -531,8 +538,12 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
             'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
 
-    rec_plot = \
-        plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, rec_track_points1, rec_track_points2, 'ob', 'ob')
+    rec_plot = create_subplot(fig, 2, 1, 2, title,
+                              im1_array.shape[1] + im2_array.shape[1],
+                              np.max([im1_array.shape[0], im2_array.shape[0]]),
+                              15)
+    show_images(rec_plot, im1_array, im2_array)
+    plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
     plot_points(rec_plot, im1_array, rp1, '+w', im2_array, rp2, '+w')
     plot_points(rec_plot, im1_array, triangulated_points1, 'om', im2_array, triangulated_points2, 'om')
     plot_points(rec_plot, im1_array, reprojected1, '+w', im2_array, reprojected2, '+w')
@@ -567,7 +578,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
         .format(tracks.shape[0], rec_tracks.shape[0])
 
-    rec_plot = create_subplot(fig, 1, 2, 1, title, im_array.shape[1])
+    rec_plot = create_subplot(fig, 1, 2, 1, title, im_array.shape[1], im_array.shape[0])
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
@@ -582,7 +593,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     title = 'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
 
-    non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1])
+    non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1], im_array.shape[0])
     non_rec_plot.imshow(im_array)
     plot_points(non_rec_plot, im_array, triangulated_points, 'om')
     plot_points(non_rec_plot, im_array, excluded_points, 'or')

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -188,13 +188,16 @@ def load_tracks(im, graph):
     return np.array(tracks) if len(tracks) else np.empty((0, 2), int)
 
 
-def non_matches(a1, a2, map_function):
-    """ Retrieves the row arrays in a1 that does not have an equal row array in a2.
+def matches(a1, a2, map_function):
+    """ Retrieves the row arrays in a1 that has an equal row array in a2 and the row arrays in a1 that
+         does not have an equal row array in a2.
     :param a1: Numpy array of arrays.
     :param a2: Numpy array of arrays.
     :param map_function: Function mapping the array a1 to another array..
-    :return: The mapped rows in a1 that does not correspond to any row in a2.
+    :return: An array with the mapped rows in a1 that correspond to any row in a2 as well as an array with
+             the mapped rows in a1 that do not correspond with an array in a2.
     """
+    m = []
     nm = []
 
     for arr1 in a1:
@@ -206,10 +209,13 @@ def non_matches(a1, a2, map_function):
 
         if not found:
             nm.append(arr1)
+        else:
+            m.append(arr1)
 
+    m = np.array(m) if len(m) else np.empty((0, a1.shape[1]), int)
     nm = np.array(nm) if len(nm) else np.empty((0, a1.shape[1]), int)
 
-    return nm
+    return m, nm
 
 
 def create_matches_figure(im1, im2, data, save_figs=False):
@@ -259,7 +265,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      r_matches1, r_matches2,
                      'g', 'oy')
 
-    outliers = non_matches(symmetric_matches, robust_matches, lambda a: a)
+    outliers = matches(symmetric_matches, robust_matches, lambda a: a)[1]
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
 
@@ -298,7 +304,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     track_points1 = p1[tracks[:, 1]]
     track_points2 = p2[tracks[:, 2]]
 
-    non_robust_tracks = non_matches(tracks, robust_matches, lambda a: a[1:])
+    robust_tracks, non_robust_tracks = matches(tracks, robust_matches, lambda a: a[1:])
     non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
     non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 
@@ -359,25 +365,9 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     reset_print(stdout_reset)
 
     if reconstruction:
-        robust_rec_tracks = []
-        non_robust_rec_tracks = []
-        for track in reconstruction['points']:
-            track = int(track)
-            if track in non_robust_tracks[:, 0]:
-                non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 0] == track]))
-                non_robust_rec_tracks.append(non_robust_track)
-            else:
-                robust_track = np.squeeze(np.array(tracks[tracks[:, 0] == track]))
-                robust_rec_tracks.append(robust_track)
-
-        failed_rec_tracks = []
-        for track in tracks:
-            if not str(track[0]) in reconstruction['points']:
-                failed_rec_tracks.append(track)
-
-        robust_rec_tracks = np.array(robust_rec_tracks) if len(robust_rec_tracks) else np.empty((0, 3), int)
-        non_robust_rec_tracks = np.array(non_robust_rec_tracks) if len(non_robust_rec_tracks) else np.empty((0, 3), int)
-        failed_rec_tracks = np.array(failed_rec_tracks) if len(failed_rec_tracks) else np.empty((0, 3), int)
+        robust_rec_tracks, failed_robust = reconstruction_tracks(robust_tracks, reconstruction)
+        non_robust_rec_tracks, failed_non_robust = reconstruction_tracks(non_robust_tracks, reconstruction)
+        failed_rec_tracks = np.vstack((failed_robust, failed_non_robust))
 
         robust_rec_points1 = p1[robust_rec_tracks[:, 1]]
         robust_rec_points2 = p2[robust_rec_tracks[:, 2]]

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -613,8 +613,8 @@ if __name__ == "__main__":
     parser.add_argument('--save_figs',
                         help='save figures instead of showing them',
                         action='store_true')
-    parser.add_argument('--plot_all',
-                        help='save figures instead of showing them',
+    parser.add_argument('--plot_rec',
+                        help='plots the reconstruction tracks for each image',
                         action='store_true')
 
     args = parser.parse_args()
@@ -623,10 +623,18 @@ if __name__ == "__main__":
     image2 = args.image2
     save = args.save_figs
 
+    print 'Plotting matches for {0} - {1}...'.format(image1, image2)
     create_matches_figure(image1, image2, ds, save)
+
+    print 'Plotting tracks for {0} - {1}...'.format(image1, image2)
     create_tracks_figure(image1, image2, ds, save)
+
+    print 'Plotting reconstruction matches for {0} - {1}...'.format(image1, image2)
     create_reconstruction_matches_figure(image1, image2, ds, save)
 
-    if args.plot_all:
+    if args.plot_rec:
+        print 'Plotting complete reconstruction tracks for {0}...'.format(image1)
         create_complete_reconstruction_figure(image1, ds, save)
+
+        print 'Plotting complete reconstruction tracks for {0}...'.format(image2)
         create_complete_reconstruction_figure(image2, ds, save)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -48,11 +48,12 @@ def show_images(plot, im1, im2):
 
 def plot_points(plot, im1, p1, point_format1='ob', im2=None, p2=None, point_format2='ob'):
     """ Plots the points in the supplied subplot. """
-    h1, w1, c = im1.shape
-    p1d = features.denormalized_image_coordinates(p1, w1, h1)
-    plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
+    if p1.shape[0] != 0:
+        h1, w1, c = im1.shape
+        p1d = features.denormalized_image_coordinates(p1, w1, h1)
+        plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
 
-    if im2 is None or p2 is None:
+    if im2 is None or p2 is None or p2.shape[0] == 0:
         return
 
     h2, w2, c = im2.shape
@@ -63,6 +64,9 @@ def plot_points(plot, im1, p1, point_format1='ob', im2=None, p2=None, point_form
 
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     """ Plots the matches in the supplied subplot. """
+    if p1.shape[0] == 0 or p1.shape != p2.shape:
+        return
+
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
     p1d = features.denormalized_image_coordinates(p1, w1, h1)
@@ -173,7 +177,7 @@ def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
         reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {}, 1, min_ray_angle)
         succeeded.append(True) if str(track) in reconstruction['points'] else succeeded.append(False)
 
-    return np.array(succeeded)
+    return np.array(succeeded) if len(succeeded) else np.empty((0, 1), bool)
 
 
 def find_reconstruction(images, data):

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -178,7 +178,9 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     p1 = np.array(p1[:, :2], np.float64)
     p2 = np.array(p2[:, :2], np.float64)
 
-    robust_matches = data.find_matches(im1, im2) or np.empty((0, 2), int)
+    robust_matches = data.find_matches(im1, im2)
+    if not len(robust_matches):
+        robust_matches = np.empty((0, 2), int)
 
     t1, t2 = graph[im1], graph[im2]
 
@@ -322,6 +324,103 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         pl.show()
 
 
+def create_reconstruction_figure(im1, im2, data, save_figs=False):
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    fig = pl.figure(figsize=(18, 18))
+    fig.suptitle('Reconstruction ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
+                 fontsize=18, fontweight='bold')
+
+    # Retrieve tracks and robust matches from file and plot tracks corresponding to
+    # robust matches and tracks not corresponding to robust matches in different colors.
+    graph = data.load_tracks_graph()
+
+    p1, f1, c1 = data.load_features(im1)
+    p2, f2, c2 = data.load_features(im2)
+    p1 = np.array(p1[:, :2], np.float64)
+    p2 = np.array(p2[:, :2], np.float64)
+
+    t1, t2 = graph[im1], graph[im2]
+
+    track_matches = []
+    for track in t1:
+        if track in t2:
+            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id'], int(track)]))
+
+    track_matches = np.array(track_matches)
+
+    if track_matches.shape[0] < 1:
+        print 'No tracks to plot.'
+        return
+
+    track_points1 = p1[track_matches[:, 0]]
+    track_points2 = p2[track_matches[:, 1]]
+
+    reconstructions = data.load_reconstruction()
+    reconstruction = None
+
+    for rec in reconstructions:
+        if im1 in rec['shots'] and im2 in rec['shots']:
+            reconstruction = rec
+
+    if reconstruction is None:
+        print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
+
+    rec_tracks = []
+    for track in track_matches:
+        if str(track[2]) in rec['points']:
+            rec_tracks.append(track)
+
+    rec_tracks = np.array(rec_tracks)
+    rec_track_points1 = p1[rec_tracks[:, 0]]
+    rec_track_points2 = p2[rec_tracks[:, 1]]
+
+    title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
+        track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
+
+    t_subplot = plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'r', 'om')
+    plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
+
+    reprojected_points1 = []
+    for track in rec_tracks:
+        shot = reconstruction['shots'][im1]
+        camera = reconstruction['cameras'][shot['camera']]
+        point = reconstruction['points'][str(track[2])]
+
+        reprojected_points1.append(reconstruct.reproject(camera, shot, point))
+
+    reprojected_points1 = np.array(reprojected_points1)
+
+    reprojected_points2 = []
+    for track in rec_tracks:
+        shot = reconstruction['shots'][im2]
+        camera = reconstruction['cameras'][shot['camera']]
+        point = reconstruction['points'][str(track[2])]
+
+        reprojected_points2.append(reconstruct.reproject(camera, shot, point))
+
+    reprojected_points2 = np.array(reprojected_points2)
+
+    title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
+        track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
+
+    rec_plot = plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, track_points1, track_points2, 'or', 'or')
+    plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
+    plot_points(rec_plot, im1_array, reprojected_points1, '+w', im2_array, reprojected_points2, '+w')
+
+
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
+
+    if save_figs:
+        p = data.data_path + '/plot_inliers'
+        io.mkdir_p(p)
+        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_reconstruction.jpg', dpi=100)
+        pl.close()
+    else:
+        pl.show()
+
+
 def create_complete_reconstruction_figure(im, data, save_figs=False):
     im_array = data.image_as_array(im)
 
@@ -341,7 +440,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     graph = data.load_tracks_graph()
 
-    p, f = data.load_features(im)
+    p, f, c = data.load_features(im)
     p = np.array(p[:, :2], np.float64)
 
     im_tracks = graph[im]
@@ -410,6 +509,7 @@ if __name__ == "__main__":
 
     create_matches_figure(args.image1, args.image2, data_set, args.save_figs)
     create_tracks_figure(args.image1, args.image2, data_set, args.save_figs)
+    create_reconstruction_figure(args.image1, args.image2, data_set, args.save_figs)
 
     if args.plot_all:
         create_complete_reconstruction_figure(args.image1, data_set, args.save_figs)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -69,6 +69,15 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
     return subplot
 
 
+def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
+    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
+
+    show_images(subplot, im1, im2)
+    plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
+
+    return subplot
+
+
 def reproject_tracks(im, tracks, reconstruction):
     p = []
     for track in tracks:
@@ -108,13 +117,16 @@ def reconstruction_tracks(tracks, reconstruction):
     return np.array(r_tracks)
 
 
-def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
-    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
+def display_figure(figure, save_figs, data=None, file_name=''):
+    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
 
-    show_images(subplot, im1, im2)
-    plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
-
-    return subplot
+    if save_figs:
+        p = data.data_path + '/plot_inliers'
+        io.mkdir_p(p)
+        figure.savefig(p + '/' + file_name, dpi=100)
+        pl.close()
+    else:
+        pl.show()
 
 
 def create_matches_figure(im1, im2, data, save_figs=False):
@@ -188,15 +200,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      outliers1, outliers2,
                      'r', 'om')
 
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_matches.jpg', dpi=100)
-        pl.close()
-    else:
-        pl.show()
+    display_figure(fig, save_figs, data, '{0}_{1}_{2}_matches.jpg'.format(im1, im2, data.feature_type()))
 
 
 def create_tracks_figure(im1, im2, data, save_figs=False):
@@ -352,15 +356,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
                 data.config.get('triangulation_min_ray_angle', 2.0))
         create_subplot(fig, 2, 2, 4, failed_title, 100)
 
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_tracks.jpg', dpi=100)
-        pl.close()
-    else:
-        pl.show()
+    display_figure(fig, save_figs, data, '{0}_{1}_{2}_tracks.jpg'.format(im1, im2, data.feature_type()))
 
 
 def create_reconstruction_figure(im1, im2, data, save_figs=False):
@@ -420,16 +416,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
     plot_points(rec_plot, im1_array, rp1, '+w', im2_array, rp2, '+w')
 
-
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        fig.savefig(p + '/' + im1 + '_' + im2 + '_' + data.feature_type() + '_reconstruction.jpg', dpi=100)
-        pl.close()
-    else:
-        pl.show()
+    display_figure(fig, save_figs, data, '{0}_{1}_{2}_reconstruction.jpg'.format(im1, im2, data.feature_type()))
 
 
 def create_complete_reconstruction_figure(im, data, save_figs=False):
@@ -470,15 +457,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
 
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        fig.savefig(p + '/' + im + '_' + data.feature_type() + '_complete_rec.jpg', dpi=100)
-        pl.close()
-    else:
-        pl.show()
+    display_figure(fig, save_figs, data, '{0}_{1}_complete_rec.jpg'.format(im, data.feature_type()))
 
 
 if __name__ == "__main__":

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -321,6 +321,23 @@ def matches(a1, a2, map_function):
     return m, nm
 
 
+def thresholds(im1_array, im2_array, key, default, data):
+    """ Retrieves the threshold value for a config key as well as the corresponding valude in pixels
+        for two image arrays.
+    :param im1_array: First image array.
+    :param im2_array: Second image array.
+    :param key: Threshold config key.
+    :param default: Default threshold value.
+    :param data: Dataset.
+    :return: The threshold config value and the value in pixels for each image.
+    """
+    threshold = data.config.get(key, default)
+    pixel_threshold1 = threshold * np.max(im1_array.shape[:2])
+    pixel_threshold2 = threshold * np.max(im2_array.shape[:2])
+
+    return threshold, pixel_threshold1, pixel_threshold2
+
+
 def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     fig, rows, cols = \
         create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
@@ -361,13 +378,14 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     r_matches1 = p1[robust_matches[:, 0]]
     r_matches2 = p2[robust_matches[:, 1]]
 
-    threshold = data.config.get('robust_matching_threshold', 0.006)
-    plot_matches_sub(fig, rows, cols, 3,
-                     'Robust matching inliers (calculated with RANSAC eight point algorithm): {0}. Threshold: {1}'
-                     .format(robust_matches.shape[0], threshold),
-                     im1_array, im2_array,
-                     r_matches1, r_matches2,
-                     'g', 'oy')
+    threshold, pixels1, pixels2 = thresholds(im1_array, im2_array, 'robust_matching_threshold', 0.006, data)
+    plot_matches_sub(
+        fig, rows, cols, 3,
+        'Robust matching inliers (RANSAC 7-point algorithm, calculated): {0}. Threshold: {1} ({2:.1f} - {3:.1f} pixels)'
+        .format(robust_matches.shape[0], threshold, pixels1, pixels2),
+        im1_array, im2_array,
+        r_matches1, r_matches2,
+        'g', 'oy')
 
     # Plot robust matching outliers.
     outliers = matches(symmetric_matches, robust_matches, lambda a: a)[1]
@@ -375,8 +393,8 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     outliers2 = p2[outliers[:, 1]]
 
     plot_matches_sub(fig, rows, cols, 4,
-                     'Robust matching outliers (calculated): {0}. Threshold: {1}'
-                     .format(outliers.shape[0], threshold),
+                     'Robust matching outliers (calculated): {0}. Threshold: {1} ({2:.1f} - {3:.1f} pixels)'
+                     .format(outliers.shape[0], threshold, pixels1, pixels2),
                      im1_array, im2_array,
                      outliers1, outliers2,
                      'r', 'om')
@@ -408,8 +426,8 @@ def plot_common_tracks(fw, ip, index, p1, p2, tracks, robust_tracks, linked_trac
 def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_points2, data):
     """ Plot inliers and outliers of the tracks from OpenCV find homography. """
 
-    threshold_h = data.config.get('homography_threshold', 0.004)
-    H, inliers = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
+    threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'homography_threshold', 0.004, data)
+    H, inliers = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold)
 
     inliers = np.array(np.squeeze(inliers), np.bool)
 
@@ -420,9 +438,9 @@ def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_poin
     outliers2 = track_points2[~inliers, :]
 
     title = \
-        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3}'\
-        .format(
-            inliers.sum(), (~inliers).sum(), float((~inliers).sum()) / tracks.shape[0], threshold_h)
+        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3} '\
+        .format(inliers.sum(), (~inliers).sum(), float((~inliers).sum()) / tracks.shape[0], threshold) + \
+        '({0:.1f} - {1:.1f} pixels)'.format(pixels1, pixels2)
 
     subplot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, title, ip.im1_array, ip.im2_array,
                                outliers1, outliers2, 'r', 'om')
@@ -435,7 +453,7 @@ def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, da
     f1 = data.load_exif(ip.im1)['focal_prior']
     f2 = data.load_exif(ip.im2)['focal_prior']
 
-    threshold = data.config.get('five_point_algo_threshold', 0.006)
+    threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'five_point_algo_threshold', 0.006, data)
     R, t, cov, inliers = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold)
 
     inliers1 = track_points1[inliers, :]
@@ -446,8 +464,9 @@ def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, da
     outliers1 = track_points1[outliers, :]
     outliers2 = track_points2[outliers, :]
 
-    title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2}'.format(
-        len(inliers), outliers.sum(), threshold)
+    title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2} '.format(
+        len(inliers), outliers.sum(), threshold) + \
+        '({0:.1f} - {1:.1f} pixels)'.format(pixels1, pixels2)
 
     subplot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, title, ip.im1_array, ip.im2_array,
                                inliers1, inliers2, 'c', 'ob')
@@ -460,6 +479,8 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
     print_reset = redirect_print()
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2)
     reset_print(print_reset)
+
+    threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'triangulation_threshold', 0.004, data)
 
     if reconstruction:
         robust_rec_tracks, failed_robust = reconstruction_tracks(robust_tracks, reconstruction)
@@ -476,14 +497,13 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
         failed_rec_points2 = p2[failed_rec_tracks[:, 2]]
 
         rec_title = \
-            'Reconstructed 3D points (bootstrapped): {0}. Robust {1}. Linked: {2}. Failed: {3}. '.format(
+            'Bootstrapped 3D points: {0}. Robust {1}. Linked: {2}. Failed: {3}. '.format(
                 len(reconstruction['points']),
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],
                 failed_rec_tracks.shape[0]) + \
-            'Triangulation threshold: {0}. Min ray angle: {1}.'.format(
-                data.config.get('triangulation_threshold', 0.004),
-                data.config.get('triangulation_min_ray_angle', 2.0))
+            'Triangulation threshold: {0} ({1:.1f} - {2:.1f} pixels). Min ray angle: {3}.'.format(
+                threshold, pixels1, pixels2, data.config.get('triangulation_min_ray_angle', 2.0))
 
         rec_plot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, rec_title, ip.im1_array, ip.im2_array,
                                     robust_rec_points1, robust_rec_points2, 'c', 'ob')
@@ -491,11 +511,9 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
         plot_matches(rec_plot, ip.im1_array, ip.im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
         failed_title = \
-            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1}. Min ray angle: {2}.'\
-            .format(
-                data.config.get('five_point_algo_min_inliers', 50),
-                data.config.get('triangulation_threshold', 0.004),
-                data.config.get('triangulation_min_ray_angle', 2.0))
+            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1} ({2:.1f} - {3:.1f} pixels).'.format(
+                data.config.get('five_point_algo_min_inliers', 50), threshold, pixels1, pixels2) +\
+            'Min ray angle: {0}.'.format(data.config.get('triangulation_min_ray_angle', 2.0))
         create_subplot(fw.figure, fw.rows, fw.cols, index, failed_title, 100, 100)
 
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -271,25 +271,21 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
 
     if reconstruction:
-        robust_rec_tracks = []
-        non_robust_rec_tracks = []
+        robust_rec_tracks = np.empty((0, 3), int)
+        non_robust_rec_tracks = np.empty((0, 3), int)
         for track in reconstruction['points']:
             track = int(track)
             if track in non_robust_tracks[:, 2]:
                 non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 2] == track]))
-                non_robust_rec_tracks.append(non_robust_track)
+                non_robust_rec_tracks = np.vstack((non_robust_rec_tracks, non_robust_track))
             else:
                 robust_track = np.squeeze(np.array(track_matches[track_matches[:, 2] == track]))
-                robust_rec_tracks.append(robust_track)
+                robust_rec_tracks = np.vstack((robust_rec_tracks, robust_track))
 
-        failed_rec_tracks = []
+        failed_rec_tracks = np.empty((0, 3), int)
         for track in track_matches:
             if not str(track[2]) in reconstruction['points']:
-                failed_rec_tracks.append(track)
-
-        robust_rec_tracks = np.array(robust_rec_tracks)
-        non_robust_rec_tracks = np.array(non_robust_rec_tracks)
-        failed_rec_tracks = np.array(failed_rec_tracks)
+                failed_rec_tracks = np.vstack((failed_rec_tracks, track))
 
         robust_rec_points1 = p1[robust_rec_tracks[:, 0]]
         robust_rec_points2 = p2[robust_rec_tracks[:, 1]]

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -226,7 +226,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    # Calculate symmetric matches and plot.
+    # Calculate symmetric matches.
     p1, f1, c1 = data.load_features(im1)
     i1 = data.load_feature_index(im1, f1)
 
@@ -239,9 +239,11 @@ def create_matches_figure(im1, im2, data, save_figs=False):
         print 'Not enough matches for eight point algorithm: ' + str(symmetric_matches.shape[0])
         return
 
+    # Plot features
     features_title = 'Features (loaded): {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
     plot_points_sub(fig, 2, 2, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
 
+     # Plot symmetric matches.
     s_matches1 = p1[symmetric_matches[:, 0]]
     s_matches2 = p2[symmetric_matches[:, 1]]
 
@@ -265,6 +267,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      r_matches1, r_matches2,
                      'g', 'oy')
 
+    # Plot robust matching outliers.
     outliers = matches(symmetric_matches, robust_matches, lambda a: a)[1]
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
@@ -290,7 +293,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     p2 = load_points(im2, data)
 
     # Retrieve tracks and robust matches from file and plot tracks corresponding to
-    # robust matches and tracks not corresponding to robust matches in different colors.
+    # robust matches and tracks not corresponding to robust matches (linked tracks) in different colors.
     robust_matches = data.find_matches(im1, im2)
     robust_matches = np.array(robust_matches) if len(robust_matches) else np.empty((0, 2), int)
 
@@ -301,24 +304,28 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         print 'Not enough tracks for five point algorithm: ' + str(tracks.shape[0])
         return
 
-    track_points1 = p1[tracks[:, 1]]
-    track_points2 = p2[tracks[:, 2]]
-
     robust_tracks, non_robust_tracks = matches(tracks, robust_matches, lambda a: a[1:])
-    non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
-    non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
+
+    robust_points1 = p1[robust_tracks[:, 1]]
+    robust_points2 = p2[robust_tracks[:, 2]]
+
+    non_robust_points1 = p1[non_robust_tracks[:, 1]]
+    non_robust_points2 = p2[non_robust_tracks[:, 2]]
 
     tracks_title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Linked tracks: {3}'.format(
         tracks.shape[0],
-        tracks.shape[0] - non_robust_tracks.shape[0],
+        robust_tracks.shape[0],
         robust_matches.shape[0],
         non_robust_tracks.shape[0])
 
     tracks_subplot = plot_matches_sub(
-        fig, 2, 2, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
-    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
+        fig, 2, 2, 1, tracks_title, im1_array, im2_array, robust_points1, robust_points2, 'c', 'ob')
+    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_points1, non_robust_points2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
+    track_points1 = p1[tracks[:, 1]]
+    track_points2 = p2[tracks[:, 2]]
+
     threshold_h = data.config.get('homography_threshold', 0.004)
     H, inliers_h = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
 
@@ -359,7 +366,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     t_subplot = plot_matches_sub(fig, 2, 2, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
-    # Plot successfully reconstructed and failed 3D points
+    # Plot successfully reconstructed and failed 3D points by reconstruction bootstrap.
     stdout_reset = redirect_print()
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
     reset_print(stdout_reset)
@@ -379,7 +386,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         failed_rec_points2 = p2[failed_rec_tracks[:, 2]]
 
         rec_title = \
-            'Reconstructed 3D points (calculated): {0}. Robust {1}. Linked: {2}. Failed: {3}. '.format(
+            'Reconstructed 3D points (bootstrapped): {0}. Robust {1}. Linked: {2}. Failed: {3}. '.format(
                 len(reconstruction['points']),
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],
@@ -394,7 +401,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         plot_matches(rec_plot, im1_array, im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
         failed_title = \
-            'Reconstruction failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}. '\
+            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}.'\
             .format(
                 data.config.get('five_point_algo_min_inliers', 50),
                 data.config.get('triangulation_threshold', 0.004),
@@ -404,8 +411,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_tracks.jpg'.format(im1, im2, data.feature_type()))
 
 
-def create_reconstruction_figure(im1, im2, data, save_figs=False):
-    fig = pl.figure(figsize=(18, 18))
+def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
+    fig = pl.figure(figsize=(15, 15))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=18, fontweight='bold')
 
@@ -425,6 +432,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
+    # Retrieve reconstructed tracks and plot as matches. Plot rejected tracks in other color.
     rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
@@ -439,6 +447,8 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
         plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, non_rec_track_points1, non_rec_track_points2, 'r', 'om')
 
+    # Reproject reconstructed tracks. Triangulate rejected tracks and plot min ray angle removals and successfully
+    # triangulated tracks in different colors.
     rp1 = reproject_tracks(im1, rec_tracks[:, 0], reconstruction)
     rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
 
@@ -454,7 +464,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
 
     title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}.\n'\
         .format(tracks.shape[0], rec_tracks.shape[0]) + \
-            'Rejected tracks: {0}. Re-triangulated: {1}. Re-triangulation min ray angle ({2} deg) removals: {3}.'\
+            'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
 
     rec_plot = \
@@ -505,7 +515,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     triangulated_points = p[non_rec_tracks[succeeded, 1]]
     excluded_points = p[non_rec_tracks[~succeeded, 1]]
 
-    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Re-triangulation min ray angle ({2} deg) removals: {3}.'\
+    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Min ray angle ({2} deg) removals: {3}.'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
 
     non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1])
@@ -540,7 +550,7 @@ if __name__ == "__main__":
 
     create_matches_figure(image1, image2, ds, save)
     create_tracks_figure(image1, image2, ds, save)
-    create_reconstruction_figure(image1, image2, ds, save)
+    create_reconstruction_matches_figure(image1, image2, ds, save)
 
     if args.plot_all:
         create_complete_reconstruction_figure(image1, ds, save)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -119,18 +119,15 @@ def reproject_tracks(im, tracks, reconstruction):
 
 def triangulate_tracks(tracks, reconstruction, data):
     graph = data.load_tracks_graph()
-    points = []
+    succeeded = []
 
     for track in tracks:
-        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {},
-                                      reproj_threshold=1, min_ray_angle_degrees=0)
-        if str(track) in reconstruction['points']:
-            point = reconstruction['points'][str(track)]
-        else:
-            point = None
-        points.append(point)
+        # Triangulate with 1 as threshold to avoid excluding tracks because of error.
+        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {}, 1,
+                                      data.config.get('triangulation_min_ray_angle', 2.0))
+        succeeded.append(True) if str(track) in reconstruction['points'] else succeeded.append(False)
 
-    return points
+    return np.array(succeeded)
 
 
 def find_reconstruction(images, data):
@@ -486,13 +483,10 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
     rec_track_points = p[rec_tracks[:, 1]]
-    non_rec_track_points = p[non_rec_tracks[:, 1]]
 
     rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
-    triangulate_tracks(non_rec_tracks[:, 0], reconstruction, data)
-    nrp = reproject_tracks(im, non_rec_tracks[:, 0], reconstruction)
 
-    title = 'All tracks (loaded): {0}. Reprojected points (calculated): {1}'\
+    title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
         .format(tracks.shape[0], rec_tracks.shape[0])
 
     rec_plot = create_subplot(fig, 1, 2, 1, title, im_array.shape[1])
@@ -500,13 +494,21 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
 
-    title = 'Triangulation and reprojection error removals reprojected: {0}'\
-        .format(non_rec_tracks.shape[0])
+    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, data)
+    reprojected = reproject_tracks(im, non_rec_tracks[succeeded, 0], reconstruction)
+
+    triangulated_points = p[non_rec_tracks[succeeded, 1]]
+    excluded_points = p[non_rec_tracks[~succeeded, 1]]
+
+    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Re-triangulation min ray angle ({2} deg) removals: {3}.'\
+        .format(non_rec_tracks.shape[0], succeeded.sum(),
+                data.config.get('triangulation_min_ray_angle', 2.0), (~succeeded).sum())
 
     non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1])
     non_rec_plot.imshow(im_array)
-    plot_points(non_rec_plot, im_array, non_rec_track_points, 'or')
-    plot_points(non_rec_plot, im_array, nrp, '+w')
+    plot_points(non_rec_plot, im_array, triangulated_points, 'om')
+    plot_points(non_rec_plot, im_array, excluded_points, 'or')
+    plot_points(non_rec_plot, im_array, reprojected, '+w')
 
     display_figure(fig, save_figs, data, '{0}_{1}_complete_rec.jpg'.format(im, data.feature_type()))
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -94,6 +94,21 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     plot_points(plot, im1, p1, point_format, im2, p2, point_format)
 
 
+def plot_circle(subplot, diameter, format):
+    """ Plots a circle.
+
+    :param subplot: The subplot.
+    :param diameter: The diameter of the circle.
+    :param format: The circle format.
+    """
+
+    angles = np.linspace(0, 2 * np.pi, 300)
+    x = diameter * np.sin(angles)
+    y = diameter * np.cos(angles)
+
+    subplot.plot(x, y, format)
+
+
 def create_subplot(figure, rows, columns, index, title, x_lim, y_lim, font_size=12, axis=False, aspect=None, grid=False):
     """ Creates a subplot. """
     subplot = figure.add_subplot(rows, columns, index)
@@ -189,6 +204,7 @@ def reproject_tracks(im, tracks, reconstruction):
 
 def reprojection_errors(reprojections, observations, scale):
     """ Calculates reprojection errors with respect to observations.
+
     :param reprojections: The reprojections.
     :param observations: The observations.
     :param scale: The scale for the errors.
@@ -207,9 +223,13 @@ def reprojection_errors(reprojections, observations, scale):
     max_norm = np.max(errors_norm)
 
     observations_norm = scale * np.linalg.norm(observations, axis=1)
-    corr = np.corrcoef(observations_norm, errors_norm)
 
-    return errors, mean, std, min_norm, max_norm, corr[0, 1]
+    if len(observations_norm) > 1:
+        corr = np.corrcoef(observations_norm, errors_norm)[0, 1]
+    else:
+        corr = np.nan
+
+    return errors, mean, std, min_norm, max_norm, corr
 
 
 def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
@@ -869,13 +889,13 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     rec_errors, rec_mean, rec_std, rec_min, rec_max, rec_corr = reprojection_errors(reproj_rec, rec_points, scale)
     non_errors, non_mean, non_std, non_min, non_max, non_corr = reprojection_errors(reproj_non, triang_non, scale)
 
-    axis_max = 1.05 * np.max(np.abs(np.vstack((rec_errors, non_errors))))
+    triang_thld = data.config.get('triangulation_threshold', 0.004)
+    bundle_thld = data.config.get('bundle_outlier_threshold', 0.008)
+    axis_max = np.max(np.abs(np.vstack((rec_errors, non_errors))))
+    axis_max = 1.05 * np.max([axis_max, scale * triang_thld, scale * bundle_thld])
 
     title = 'Reconstructed tracks: {0}. '.format(rec_tracks.shape[0])
     error_title = "Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max norm: {4:.1f}. Min norm: {5:.1f}."
-
-    triang_thld = data.config.get('triangulation_threshold', 0.004)
-    bundle_thld = data.config.get('bundle_outlier_threshold', 0.008)
     thld_title = 'Thresholds: Triangulation: {0:.1f} ({1:.2g}). Bundle outlier: {2:.1f} ({3:.2g}).'\
         .format(scale * triang_thld, triang_thld, scale * bundle_thld, bundle_thld)
     corr_title = ' Distance to principal point - Error norm correlation: {0:.3f}'
@@ -886,6 +906,9 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
         thld_title + '\n' + corr_title.format(rec_corr) if rec_corr is not np.nan else '',
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
+
+    plot_circle(rec_sub, scale * triang_thld, 'r')
+    plot_circle(rec_sub, scale * bundle_thld, 'm')
 
     zero = np.array([0])
     rec_sub.plot(zero, zero, '+k')
@@ -900,6 +923,8 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
 
+    plot_circle(non_rec_sub, scale * triang_thld, 'r')
+    plot_circle(non_rec_sub, scale * bundle_thld, 'm')
     non_rec_sub.plot(zero, zero, '+k')
     non_rec_sub.plot(non_errors[:, 0], non_errors[:, 1], 'om')
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -117,6 +117,22 @@ def reproject_tracks(im, tracks, reconstruction):
     return np.array(p) if len(p) else np.empty((0, 2), int)
 
 
+def triangulate_tracks(tracks, reconstruction, data):
+    graph = data.load_tracks_graph()
+    points = []
+
+    for track in tracks:
+        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {},
+                                      reproj_threshold=1, min_ray_angle_degrees=0)
+        if str(track) in reconstruction['points']:
+            point = reconstruction['points'][str(track)]
+        else:
+            point = None
+        points.append(point)
+
+    return points
+
+
 def find_reconstruction(images, data):
     reconstructions = data.load_reconstruction()
     reconstruction = None
@@ -137,11 +153,18 @@ def find_reconstruction(images, data):
 
 def reconstruction_tracks(tracks, reconstruction):
     r_tracks = []
+    n_tracks = []
+
     for track in tracks:
         if str(track[0]) in reconstruction['points']:
             r_tracks.append(track)
+        else:
+            n_tracks.append(track)
 
-    return np.array(r_tracks) if len(r_tracks) else np.empty((0, tracks.shape[1]), int)
+    r_tracks = np.array(r_tracks) if len(r_tracks) else np.empty((0, tracks.shape[1]), int)
+    n_tracks = np.array(n_tracks) if len(n_tracks) else np.empty((0, tracks.shape[1]), int)
+
+    return r_tracks, n_tracks
 
 
 def load_points(im, data):
@@ -307,8 +330,10 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_h1 = track_points1[~inliers_h, :]
     outliers_h2 = track_points2[~inliers_h, :]
 
-    h_title = 'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
-        inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
+    h_title = \
+        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'\
+        .format(
+            inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
 
     h_subplot = plot_matches_sub(fig, 2, 2, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
@@ -418,7 +443,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
-    rec_tracks = reconstruction_tracks(tracks, reconstruction)
+    rec_tracks = reconstruction_tracks(tracks, reconstruction)[0]
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
 
@@ -443,7 +468,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
 
 
 def create_complete_reconstruction_figure(im, data, save_figs=False):
-    fig = pl.figure(figsize=(12, 9))
+    fig = pl.figure(figsize=(18, 9))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
 
@@ -459,21 +484,29 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
         print 'No tracks for exist for {0}.'.format(im)
         return
 
-    track_points = p[tracks[:, 1]]
-
-    rec_tracks = reconstruction_tracks(tracks, reconstruction)
+    rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
     rec_track_points = p[rec_tracks[:, 1]]
+    non_rec_track_points = p[non_rec_tracks[:, 1]]
 
     rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
+    triangulate_tracks(non_rec_tracks[:, 0], reconstruction, data)
+    nrp = reproject_tracks(im, non_rec_tracks[:, 0], reconstruction)
 
-    title = 'All tracks (loaded): {0}. Reprojected points (calculated): {1}. Triangulation and reprojection error removals: {2}'\
-        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    title = 'All tracks (loaded): {0}. Reprojected points (calculated): {1}'\
+        .format(tracks.shape[0], rec_tracks.shape[0])
 
-    rec_plot = create_subplot(fig, 1, 1, 1, title, im_array.shape[1])
+    rec_plot = create_subplot(fig, 1, 2, 1, title, im_array.shape[1])
     rec_plot.imshow(im_array)
-    plot_points(rec_plot, im_array, track_points, 'or')
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
+
+    title = 'Triangulation and reprojection error removals reprojected: {0}'\
+        .format(non_rec_tracks.shape[0])
+
+    non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1])
+    non_rec_plot.imshow(im_array)
+    plot_points(non_rec_plot, im_array, non_rec_track_points, 'or')
+    plot_points(non_rec_plot, im_array, nrp, '+w')
 
     display_figure(fig, save_figs, data, '{0}_{1}_complete_rec.jpg'.format(im, data.feature_type()))
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -305,7 +305,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
     non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 
-    tracks_title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
+    tracks_title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Linked tracks: {3}'.format(
         tracks.shape[0],
         tracks.shape[0] - non_robust_tracks.shape[0],
         robust_matches.shape[0],
@@ -392,7 +392,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         failed_rec_points2 = p2[failed_rec_tracks[:, 2]]
 
         rec_title = \
-            'Reconstructed 3D points (calculated): {0}. Robust {1}. Non robust: {2}. Failed: {3}. '.format(
+            'Reconstructed 3D points (calculated): {0}. Robust {1}. Linked: {2}. Failed: {3}. '.format(
                 len(reconstruction['points']),
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -358,6 +358,7 @@ def matches(a1, a2, map_function):
 def thresholds(im1_array, im2_array, key, default, data):
     """ Retrieves the threshold value for a config key as well as the corresponding valude in pixels
         for two image arrays.
+        
     :param im1_array: First image array.
     :param im2_array: Second image array.
     :param key: Threshold config key.
@@ -373,6 +374,15 @@ def thresholds(im1_array, im2_array, key, default, data):
 
 
 def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
+    """ Plots the features, symmetric matches as well as the robust matching inliers and outliers.
+
+    :param im1: Name of the first image.
+    :param im2: Name of the second image.
+    :param data: Data set.
+    :param save_figs: Boolean specifying if figures should be saved to file.
+    :param single_column: Boolean specifying if the subplots should be ordered in a single column.
+    """
+
     fig, rows, cols = \
         create_four_figure('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
 
@@ -552,6 +562,16 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
 
 
 def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
+    """ Plots the common tracks as well as the find homography, two view reconstruction and bootstrapped
+        reconstruction inliers and outliers.
+
+    :param im1: Name of the first image.
+    :param im2: Name of the second image.
+    :param data: Data set.
+    :param save_figs: Boolean specifying if figures should be saved to file.
+    :param single_column: Boolean specifying if the subplots should be ordered in a single column.
+    """
+
     fig, rows, cols = \
         create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
 
@@ -643,6 +663,15 @@ def plot_reprojected_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_t
 
 
 def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
+    """ Plots the track match inliers and outliers in the loaded reconstruction for the two images as
+        well as the reprojections.
+
+    :param im1: Name of the first image.
+    :param im2: Name of the second image.
+    :param data: Data set.
+    :param save_figs: Boolean specifying if figures should be saved to file.
+    """
+
     fig = pl.figure(figsize=(15, 15))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=18, fontweight='bold')
@@ -672,6 +701,14 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
 
 
 def create_complete_reconstruction_figure(im, data, save_figs=False, single_column=False):
+    """ Plots the inliers, outliers and their respective reprojections.
+
+    :param im: Image name.
+    :param data: Data set.
+    :param save_figs: Boolean specifying if figures should be saved to file.
+    :param single_column: Boolean specifying if results should be plotted in a single figure.
+    """
+
     fig = pl.figure(figsize=(9, 15) if single_column else (18, 9))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
@@ -726,6 +763,14 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
 
 
 def create_reprojection_error_figure(im, data, save_figs=False, single_column=False):
+    """ Plots the reprojection error distribution.
+
+    :param im: Image name.
+    :param data: Data set.
+    :param save_figs: Boolean specifying if figures should be saved to file.
+    :param single_column: Boolean specifying if results should be plotted in a single figure.
+    """
+
     fig = pl.figure(figsize=(9, 18) if single_column else (18, 9))
     fig.suptitle('Reprojection error distribution in pixels ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -646,6 +646,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
     reconstruction = find_reconstruction([im], data)
     if reconstruction is None:
         print '{0} does not exist in a reconstruction.'.format(im)
+        return
 
     im_array = data.image_as_array(im)
     p = load_points(im, data)
@@ -689,6 +690,111 @@ def create_complete_reconstruction_figure(im, data, save_figs=False, single_colu
     display_figure(fig, save_figs, data, '{0}_{1}_complete_rec.jpg'.format(im, data.feature_type()))
 
 
+def create_reprojection_error_figure(im, data, save_figs=False, single_column=False):
+    fig = pl.figure(figsize=(9, 18) if single_column else (18, 9))
+    fig.suptitle('Reprojection error distribution ({0}): {1}'.format(data.feature_type().upper(), im),
+                 fontsize=14, fontweight='bold')
+    fw = FigureWrapper(fig, 2 if single_column else 1, 1 if single_column else 2)
+
+    reconstruction = find_reconstruction([im], data)
+    if reconstruction is None:
+        print '{0} does not exist in a reconstruction.'.format(im)
+        return
+
+    im_array = data.image_as_array(im)
+    p = load_points(im, data)
+
+    graph = data.load_tracks_graph()
+    tracks = load_tracks(im, graph)
+    if tracks.shape[0] < 1:
+        print 'No tracks for exist for {0}.'.format(im)
+        return
+
+    rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
+    rec_track_points = p[rec_tracks[:, 1]]
+
+    rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
+
+    s = np.max(im_array.shape[:2])
+
+    rec_errors = s * np.subtract(rec_track_points, rp)
+    rec_mean_error = np.mean(rec_errors, axis=0)
+    rec_std_error = np.std(rec_errors, axis=0)
+
+    rec_errors_norm = np.linalg.norm(rec_errors, axis=1)
+    rec_min_error = np.min(rec_errors_norm)
+    rec_max_error = np.max(rec_errors_norm)
+
+    min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
+    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
+    reprojected = reproject_tracks(im, non_rec_tracks[succeeded, 0], reconstruction)
+
+    triangulated_points = p[non_rec_tracks[succeeded, 1]]
+
+    non_rec_errors = s * np.subtract(reprojected, triangulated_points)
+    non_rec_mean_error = np.mean(non_rec_errors, axis=0)
+    non_rec_std_error = np.std(non_rec_errors, axis=0)
+
+    non_rec_errors_norm = np.linalg.norm(non_rec_errors, axis=1)
+    non_rec_min_error = np.min(non_rec_errors_norm)
+    non_rec_max_error = np.max(non_rec_errors_norm)
+
+    axis_max = np.max(np.abs(np.vstack((rec_errors, non_rec_errors)))) + 1
+
+    rec_sub = fig.add_subplot(fw.rows, fw.cols, 1)
+    pl.xlim(-axis_max, axis_max)
+    pl.ylim(-axis_max, axis_max)
+
+    title = 'Reconstructed track errors: {0}.'.format(rec_tracks.shape[0])
+    error_title = " Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max dist: {4:.1f}. Min dist: {5:.1f}."
+    rec_sub.text(0.5, 1.04,
+                 title + error_title.format(rec_mean_error[0], rec_mean_error[1], rec_std_error[0], rec_std_error[1],
+                                            rec_max_error, rec_min_error),
+                 horizontalalignment='center',
+                 fontsize=12,
+                 transform=rec_sub.transAxes)
+    rec_sub.set_aspect('equal')
+
+    pl.grid(b=True, which='major', color='0.3')
+
+    rec_sub.plot(np.array([0]), np.array([0]), '+k')
+    rec_sub.plot(rec_errors[:, 0], rec_errors[:, 1], 'ob')
+
+
+    non_rec_sub = fig.add_subplot(fw.rows, fw.cols, 2)
+    pl.xlim(-axis_max, axis_max)
+    pl.ylim(-axis_max, axis_max)
+
+    title = 'Failed track errors (re-triangulated): {0} / {1}.'.format(np.sum(succeeded), non_rec_tracks.shape[0])
+    non_rec_sub.text(0.5, 1.04,
+                     title + error_title.format(non_rec_mean_error[0], non_rec_mean_error[1], non_rec_std_error[0],
+                                                non_rec_std_error[1], non_rec_max_error, non_rec_min_error),
+                     horizontalalignment='center',
+                     fontsize=12,
+                     transform=non_rec_sub.transAxes)
+    non_rec_sub.set_aspect('equal')
+    pl.grid(b=True, which='major', color='0.3')
+
+    non_rec_sub.plot(np.array([0]), np.array([0]), '+k')
+    non_rec_sub.plot(non_rec_errors[:, 0], non_rec_errors[:, 1], 'om')
+
+    fig.subplots_adjust(left=0.01,
+                        bottom=0.05,
+                        right=0.99,
+                        top=0.88,
+                        wspace=0.04,
+                        hspace=0.14)
+
+    if save_figs:
+        p = data.data_path + '/plot_inliers'
+        io.mkdir_p(p)
+        fig.savefig(p + '/' + '{0}_{1}_error_dist.jpg'.format(im, data.feature_type()), dpi=100)
+        pl.close()
+    else:
+        pl.show()
+
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Plot inlier and outlier matches between images')
     parser.add_argument('dataset',
@@ -727,5 +833,11 @@ if __name__ == "__main__":
         print 'Plotting complete reconstruction tracks for {0}...'.format(image1)
         create_complete_reconstruction_figure(image1, ds, save, single)
 
+        print 'Plotting reprojection error for {0}...'.format(image1)
+        create_reprojection_error_figure(image1, ds, save, single)
+
         print 'Plotting complete reconstruction tracks for {0}...'.format(image2)
         create_complete_reconstruction_figure(image2, ds, save, single)
+
+        print 'Plotting reprojection error for {0}...'.format(image2)
+        create_reprojection_error_figure(image2, ds, save, single)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -258,35 +258,57 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
 
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
 
-    robust_rec_tracks = []
-    non_robust_rec_tracks = []
-    for track in reconstruction['points']:
-        track = int(track)
-        if track in non_robust_tracks[:, 2]:
-            non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 2] == track]))
-            non_robust_rec_tracks.append(non_robust_track)
-        else:
-            robust_track = np.squeeze(np.array(track_matches[track_matches[:, 2] == track]))
-            robust_rec_tracks.append(robust_track)
+    if reconstruction:
+        robust_rec_tracks = []
+        non_robust_rec_tracks = []
+        for track in reconstruction['points']:
+            track = int(track)
+            if track in non_robust_tracks[:, 2]:
+                non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 2] == track]))
+                non_robust_rec_tracks.append(non_robust_track)
+            else:
+                robust_track = np.squeeze(np.array(track_matches[track_matches[:, 2] == track]))
+                robust_rec_tracks.append(robust_track)
 
-    robust_rec_tracks = np.array(robust_rec_tracks)
-    non_robust_rec_tracks = np.array(non_robust_rec_tracks)
+        failed_rec_tracks = []
+        for track in track_matches:
+            if not str(track[2]) in reconstruction['points']:
+                failed_rec_tracks.append(track)
 
-    robust_rec_points1 = p1[robust_rec_tracks[:, 0]]
-    robust_rec_points2 = p2[robust_rec_tracks[:, 1]]
+        robust_rec_tracks = np.array(robust_rec_tracks)
+        non_robust_rec_tracks = np.array(non_robust_rec_tracks)
+        failed_rec_tracks = np.array(failed_rec_tracks)
 
-    non_robust_rec_points1 = p1[non_robust_rec_tracks[:, 0]]
-    non_robust_rec_points2 = p2[non_robust_rec_tracks[:, 1]]
+        robust_rec_points1 = p1[robust_rec_tracks[:, 0]]
+        robust_rec_points2 = p2[robust_rec_tracks[:, 1]]
 
-    rec_title = 'Reconstructed 3D points: {0}. Robust {1}. Non robust: {2}. Failed: {3}'.format(
-        len(reconstruction['points']),
-        robust_rec_tracks.shape[0],
-        non_robust_rec_tracks.shape[0],
-        track_matches.shape[0] - (robust_rec_tracks.shape[0] + non_robust_rec_tracks.shape[0]))
+        non_robust_rec_points1 = p1[non_robust_rec_tracks[:, 0]]
+        non_robust_rec_points2 = p2[non_robust_rec_tracks[:, 1]]
 
-    rec_plot = plot_matches_sub(
-        fig, 2, 2, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
-    plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
+        failed_rec_points1 = p1[failed_rec_tracks[:, 0]]
+        failed_rec_points2 = p2[failed_rec_tracks[:, 1]]
+
+        rec_title = \
+            'Reconstructed 3D points: {0}. Robust {1}. Non robust: {2}. Failed: {3}. '.format(
+                len(reconstruction['points']),
+                robust_rec_tracks.shape[0],
+                non_robust_rec_tracks.shape[0],
+                failed_rec_tracks.shape[0]) + \
+            'Triangulation threshold: {0:.4f}. Min ray angle: {1}.'.format(
+                data.config.get('triangulation_threshold', 0.004),
+                data.config.get('triangulation_min_ray_angle', 2.0))
+
+        rec_plot = plot_matches_sub(
+            fig, 2, 2, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
+        plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
+        plot_matches(rec_plot, im1_array, im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
+    else:
+        failed_title = \
+            'Reconstruction failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}. '.format(
+                data.config.get('five_point_algo_min_inliers', 50),
+                data.config.get('triangulation_threshold', 0.004),
+                data.config.get('triangulation_min_ray_angle', 2.0))
+        create_subplot(fig, 2, 2, 4, failed_title, 100)
 
     fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -22,25 +22,18 @@ def show_images(plot, im1, im2):
     plot.imshow(image)
 
 
-def show_image(plot, im1):
-    plot.imshow(im1)
-
-
-def plot_points(plot, im1, im2, p1, p2, point_format1='ob', point_format2='ob'):
+def plot_points(plot, im1, p1, point_format1='ob', im2=None, p2=None, point_format2='ob'):
     h1, w1, c = im1.shape
-    h2, w2, c = im2.shape
     p1d = features.denormalized_image_coordinates(p1, w1, h1)
+    plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
+
+    if im2 is None or p2 is None:
+        return
+
+    h2, w2, c = im2.shape
     p2d = features.denormalized_image_coordinates(p2, w2, h2)
 
-    plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
     plot.plot(p2d[:, 0] + w1, p2d[:, 1], point_format2)
-
-
-def plot_point(plot, im, p, point_format='ob'):
-    h, w, c = im.shape
-    pd = features.denormalized_image_coordinates(p, w, h)
-
-    plot.plot(pd[:, 0], pd[:, 1], point_format)
 
 
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
@@ -51,7 +44,7 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     for a, b in zip(p1d, p2d):
         plot.plot([a[0], b[0] + w1], [a[1], b[1]], line_format)
 
-    plot_points(plot, im1, im2, p1, p2, point_format, point_format)
+    plot_points(plot, im1, p1, point_format, im2, p2, point_format)
 
 
 def create_subplot(figure, rows, columns, index, title, width):
@@ -71,7 +64,7 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
     subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
     show_images(subplot, im1, im2)
-    plot_points(subplot, im1, im2, p1, p2, point_format1, point_format2)
+    plot_points(subplot, im1, p1, point_format1, im2, p2, point_format2)
 
     return subplot
 
@@ -380,11 +373,11 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     title = 'Tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
         tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
-    sub = create_subplot(fig, 1, 1, 1, title, im_array.shape[1])
-    show_image(sub, im_array)
-    plot_point(sub, im_array, track_points, 'or')
-    plot_point(sub, im_array, rec_track_points, 'ob')
-    plot_point(sub, im_array, reprojected_points, '+w')
+    rec_plot = create_subplot(fig, 1, 1, 1, title, im_array.shape[1])
+    rec_plot.imshow(im_array)
+    plot_points(rec_plot, im_array, track_points, 'or')
+    plot_points(rec_plot, im_array, rec_track_points, 'ob')
+    plot_points(rec_plot, im_array, reprojected_points, '+w')
 
     fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -16,6 +16,21 @@ from opensfm import csfm
 import opensfm.reconstruction as reconstruct
 
 
+class FigureWrapper:
+    def __init__(self, figure, rows, cols):
+        self.figure = figure
+        self.rows = rows
+        self.cols = cols
+
+
+class ImagePair:
+    def __init__(self, im1, im2, im1_array, im2_array):
+        self.im1 = im1
+        self.im2 = im2
+        self.im1_array = im1_array
+        self.im2_array = im2_array
+
+
 def redirect_print():
     """ Redirects the sys.stdout to the null device.
 
@@ -332,7 +347,7 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     s_matches1 = p1[symmetric_matches[:, 0]]
     s_matches2 = p2[symmetric_matches[:, 1]]
 
-    plot_matches_sub(fig, rows, cols, 3,
+    plot_matches_sub(fig, rows, cols, 2,
                      'Symmetric matches (calculated): {0}'.format(symmetric_matches.shape[0]),
                      im1_array, im2_array,
                      s_matches1, s_matches2,
@@ -345,8 +360,8 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     r_matches2 = p2[robust_matches[:, 1]]
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
-    plot_matches_sub(fig, rows, cols, 2,
-                     'Robust matching inliers (calculated with RANSAC eight point algorithm): {0}. Threshold: {1:.4f}'
+    plot_matches_sub(fig, rows, cols, 3,
+                     'Robust matching inliers (calculated with RANSAC eight point algorithm): {0}. Threshold: {1}'
                      .format(robust_matches.shape[0], threshold),
                      im1_array, im2_array,
                      r_matches1, r_matches2,
@@ -358,7 +373,8 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     outliers2 = p2[outliers[:, 1]]
 
     plot_matches_sub(fig, rows, cols, 4,
-                     'Robust matching outliers (calculated): {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
+                     'Robust matching outliers (calculated): {0}. Threshold: {1}'
+                     .format(outliers.shape[0], threshold),
                      im1_array, im2_array,
                      outliers1, outliers2,
                      'r', 'om')
@@ -366,98 +382,86 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_matches.jpg'.format(im1, im2, data.feature_type()))
 
 
-def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
-    fig, rows, cols = \
-        create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
-
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
-    p1 = load_points(im1, data)
-    p2 = load_points(im2, data)
-
-    # Retrieve tracks and robust matches from file and plot tracks corresponding to
-    # robust matches and tracks not corresponding to robust matches (linked tracks) in different colors.
-    robust_matches = data.find_matches(im1, im2)
-    robust_matches = np.array(robust_matches) if len(robust_matches) else np.empty((0, 2), int)
-
-    graph = data.load_tracks_graph()
-    tracks = load_common_tracks(im1, im2, graph)
-
-    if tracks.shape[0] < 5:
-        print 'Not enough tracks for five point algorithm: ' + str(tracks.shape[0])
-        return
-
-    robust_tracks, non_robust_tracks = matches(tracks, robust_matches, lambda a: a[1:])
+def plot_common_tracks(fw, ip, index, p1, p2, tracks, robust_tracks, linked_tracks, robust_matches):
+    """ Plot common tracks corresponding to robust matches and tracks not corresponding to robust matches
+        (linked tracks) in different colors. """
 
     robust_points1 = p1[robust_tracks[:, 1]]
     robust_points2 = p2[robust_tracks[:, 2]]
 
-    non_robust_points1 = p1[non_robust_tracks[:, 1]]
-    non_robust_points2 = p2[non_robust_tracks[:, 2]]
+    linked_points1 = p1[linked_tracks[:, 1]]
+    linked_points2 = p2[linked_tracks[:, 2]]
 
-    tracks_title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Linked tracks: {3}'.format(
+    title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Linked tracks: {3}'.format(
         tracks.shape[0],
         robust_tracks.shape[0],
         robust_matches.shape[0],
-        non_robust_tracks.shape[0])
+        linked_tracks.shape[0])
 
-    tracks_subplot = plot_matches_sub(
-        fig, rows, cols, 1, tracks_title, im1_array, im2_array, robust_points1, robust_points2, 'c', 'ob')
-    plot_matches(tracks_subplot, im1_array, im2_array, non_robust_points1, non_robust_points2, 'g', 'oy')
+    subplot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, title, ip.im1_array, ip.im2_array,
+                               robust_points1, robust_points2, 'c', 'ob')
+    plot_matches(subplot, ip.im1_array, ip.im2_array, linked_points1, linked_points2, 'g', 'oy')
 
-    # Plot inliers and outliers of the tracks from OpenCV find homography.
-    track_points1 = p1[tracks[:, 1]]
-    track_points2 = p2[tracks[:, 2]]
+
+def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_points2, data):
+    """ Plot inliers and outliers of the tracks from OpenCV find homography. """
 
     threshold_h = data.config.get('homography_threshold', 0.004)
-    H, inliers_h = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
+    H, inliers = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold_h)
 
-    inliers_h = np.array(np.squeeze(inliers_h), np.bool)
+    inliers = np.array(np.squeeze(inliers), np.bool)
 
-    inliers_h1 = track_points1[inliers_h, :]
-    inliers_h2 = track_points2[inliers_h, :]
+    inliers1 = track_points1[inliers, :]
+    inliers2 = track_points2[inliers, :]
 
-    outliers_h1 = track_points1[~inliers_h, :]
-    outliers_h2 = track_points2[~inliers_h, :]
+    outliers1 = track_points1[~inliers, :]
+    outliers2 = track_points2[~inliers, :]
 
-    h_title = \
-        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'\
+    title = \
+        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3}'\
         .format(
-            inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
+            inliers.sum(), (~inliers).sum(), float((~inliers).sum()) / tracks.shape[0], threshold_h)
 
-    h_subplot = plot_matches_sub(fig, rows, cols, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
-    plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
+    subplot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, title, ip.im1_array, ip.im2_array,
+                               outliers1, outliers2, 'r', 'om')
+    plot_matches(subplot, ip.im1_array, ip.im2_array, inliers1, inliers2, 'c', 'ob')
 
-    # Plot inliers and outliers of the tracks from csfm two view reconstruction.
-    f1 = data.load_exif(im1)['focal_prior']
-    f2 = data.load_exif(im2)['focal_prior']
 
-    threshold_t = data.config.get('five_point_algo_threshold', 0.006)
-    R, t, cov, inliers_t = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold_t)
+def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, data):
+    """ Plot inliers and outliers of the tracks from csfm two view reconstruction. """
 
-    inliers_t1 = track_points1[inliers_t, :]
-    inliers_t2 = track_points2[inliers_t, :]
+    f1 = data.load_exif(ip.im1)['focal_prior']
+    f2 = data.load_exif(ip.im2)['focal_prior']
 
-    outliers_t = np.ones(track_points1.shape[0], dtype=bool)
-    outliers_t[inliers_t] = False
-    outliers_t1 = track_points1[outliers_t, :]
-    outliers_t2 = track_points2[outliers_t, :]
+    threshold = data.config.get('five_point_algo_threshold', 0.006)
+    R, t, cov, inliers = csfm.two_view_reconstruction(track_points1, track_points2, f1, f2, threshold)
 
-    t_title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
-        len(inliers_t), outliers_t.sum(), threshold_t)
+    inliers1 = track_points1[inliers, :]
+    inliers2 = track_points2[inliers, :]
 
-    t_subplot = plot_matches_sub(fig, rows, cols, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
-    plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
+    outliers = np.ones(track_points1.shape[0], dtype=bool)
+    outliers[inliers] = False
+    outliers1 = track_points1[outliers, :]
+    outliers2 = track_points2[outliers, :]
 
-    # Plot successfully reconstructed and failed 3D points by reconstruction bootstrap.
-    stdout_reset = redirect_print()
-    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
-    reset_print(stdout_reset)
+    title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2}'.format(
+        len(inliers), outliers.sum(), threshold)
+
+    subplot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, title, ip.im1_array, ip.im2_array,
+                               inliers1, inliers2, 'c', 'ob')
+    plot_matches(subplot, ip.im1_array, ip.im2_array, outliers1, outliers2, 'r', 'om')
+
+
+def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linked_tracks, graph, data):
+    """ Plot successfully reconstructed and failed 3D points by reconstruction bootstrap. """
+
+    print_reset = redirect_print()
+    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2)
+    reset_print(print_reset)
 
     if reconstruction:
         robust_rec_tracks, failed_robust = reconstruction_tracks(robust_tracks, reconstruction)
-        non_robust_rec_tracks, failed_non_robust = reconstruction_tracks(non_robust_tracks, reconstruction)
+        non_robust_rec_tracks, failed_non_robust = reconstruction_tracks(linked_tracks, reconstruction)
         failed_rec_tracks = np.vstack((failed_robust, failed_non_robust))
 
         robust_rec_points1 = p1[robust_rec_tracks[:, 1]]
@@ -475,24 +479,113 @@ def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],
                 failed_rec_tracks.shape[0]) + \
-            'Triangulation threshold: {0:.4f}. Min ray angle: {1}.'.format(
+            'Triangulation threshold: {0}. Min ray angle: {1}.'.format(
                 data.config.get('triangulation_threshold', 0.004),
                 data.config.get('triangulation_min_ray_angle', 2.0))
 
-        rec_plot = plot_matches_sub(
-            fig, rows, cols, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
-        plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
-        plot_matches(rec_plot, im1_array, im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
+        rec_plot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, rec_title, ip.im1_array, ip.im2_array,
+                                    robust_rec_points1, robust_rec_points2, 'c', 'ob')
+        plot_matches(rec_plot, ip.im1_array, ip.im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
+        plot_matches(rec_plot, ip.im1_array, ip.im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
         failed_title = \
-            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}.'\
+            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1}. Min ray angle: {2}.'\
             .format(
                 data.config.get('five_point_algo_min_inliers', 50),
                 data.config.get('triangulation_threshold', 0.004),
                 data.config.get('triangulation_min_ray_angle', 2.0))
-        create_subplot(fig, rows, cols, 4, failed_title, 100, 100)
+        create_subplot(fw.figure, fw.rows, fw.cols, index, failed_title, 100, 100)
+
+
+def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
+    fig, rows, cols = \
+        create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
+
+    fw = FigureWrapper(fig, rows, cols)
+    ip = ImagePair(im1, im2, data.image_as_array(im1), data.image_as_array(im2))
+
+    p1 = load_points(im1, data)
+    p2 = load_points(im2, data)
+
+    # Retrieve tracks and robust matches from file
+    robust_matches = data.find_matches(im1, im2)
+    robust_matches = np.array(robust_matches) if len(robust_matches) else np.empty((0, 2), int)
+
+    graph = data.load_tracks_graph()
+    tracks = load_common_tracks(im1, im2, graph)
+    track_points1 = p1[tracks[:, 1]]
+    track_points2 = p2[tracks[:, 2]]
+
+    if tracks.shape[0] < 5:
+        print 'Not enough tracks for five point algorithm: ' + str(tracks.shape[0])
+        return
+
+    robust_tracks, linked_tracks = matches(tracks, robust_matches, lambda a: a[1:])
+
+    plot_common_tracks(fw, ip, 1, p1, p2, tracks, robust_tracks, linked_tracks, robust_matches)
+    plot_opencv_find_homography(fw, ip, 2, tracks, track_points1, track_points2, data)
+    plot_two_view_reconstruction(fw, ip, 3, track_points1, track_points2, data)
+    plot_bootstrapped_reconstruction(fw, ip, 4, p1, p2, robust_tracks, linked_tracks, graph, data)
 
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_tracks.jpg'.format(im1, im2, data.feature_type()))
+
+
+def plot_reconstructed_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_tracks):
+    """ Plot reconstructed tracks and rejected tracks as matches in different colors. """
+
+    rec_track_points1 = p1[rec_tracks[:, 1]]
+    rec_track_points2 = p2[rec_tracks[:, 2]]
+    non_rec_track_points1 = p1[non_rec_tracks[:, 1]]
+    non_rec_track_points2 = p2[non_rec_tracks[:, 2]]
+
+    title = \
+        'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}. All loaded.'\
+        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+
+    subplot = create_subplot(fw.figure, fw.rows, fw.cols, index, title,
+                             ip.im1_array.shape[1] + ip.im2_array.shape[1],
+                             np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]),
+                             15)
+
+    show_images(subplot, ip.im1_array, ip.im2_array)
+    plot_matches(subplot, ip.im1_array, ip.im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
+    plot_matches(subplot, ip.im1_array, ip.im2_array, non_rec_track_points1, non_rec_track_points2, 'r', 'om')
+
+
+def plot_reprojected_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_tracks, reconstruction, graph, data):
+    """ Reproject tracks and plot. """
+
+    rec_track_points1 = p1[rec_tracks[:, 1]]
+    rec_track_points2 = p2[rec_tracks[:, 2]]
+
+    rp1 = reproject_tracks(ip.im1, rec_tracks[:, 0], reconstruction)
+    rp2 = reproject_tracks(ip.im2, rec_tracks[:, 0], reconstruction)
+
+    min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
+    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
+    reprojected1 = reproject_tracks(ip.im1, non_rec_tracks[succeeded, 0], reconstruction)
+    reprojected2 = reproject_tracks(ip.im2, non_rec_tracks[succeeded, 0], reconstruction)
+
+    triangulated_points1 = p1[non_rec_tracks[succeeded, 1]]
+    triangulated_points2 = p2[non_rec_tracks[succeeded, 2]]
+    excluded_points1 = p1[non_rec_tracks[~succeeded, 1]]
+    excluded_points2 = p2[non_rec_tracks[~succeeded, 2]]
+
+    title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}.\n'\
+        .format(tracks.shape[0], rec_tracks.shape[0]) + \
+            'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
+        .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
+
+    subplot = create_subplot(fw.figure, fw.rows, fw.cols, index, title,
+                             ip.im1_array.shape[1] + ip.im2_array.shape[1],
+                             np.max([ip.im1_array.shape[0], ip.im2_array.shape[0]]),
+                             font_size=15)
+    show_images(subplot, ip.im1_array, ip.im2_array)
+    plot_points(subplot, ip.im1_array, rec_track_points1, 'ob', ip.im2_array, rec_track_points2, 'ob')
+    plot_points(subplot, ip.im1_array, rp1, '+w', ip.im2_array, rp2, '+w')
+    plot_points(subplot, ip.im1_array, triangulated_points1, 'om', ip.im2_array, triangulated_points2, 'om')
+    plot_points(subplot, ip.im1_array, reprojected1, '+w', ip.im2_array, reprojected2, '+w')
+    plot_points(subplot, ip.im1_array, excluded_points1, 'or', ip.im2_array, excluded_points2, 'or')
 
 
 def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
@@ -500,8 +593,8 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=18, fontweight='bold')
 
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
+    fw = FigureWrapper(fig, 2, 1)
+    ip = ImagePair(im1, im2, data.image_as_array(im1), data.image_as_array(im2))
 
     p1 = load_points(im1, data)
     p2 = load_points(im2, data)
@@ -516,55 +609,10 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
-    # Retrieve reconstructed tracks and plot as matches. Plot rejected tracks in other color.
     rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
-    rec_track_points1 = p1[rec_tracks[:, 1]]
-    rec_track_points2 = p2[rec_tracks[:, 2]]
-    non_rec_track_points1 = p1[non_rec_tracks[:, 1]]
-    non_rec_track_points2 = p2[non_rec_tracks[:, 2]]
 
-    title = \
-        'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}. All loaded.'\
-        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
-
-    t_subplot = create_subplot(fig, 2, 1, 1, title,
-                               im1_array.shape[1] + im2_array.shape[1],
-                               np.max([im1_array.shape[0], im2_array.shape[0]]),
-                               15)
-    show_images(t_subplot, im1_array, im2_array)
-    plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
-    plot_matches(t_subplot, im1_array, im2_array, non_rec_track_points1, non_rec_track_points2, 'r', 'om')
-
-    # Reproject reconstructed tracks. Triangulate rejected tracks and plot min ray angle removals and successfully
-    # triangulated tracks in different colors.
-    rp1 = reproject_tracks(im1, rec_tracks[:, 0], reconstruction)
-    rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
-
-    min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
-    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
-    reprojected1 = reproject_tracks(im1, non_rec_tracks[succeeded, 0], reconstruction)
-    reprojected2 = reproject_tracks(im2, non_rec_tracks[succeeded, 0], reconstruction)
-
-    triangulated_points1 = p1[non_rec_tracks[succeeded, 1]]
-    triangulated_points2 = p2[non_rec_tracks[succeeded, 2]]
-    excluded_points1 = p1[non_rec_tracks[~succeeded, 1]]
-    excluded_points2 = p2[non_rec_tracks[~succeeded, 2]]
-
-    title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}.\n'\
-        .format(tracks.shape[0], rec_tracks.shape[0]) + \
-            'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
-        .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
-
-    rec_plot = create_subplot(fig, 2, 1, 2, title,
-                              im1_array.shape[1] + im2_array.shape[1],
-                              np.max([im1_array.shape[0], im2_array.shape[0]]),
-                              15)
-    show_images(rec_plot, im1_array, im2_array)
-    plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
-    plot_points(rec_plot, im1_array, rp1, '+w', im2_array, rp2, '+w')
-    plot_points(rec_plot, im1_array, triangulated_points1, 'om', im2_array, triangulated_points2, 'om')
-    plot_points(rec_plot, im1_array, reprojected1, '+w', im2_array, reprojected2, '+w')
-    plot_points(rec_plot, im1_array, excluded_points1, 'or', im2_array, excluded_points2, 'or')
+    plot_reconstructed_tracks(fw, ip, 1, p1, p2, tracks, rec_tracks, non_rec_tracks)
+    plot_reprojected_tracks(fw, ip, 2, p1, p2, tracks, rec_tracks, non_rec_tracks, reconstruction, graph, data)
 
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_reconstruction.jpg'.format(im1, im2, data.feature_type()))
 
@@ -592,10 +640,10 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
 
-    title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
+    rec_title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
         .format(tracks.shape[0], rec_tracks.shape[0])
 
-    rec_plot = create_subplot(fig, 1, 2, 1, title, im_array.shape[1], im_array.shape[0])
+    rec_plot = create_subplot(fig, 1, 2, 1, rec_title, im_array.shape[1], im_array.shape[0])
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
@@ -607,10 +655,11 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     triangulated_points = p[non_rec_tracks[succeeded, 1]]
     excluded_points = p[non_rec_tracks[~succeeded, 1]]
 
-    title = 'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
+    non_rec_title = \
+        'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
-    non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1], im_array.shape[0])
+    non_rec_plot = create_subplot(fig, 1, 2, 2, non_rec_title, im_array.shape[1], im_array.shape[0])
     non_rec_plot.imshow(im_array)
     plot_points(non_rec_plot, im_array, triangulated_points, 'om')
     plot_points(non_rec_plot, im_array, excluded_points, 'or')

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -759,12 +759,17 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
 
     axis_max = np.max(np.abs(np.vstack((rec_errors, non_errors)))) + 1
 
-    title = 'Reconstructed track errors: {0}.'.format(rec_tracks.shape[0])
-    error_title = " Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max norm: {4:.1f}. Min norm: {5:.1f}."
+    title = 'Reconstructed tracks: {0}. '.format(rec_tracks.shape[0])
+    error_title = "Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max norm: {4:.1f}. Min norm: {5:.1f}."
+
+    triang_thld = data.config.get('triangulation_threshold', 0.004)
+    bundle_thld = data.config.get('bundle_outlier_threshold', 0.008)
+    thld = 'Thold: Triangulation: {0:.1f} ({1}). Bundle outlier: {2:.1f} ({3}).'\
+        .format(scale * triang_thld, triang_thld, scale * bundle_thld, bundle_thld)
 
     rec_sub = create_subplot(
         fw.figure, fw.rows, fw.cols, 1,
-        title + error_title.format(rec_mean[0], rec_mean[1], rec_std[0], rec_std[1], rec_max, rec_min),
+        title + error_title.format(rec_mean[0], rec_mean[1], rec_std[0], rec_std[1], rec_max, rec_min) + '\n' + thld,
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
 
@@ -772,7 +777,7 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     rec_sub.plot(zero, zero, '+k')
     rec_sub.plot(rec_errors[:, 0], rec_errors[:, 1], 'ob')
 
-    title = 'Failed track errors: {0} / {1}.'.format(np.sum(succeeded), non_rec_tracks.shape[0])
+    title = 'Failed tracks: {0} / {1}. '.format(np.sum(succeeded), non_rec_tracks.shape[0])
 
     non_rec_sub = create_subplot(
         fw.figure, fw.rows, fw.cols, 2,

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -358,7 +358,7 @@ def matches(a1, a2, map_function):
 def thresholds(im1_array, im2_array, key, default, data):
     """ Retrieves the threshold value for a config key as well as the corresponding valude in pixels
         for two image arrays.
-        
+
     :param im1_array: First image array.
     :param im2_array: Second image array.
     :param key: Threshold config key.
@@ -448,7 +448,18 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
 
 def plot_common_tracks(fw, ip, index, p1, p2, tracks, robust_tracks, linked_tracks, robust_matches):
     """ Plot common tracks corresponding to robust matches and tracks not corresponding to robust matches
-        (linked tracks) in different colors. """
+        (linked tracks) in different colors.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Subplot index.
+    :param p1: Feature points for the first image.
+    :param p2: Feature points for the second image.
+    :param tracks: Common tracks.
+    :param robust_tracks: Tracks corresponding to robust matches.
+    :param linked_tracks: Common tracks linked by other image correspondences.
+    :param robust_matches: Array of feature ids for robust matches.
+    """
 
     robust_points1 = p1[robust_tracks[:, 1]]
     robust_points2 = p2[robust_tracks[:, 2]]
@@ -468,7 +479,17 @@ def plot_common_tracks(fw, ip, index, p1, p2, tracks, robust_tracks, linked_trac
 
 
 def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_points2, data):
-    """ Plot inliers and outliers of the tracks from OpenCV find homography. """
+    """ Plot inliers and outliers of the tracks from OpenCV find homography.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Subplot index.
+    :param tracks: Common tracks.
+    :param track_points1: Feature points corresponding to common tracks for image 1.
+    :param track_points2: Feature points corresponding to common tracks for image 2.
+    :param data: Data set.
+    :return:
+    """
 
     threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'homography_threshold', 0.004, data)
     H, inliers = cv2.findHomography(track_points1, track_points2, cv2.RANSAC, threshold)
@@ -492,7 +513,16 @@ def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_poin
 
 
 def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, data):
-    """ Plot inliers and outliers of the tracks from csfm two view reconstruction. """
+    """ Plot inliers and outliers of the tracks from csfm two view reconstruction.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Subplot index.
+    :param track_points1: Feature points corresponding to common tracks for image 1.
+    :param track_points2: Feature points corresponding to common tracks for image 2.
+    :param data: Data set.
+    :return:
+    """
 
     f1 = data.load_exif(ip.im1)['focal_prior']
     f2 = data.load_exif(ip.im2)['focal_prior']
@@ -518,7 +548,18 @@ def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, da
 
 
 def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linked_tracks, graph, data):
-    """ Plot successfully reconstructed and failed 3D points by reconstruction bootstrap. """
+    """ Plot successfully reconstructed and failed 3D points by bootstrapping a reconstruction.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Subplot index.
+    :param p1: Feature points for the first image.
+    :param p2: Feature points for the second image.
+    :param robust_tracks: Tracks corresponding to robust matches.
+    :param linked_tracks: Common tracks linked by other image correspondences.
+    :param graph: Tracks graph.
+    :param data: Data set.
+    """
 
     print_reset = redirect_print()
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2)
@@ -605,7 +646,17 @@ def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
 
 
 def plot_reconstructed_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_tracks):
-    """ Plot reconstructed tracks and rejected tracks as matches in different colors. """
+    """ Plots reconstructed tracks and rejected tracks as matches in different colors.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Subplot index.
+    :param p1: Feature points for the first image.
+    :param p2: Feature points for the second image.
+    :param tracks: Common tracks.
+    :param rec_tracks: Common tracks included in the reconstruction.
+    :param non_rec_tracks: Common tracks not included in the reconstruction.
+    """
 
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
@@ -627,7 +678,20 @@ def plot_reconstructed_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec
 
 
 def plot_reprojected_tracks(fw, ip, index, p1, p2, tracks, rec_tracks, non_rec_tracks, reconstruction, graph, data):
-    """ Reproject tracks and plot. """
+    """ Reprojects tracks included in and excluded from reconstruction and plots reprojections on top of observations.
+
+    :param fw: Figure wrapper.
+    :param ip: Image pair.
+    :param index: Sub plot index.
+    :param p1: Feature points for the first image.
+    :param p2: Feature points for the second image.
+    :param tracks: Common tracks.
+    :param rec_tracks: Common tracks included in the reconstruction.
+    :param non_rec_tracks: Common tracks not included in the reconstruction.
+    :param reconstruction: Reconstruction.
+    :param graph: Tracks graph.
+    :param data: Data set
+    """
 
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -431,33 +431,48 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
         print 'No tracks to plot.'
         return
 
-    track_points1 = p1[tracks[:, 1]]
-    track_points2 = p2[tracks[:, 2]]
-
     reconstruction = find_reconstruction([im1, im2], data)
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
-    rec_tracks = reconstruction_tracks(tracks, reconstruction)[0]
+    rec_tracks, non_rec_tracks = reconstruction_tracks(tracks, reconstruction)
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
+    non_rec_track_points1 = p1[non_rec_tracks[:, 1]]
+    non_rec_track_points2 = p2[non_rec_tracks[:, 2]]
 
     title = \
         'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}. All loaded.'\
         .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
-    t_subplot = plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'r', 'om')
-    plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
+    t_subplot = \
+        plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
+    plot_matches(t_subplot, im1_array, im2_array, non_rec_track_points1, non_rec_track_points2, 'r', 'om')
 
     rp1 = reproject_tracks(im1, rec_tracks[:, 0], reconstruction)
     rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
 
-    title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}. Triangulation and reprojection error removals: {2}'\
-        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
+    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
+    reprojected1 = reproject_tracks(im1, non_rec_tracks[succeeded, 0], reconstruction)
+    reprojected2 = reproject_tracks(im2, non_rec_tracks[succeeded, 0], reconstruction)
 
-    rec_plot = plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, track_points1, track_points2, 'or', 'or')
-    plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
+    triangulated_points1 = p1[non_rec_tracks[succeeded, 1]]
+    triangulated_points2 = p2[non_rec_tracks[succeeded, 2]]
+    excluded_points1 = p1[non_rec_tracks[~succeeded, 1]]
+    excluded_points2 = p2[non_rec_tracks[~succeeded, 2]]
+
+    title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}.\n'\
+        .format(tracks.shape[0], rec_tracks.shape[0]) + \
+            'Rejected tracks: {0}. Re-triangulated: {1}. Re-triangulation min ray angle ({2} deg) removals: {3}.'\
+        .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
+
+    rec_plot = \
+        plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, rec_track_points1, rec_track_points2, 'ob', 'ob')
     plot_points(rec_plot, im1_array, rp1, '+w', im2_array, rp2, '+w')
+    plot_points(rec_plot, im1_array, triangulated_points1, 'om', im2_array, triangulated_points2, 'om')
+    plot_points(rec_plot, im1_array, reprojected1, '+w', im2_array, reprojected2, '+w')
+    plot_points(rec_plot, im1_array, excluded_points1, 'or', im2_array, excluded_points2, 'or')
 
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_reconstruction.jpg'.format(im1, im2, data.feature_type()))
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -117,14 +117,12 @@ def reproject_tracks(im, tracks, reconstruction):
     return np.array(p) if len(p) else np.empty((0, 2), int)
 
 
-def triangulate_tracks(tracks, reconstruction, data):
-    graph = data.load_tracks_graph()
+def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
     succeeded = []
 
     for track in tracks:
-        # Triangulate with 1 as threshold to avoid excluding tracks because of error.
-        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {}, 1,
-                                      data.config.get('triangulation_min_ray_angle', 2.0))
+        # Triangulate with 1 as reprojection threshold to avoid excluding tracks because of error.
+        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {}, 1, min_ray_angle)
         succeeded.append(True) if str(track) in reconstruction['points'] else succeeded.append(False)
 
     return np.array(succeeded)
@@ -169,10 +167,9 @@ def load_points(im, data):
     return np.array(p[:, :2], np.float64)
 
 
-def load_common_tracks(im1, im2, data):
-    graph = data.load_tracks_graph()
+def load_common_tracks(im1, im2, graph):
     t1, t2 = graph[im1], graph[im2]
-    tc, p1, p2 = dataset.common_tracks(data.load_tracks_graph(), im1, im2)
+    tc, p1, p2 = dataset.common_tracks(graph, im1, im2)
 
     common_tracks = []
     for t in tc:
@@ -181,8 +178,7 @@ def load_common_tracks(im1, im2, data):
     return np.array(common_tracks) if len(common_tracks) else np.empty((0, 3), int)
 
 
-def load_tracks(im, data):
-    graph = data.load_tracks_graph()
+def load_tracks(im, graph):
     tn = graph[im]
 
     tracks = []
@@ -292,7 +288,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     robust_matches = data.find_matches(im1, im2)
     robust_matches = np.array(robust_matches) if len(robust_matches) else np.empty((0, 2), int)
 
-    tracks = load_common_tracks(im1, im2, data)
+    graph = data.load_tracks_graph()
+    tracks = load_common_tracks(im1, im2, graph)
 
     if tracks.shape[0] < 5:
         print 'Not enough tracks for five point algorithm: ' + str(tracks.shape[0])
@@ -358,7 +355,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
 
     # Plot successfully reconstructed and failed 3D points
     stdout_reset = redirect_print()
-    reconstruction = reconstruct.bootstrap_reconstruction(data, data.load_tracks_graph(), im1, im2)
+    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
     reset_print(stdout_reset)
 
     if reconstruction:
@@ -428,7 +425,8 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     p1 = load_points(im1, data)
     p2 = load_points(im2, data)
 
-    tracks = load_common_tracks(im1, im2, data)
+    graph = data.load_tracks_graph()
+    tracks = load_common_tracks(im1, im2, graph)
     if tracks.shape[0] < 1:
         print 'No tracks to plot.'
         return
@@ -476,7 +474,8 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     im_array = data.image_as_array(im)
     p = load_points(im, data)
 
-    tracks = load_tracks(im, data)
+    graph = data.load_tracks_graph()
+    tracks = load_tracks(im, graph)
     if tracks.shape[0] < 1:
         print 'No tracks for exist for {0}.'.format(im)
         return
@@ -494,15 +493,15 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
 
-    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, data)
+    min_ray_angle = data.config.get('triangulation_min_ray_angle', 2.0)
+    succeeded = triangulate_tracks(non_rec_tracks[:, 0], reconstruction, graph, min_ray_angle)
     reprojected = reproject_tracks(im, non_rec_tracks[succeeded, 0], reconstruction)
 
     triangulated_points = p[non_rec_tracks[succeeded, 1]]
     excluded_points = p[non_rec_tracks[~succeeded, 1]]
 
     title = 'Rejected tracks: {0}. Re-triangulated: {1}. Re-triangulation min ray angle ({2} deg) removals: {3}.'\
-        .format(non_rec_tracks.shape[0], succeeded.sum(),
-                data.config.get('triangulation_min_ray_angle', 2.0), (~succeeded).sum())
+        .format(non_rec_tracks.shape[0], succeeded.sum(), min_ray_angle, (~succeeded).sum())
 
     non_rec_plot = create_subplot(fig, 1, 2, 2, title, im_array.shape[1])
     non_rec_plot.imshow(im_array)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -78,6 +78,18 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
     return subplot
 
 
+def display_figure(figure, save_figs, data=None, file_name=''):
+    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
+
+    if save_figs:
+        p = data.data_path + '/plot_inliers'
+        io.mkdir_p(p)
+        figure.savefig(p + '/' + file_name, dpi=100)
+        pl.close()
+    else:
+        pl.show()
+
+
 def reproject_tracks(im, tracks, reconstruction):
     p = []
     for track in tracks:
@@ -87,7 +99,7 @@ def reproject_tracks(im, tracks, reconstruction):
 
         p.append(reconstruct.reproject(camera, shot, point))
 
-    return np.array(p)
+    return np.array(p) if len(p) else np.empty((0, 2), int)
 
 
 def find_reconstruction(images, data):
@@ -114,24 +126,35 @@ def reconstruction_tracks(tracks, reconstruction):
         if str(track[0]) in reconstruction['points']:
             r_tracks.append(track)
 
-    return np.array(r_tracks)
-
-
-def display_figure(figure, save_figs, data=None, file_name=''):
-    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
-
-    if save_figs:
-        p = data.data_path + '/plot_inliers'
-        io.mkdir_p(p)
-        figure.savefig(p + '/' + file_name, dpi=100)
-        pl.close()
-    else:
-        pl.show()
+    return np.array(r_tracks) if len(r_tracks) else np.empty((0, tracks.shape[1]), int)
 
 
 def load_points(im, data):
     p, f, c = data.load_features(im)
     return np.array(p[:, :2], np.float64)
+
+
+def load_common_tracks(im1, im2, data):
+    graph = data.load_tracks_graph()
+    t1, t2 = graph[im1], graph[im2]
+    tc, p1, p2 = dataset.common_tracks(data.load_tracks_graph(), im1, im2)
+
+    common_tracks = []
+    for t in tc:
+        common_tracks.append(np.array([int(t), t1[t]['feature_id'], t2[t]['feature_id']]))
+
+    return np.array(common_tracks) if len(common_tracks) else np.empty((0, 3), int)
+
+
+def load_tracks(im, data):
+    graph = data.load_tracks_graph()
+    tn = graph[im]
+
+    tracks = []
+    for t in tn:
+        tracks.append(np.array([int(t), tn[t]['feature_id']]))
+
+    return np.array(tracks) if len(tracks) else np.empty((0, 2), int)
 
 
 def create_matches_figure(im1, im2, data, save_figs=False):
@@ -220,44 +243,35 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     # Retrieve tracks and robust matches from file and plot tracks corresponding to
     # robust matches and tracks not corresponding to robust matches in different colors.
     robust_matches = data.find_matches(im1, im2)
-    if not len(robust_matches):
-        robust_matches = np.empty((0, 2), int)
+    robust_matches = np.array(robust_matches) if len(robust_matches) else np.empty((0, 2), int)
 
-    graph = data.load_tracks_graph()
-    t1, t2 = graph[im1], graph[im2]
+    tracks = load_common_tracks(im1, im2, data)
 
-    track_matches = []
-    for track in t1:
-        if track in t2:
-            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id'], int(track)]))
-
-    track_matches = np.array(track_matches)
-
-    if track_matches.shape[0] < 5:
-        print 'Not enough tracks for five point algorithm: ' + str(track_matches.shape[0])
+    if tracks.shape[0] < 5:
+        print 'Not enough tracks for five point algorithm: ' + str(tracks.shape[0])
         return
 
-    track_points1 = p1[track_matches[:, 0]]
-    track_points2 = p2[track_matches[:, 1]]
+    track_points1 = p1[tracks[:, 1]]
+    track_points2 = p2[tracks[:, 2]]
 
     non_robust_tracks = np.empty((0, 3), int)
-    for match in track_matches:
+    for match in tracks:
 
         found = False
         for robust_match in robust_matches:
-            if np.array_equal(match[:2], robust_match):
+            if np.array_equal(match[1:], robust_match):
                 found = True
                 break
 
         if not found:
             non_robust_tracks = np.vstack((non_robust_tracks, match))
 
-    non_robust_tracks1 = p1[non_robust_tracks[:, 0]]
-    non_robust_tracks2 = p2[non_robust_tracks[:, 1]]
+    non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
+    non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 
     tracks_title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
-        track_matches.shape[0],
-        track_matches.shape[0] - non_robust_tracks.shape[0],
+        tracks.shape[0],
+        tracks.shape[0] - non_robust_tracks.shape[0],
         robust_matches.shape[0],
         non_robust_tracks.shape[0])
 
@@ -278,7 +292,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_h2 = track_points2[~inliers_h, :]
 
     h_title = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
-        inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / track_matches.shape[0], threshold_h)
+        inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
 
     h_subplot = plot_matches_sub(fig, 2, 2, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
@@ -305,33 +319,33 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     # Plot successfully reconstructed and failed 3D points
-    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
+    reconstruction = reconstruct.bootstrap_reconstruction(data, data.load_tracks_graph(), im1, im2)
 
     if reconstruction:
         robust_rec_tracks = np.empty((0, 3), int)
         non_robust_rec_tracks = np.empty((0, 3), int)
         for track in reconstruction['points']:
             track = int(track)
-            if track in non_robust_tracks[:, 2]:
-                non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 2] == track]))
+            if track in non_robust_tracks[:, 0]:
+                non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 0] == track]))
                 non_robust_rec_tracks = np.vstack((non_robust_rec_tracks, non_robust_track))
             else:
-                robust_track = np.squeeze(np.array(track_matches[track_matches[:, 2] == track]))
+                robust_track = np.squeeze(np.array(tracks[tracks[:, 0] == track]))
                 robust_rec_tracks = np.vstack((robust_rec_tracks, robust_track))
 
         failed_rec_tracks = np.empty((0, 3), int)
-        for track in track_matches:
-            if not str(track[2]) in reconstruction['points']:
+        for track in tracks:
+            if not str(track[0]) in reconstruction['points']:
                 failed_rec_tracks = np.vstack((failed_rec_tracks, track))
 
-        robust_rec_points1 = p1[robust_rec_tracks[:, 0]]
-        robust_rec_points2 = p2[robust_rec_tracks[:, 1]]
+        robust_rec_points1 = p1[robust_rec_tracks[:, 1]]
+        robust_rec_points2 = p2[robust_rec_tracks[:, 2]]
 
-        non_robust_rec_points1 = p1[non_robust_rec_tracks[:, 0]]
-        non_robust_rec_points2 = p2[non_robust_rec_tracks[:, 1]]
+        non_robust_rec_points1 = p1[non_robust_rec_tracks[:, 1]]
+        non_robust_rec_points2 = p2[non_robust_rec_tracks[:, 2]]
 
-        failed_rec_points1 = p1[failed_rec_tracks[:, 0]]
-        failed_rec_points2 = p2[failed_rec_tracks[:, 1]]
+        failed_rec_points1 = p1[failed_rec_tracks[:, 1]]
+        failed_rec_points2 = p2[failed_rec_tracks[:, 2]]
 
         rec_title = \
             'Reconstructed 3D points: {0}. Robust {1}. Non robust: {2}. Failed: {3}. '.format(
@@ -369,33 +383,24 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     p1 = load_points(im1, data)
     p2 = load_points(im2, data)
 
-    graph = data.load_tracks_graph()
-    t1, t2 = graph[im1], graph[im2]
-
-    track_matches = []
-    for track in t1:
-        if track in t2:
-            track_matches.append(np.array([int(track), t1[track]['feature_id'], t2[track]['feature_id']]))
-
-    track_matches = np.array(track_matches)
-
-    if track_matches.shape[0] < 1:
+    tracks = load_common_tracks(im1, im2, data)
+    if tracks.shape[0] < 1:
         print 'No tracks to plot.'
         return
 
-    track_points1 = p1[track_matches[:, 1]]
-    track_points2 = p2[track_matches[:, 2]]
+    track_points1 = p1[tracks[:, 1]]
+    track_points2 = p2[tracks[:, 2]]
 
     reconstruction = find_reconstruction([im1, im2], data)
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
-    rec_tracks = reconstruction_tracks(track_matches, reconstruction)
+    rec_tracks = reconstruction_tracks(tracks, reconstruction)
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
 
     title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
-        track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
+        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
     t_subplot = plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'r', 'om')
     plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
@@ -404,7 +409,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
 
     title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
-        track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
+        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
     rec_plot = plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, track_points1, track_points2, 'or', 'or')
     plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
@@ -425,14 +430,11 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     im_array = data.image_as_array(im)
     p = load_points(im, data)
 
-    graph = data.load_tracks_graph()
-    im_tracks = graph[im]
+    tracks = load_tracks(im, data)
+    if tracks.shape[0] < 1:
+        print 'No tracks for exist for {0}.'.format(im)
+        return
 
-    tracks = []
-    for track in im_tracks:
-        tracks.append(np.array([int(track), im_tracks[track]['feature_id']]))
-
-    tracks = np.array(tracks)
     track_points = p[tracks[:, 1]]
 
     rec_tracks = reconstruction_tracks(tracks, reconstruction)
@@ -467,12 +469,15 @@ if __name__ == "__main__":
                         action='store_true')
 
     args = parser.parse_args()
-    data_set = dataset.DataSet(args.dataset)
+    d = dataset.DataSet(args.dataset)
+    i1 = args.image1
+    i2 = args.image2
+    save = args.save_figs
 
-    create_matches_figure(args.image1, args.image2, data_set, args.save_figs)
-    create_tracks_figure(args.image1, args.image2, data_set, args.save_figs)
-    create_reconstruction_figure(args.image1, args.image2, data_set, args.save_figs)
+    create_matches_figure(i1, i2, d, save)
+    create_tracks_figure(i1, i2, d, save)
+    create_reconstruction_figure(i1, i2, d, save)
 
     if args.plot_all:
-        create_complete_reconstruction_figure(args.image1, data_set, args.save_figs)
-        create_complete_reconstruction_figure(args.image2, data_set, args.save_figs)
+        create_complete_reconstruction_figure(i1, d, save)
+        create_complete_reconstruction_figure(i2, d, save)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -17,12 +17,15 @@ import opensfm.reconstruction as reconstruct
 
 
 def redirect_print():
+    reset = sys.stdout
     f = open(os.devnull, 'w')
     sys.stdout = f
 
+    return reset
 
-def reset_print():
-    sys.stdout = sys.__stdout__
+
+def reset_print(f):
+    sys.stdout = f
 
 
 def show_images(plot, im1, im2):
@@ -214,14 +217,14 @@ def create_matches_figure(im1, im2, data, save_figs=False):
         print 'Not enough matches for eight point algorithm: ' + str(symmetric_matches.shape[0])
         return
 
-    features_title = 'Features: {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
+    features_title = 'Features (loaded): {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
     plot_points_sub(fig, 2, 2, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
 
     s_matches1 = p1[symmetric_matches[:, 0]]
     s_matches2 = p2[symmetric_matches[:, 1]]
 
     plot_matches_sub(fig, 2, 2, 3,
-                     'Symmetric matches: {0}'.format(symmetric_matches.shape[0]),
+                     'Symmetric matches (calculated): {0}'.format(symmetric_matches.shape[0]),
                      im1_array, im2_array,
                      s_matches1, s_matches2,
                      'c', 'ob')
@@ -234,7 +237,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
     plot_matches_sub(fig, 2, 2, 2,
-                     'Robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
+                     'Robust matching inliers (calculated with RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
                          robust_matches.shape[0], threshold),
                      im1_array, im2_array,
                      r_matches1, r_matches2,
@@ -245,7 +248,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     outliers2 = p2[outliers[:, 1]]
 
     plot_matches_sub(fig, 2, 2, 4,
-                     'Robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
+                     'Robust matching outliers (calculated): {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
                      im1_array, im2_array,
                      outliers1, outliers2,
                      'r', 'om')
@@ -282,7 +285,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
     non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 
-    tracks_title = 'Common tracks: {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
+    tracks_title = 'Common tracks (loaded): {0}. Robust match tracks: {1} / {2}. Non robust match tracks: {3}'.format(
         tracks.shape[0],
         tracks.shape[0] - non_robust_tracks.shape[0],
         robust_matches.shape[0],
@@ -304,7 +307,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_h1 = track_points1[~inliers_h, :]
     outliers_h2 = track_points2[~inliers_h, :]
 
-    h_title = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
+    h_title = 'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
         inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
 
     h_subplot = plot_matches_sub(fig, 2, 2, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
@@ -325,16 +328,16 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     outliers_t1 = track_points1[outliers_t, :]
     outliers_t2 = track_points2[outliers_t, :]
 
-    t_title = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
+    t_title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
         len(inliers_t), outliers_t.sum(), threshold_t)
 
     t_subplot = plot_matches_sub(fig, 2, 2, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     # Plot successfully reconstructed and failed 3D points
-    redirect_print()
+    stdout_reset = redirect_print()
     reconstruction = reconstruct.bootstrap_reconstruction(data, data.load_tracks_graph(), im1, im2)
-    reset_print()
+    reset_print(stdout_reset)
 
     if reconstruction:
         robust_rec_tracks = []
@@ -367,7 +370,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         failed_rec_points2 = p2[failed_rec_tracks[:, 2]]
 
         rec_title = \
-            'Reconstructed 3D points: {0}. Robust {1}. Non robust: {2}. Failed: {3}. '.format(
+            'Reconstructed 3D points (calculated): {0}. Robust {1}. Non robust: {2}. Failed: {3}. '.format(
                 len(reconstruction['points']),
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],
@@ -382,7 +385,8 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         plot_matches(rec_plot, im1_array, im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
         failed_title = \
-            'Reconstruction failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}. '.format(
+            'Reconstruction failed. Less than {0} points. Triangulation threshold: {1:.4f}. Min ray angle: {2}. '\
+            .format(
                 data.config.get('five_point_algo_min_inliers', 50),
                 data.config.get('triangulation_threshold', 0.004),
                 data.config.get('triangulation_min_ray_angle', 2.0))
@@ -393,7 +397,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
 
 def create_reconstruction_figure(im1, im2, data, save_figs=False):
     fig = pl.figure(figsize=(18, 18))
-    fig.suptitle('Reconstruction ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
+    fig.suptitle('Reprojected reconstructed 3D points ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=18, fontweight='bold')
 
     im1_array = data.image_as_array(im1)
@@ -418,8 +422,9 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     rec_track_points1 = p1[rec_tracks[:, 1]]
     rec_track_points2 = p2[rec_tracks[:, 2]]
 
-    title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
-        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    title = \
+        'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}. All loaded.'\
+        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
     t_subplot = plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'r', 'om')
     plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
@@ -427,8 +432,8 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     rp1 = reproject_tracks(im1, rec_tracks[:, 0], reconstruction)
     rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
 
-    title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
-        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    title = 'Common tracks (loaded): {0}. Reprojected points (calculated): {1}. Triangulation and reprojection error removals: {2}'\
+        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
 
     rec_plot = plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, track_points1, track_points2, 'or', 'or')
     plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
@@ -461,8 +466,9 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
 
-    title = 'Tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
-        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    title = 'All tracks (loaded): {0}. Reprojected points (calculated): {1}. Triangulation and reprojection error removals: {2}'\
+        .format(tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+
     rec_plot = create_subplot(fig, 1, 1, 1, title, im_array.shape[1])
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, track_points, 'or')
@@ -488,15 +494,15 @@ if __name__ == "__main__":
                         action='store_true')
 
     args = parser.parse_args()
-    d = dataset.DataSet(args.dataset)
-    i1 = args.image1
-    i2 = args.image2
+    ds = dataset.DataSet(args.dataset)
+    image1 = args.image1
+    image2 = args.image2
     save = args.save_figs
 
-    create_matches_figure(i1, i2, d, save)
-    create_tracks_figure(i1, i2, d, save)
-    create_reconstruction_figure(i1, i2, d, save)
+    create_matches_figure(image1, image2, ds, save)
+    create_tracks_figure(image1, image2, ds, save)
+    create_reconstruction_figure(image1, image2, ds, save)
 
     if args.plot_all:
-        create_complete_reconstruction_figure(i1, d, save)
-        create_complete_reconstruction_figure(i2, d, save)
+        create_complete_reconstruction_figure(image1, ds, save)
+        create_complete_reconstruction_figure(image2, ds, save)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -22,6 +22,10 @@ def show_images(plot, im1, im2):
     plot.imshow(image)
 
 
+def show_image(plot, im1):
+    plot.imshow(im1)
+
+
 def plot_points(plot, im1, im2, p1, p2, point_format1='ob', point_format2='ob'):
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
@@ -30,6 +34,13 @@ def plot_points(plot, im1, im2, p1, p2, point_format1='ob', point_format2='ob'):
 
     plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
     plot.plot(p2d[:, 0] + w1, p2d[:, 1], point_format2)
+
+
+def plot_point(plot, im, p, point_format='ob'):
+    h, w, c = im.shape
+    pd = features.denormalized_image_coordinates(p, w, h)
+
+    plot.plot(pd[:, 0], pd[:, 1], point_format)
 
 
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
@@ -256,6 +267,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     t_subplot = plot_matches_sub(fig, 2, 2, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
+    # Plot successfully reconstructed and failed 3D points
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
 
     if reconstruction:
@@ -321,6 +333,74 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         pl.show()
 
 
+def create_complete_reconstruction_figure(im, data, save_figs=False):
+    im_array = data.image_as_array(im)
+
+    fig = pl.figure(figsize=(12, 9))
+    fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
+                 fontsize=14, fontweight='bold')
+
+    reconstructions = data.load_reconstruction()
+    reconstruction = None
+
+    for rec in reconstructions:
+        if im in rec['shots']:
+            reconstruction = rec
+
+    if reconstruction is None:
+        print '{0} does not exist in a reconstruction.'.format(im)
+
+    graph = data.load_tracks_graph()
+
+    p, f = data.load_features(im)
+    p = np.array(p[:, :2], np.float64)
+
+    im_tracks = graph[im]
+
+    tracks = []
+    for track in im_tracks:
+        tracks.append(np.array([im_tracks[track]['feature_id'], int(track)]))
+
+    tracks = np.array(tracks)
+    track_points = p[tracks[:, 0]]
+
+    rec_tracks = []
+    for track in rec['points']:
+        if track in im_tracks:
+            rec_tracks.append(np.array([im_tracks[str(track)]['feature_id'], int(track)]))
+
+    rec_tracks = np.array(rec_tracks)
+    rec_track_points = p[rec_tracks[:, 0]]
+
+    reprojected_points = []
+    for track in rec_tracks:
+        shot = reconstruction['shots'][im]
+        camera = reconstruction['cameras'][shot['camera']]
+        point = reconstruction['points'][str(track[1])]
+
+        reprojected_points.append(reconstruct.reproject(camera, shot, point))
+
+    reprojected_points = np.array(reprojected_points)
+
+    title = 'Tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
+        tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
+    sub = create_subplot(fig, 1, 1, 1, title, im_array.shape[1])
+    show_image(sub, im_array)
+    plot_point(sub, im_array, track_points, 'or')
+    plot_point(sub, im_array, rec_track_points, 'ob')
+    plot_point(sub, im_array, reprojected_points, '+w')
+
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
+
+    if save_figs:
+        p = data.data_path + '/plot_inliers'
+        io.mkdir_p(p)
+        fig.savefig(p + '/' + im + '_' + data.feature_type() + '_complete_rec.jpg', dpi=100)
+        pl.close()
+    else:
+        pl.show()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Plot inlier and outlier matches between images')
     parser.add_argument('dataset',
@@ -332,9 +412,16 @@ if __name__ == "__main__":
     parser.add_argument('--save_figs',
                         help='save figures instead of showing them',
                         action='store_true')
+    parser.add_argument('--plot_all',
+                        help='save figures instead of showing them',
+                        action='store_true')
 
     args = parser.parse_args()
     data_set = dataset.DataSet(args.dataset)
 
     create_matches_figure(args.image1, args.image2, data_set, args.save_figs)
     create_tracks_figure(args.image1, args.image2, data_set, args.save_figs)
+
+    if args.plot_all:
+        create_complete_reconstruction_figure(args.image1, data_set, args.save_figs)
+        create_complete_reconstruction_figure(args.image2, data_set, args.save_figs)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import os
+import sys
+
 import argparse
 import matplotlib.pyplot as pl
 import numpy as np
@@ -11,6 +14,15 @@ from opensfm import matching
 from opensfm import io
 from opensfm import csfm
 import opensfm.reconstruction as reconstruct
+
+
+def redirect_print():
+    f = open(os.devnull, 'w')
+    sys.stdout = f
+
+
+def reset_print():
+    sys.stdout = sys.__stdout__
 
 
 def show_images(plot, im1, im2):
@@ -322,7 +334,9 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     # Plot successfully reconstructed and failed 3D points
+    redirect_print()
     reconstruction = reconstruct.bootstrap_reconstruction(data, data.load_tracks_graph(), im1, im2)
+    reset_print()
 
     if reconstruction:
         robust_rec_tracks = []

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -169,6 +169,30 @@ def load_tracks(im, data):
     return np.array(tracks) if len(tracks) else np.empty((0, 2), int)
 
 
+def non_matches(a1, a2, map_function):
+    """ Retrieves the row arrays in a1 that does not have an equal row array in a2.
+    :param a1: Numpy array of arrays.
+    :param a2: Numpy array of arrays.
+    :param map_function: Function mapping the array a1 to another array..
+    :return: The mapped rows in a1 that does not correspond to any row in a2.
+    """
+    nm = []
+
+    for arr1 in a1:
+        found = False
+        for arr2 in a2:
+            if np.array_equal(map_function(arr1), arr2):
+                found = True
+                break
+
+        if not found:
+            nm.append(arr1)
+
+    nm = np.array(nm) if len(nm) else np.empty((0, a1.shape[1]), int)
+
+    return nm
+
+
 def create_matches_figure(im1, im2, data, save_figs=False):
     fig = pl.figure(figsize=(24, 12))
     fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
@@ -216,21 +240,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      r_matches1, r_matches2,
                      'g', 'oy')
 
-    # Retrieve and plot robust match outliers.
-    outliers = []
-    for match in symmetric_matches:
-
-        found = False
-        for robust_match in robust_matches:
-            if np.array_equal(match, robust_match):
-                found = True
-                break
-
-        if not found:
-            outliers.append(match)
-
-    outliers = np.array(outliers) if len(outliers) else np.empty((0, 2), int)
-
+    outliers = non_matches(symmetric_matches, robust_matches, lambda a: a)
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
 
@@ -268,19 +278,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     track_points1 = p1[tracks[:, 1]]
     track_points2 = p2[tracks[:, 2]]
 
-    non_robust_tracks = []
-    for match in tracks:
-
-        found = False
-        for robust_match in robust_matches:
-            if np.array_equal(match[1:], robust_match):
-                found = True
-                break
-
-        if not found:
-            non_robust_tracks.append(match)
-
-    non_robust_tracks = np.array(non_robust_tracks) if len(non_robust_tracks) else np.empty((0, 3), int)
+    non_robust_tracks = non_matches(tracks, robust_matches, lambda a: a[1:])
     non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
     non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -760,7 +760,7 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     rec_errors, rec_mean, rec_std, rec_min, rec_max, rec_corr = reprojection_errors(reproj_rec, rec_points, scale)
     non_errors, non_mean, non_std, non_min, non_max, non_corr = reprojection_errors(reproj_non, triang_non, scale)
 
-    axis_max = np.max(np.abs(np.vstack((rec_errors, non_errors)))) + 1
+    axis_max = 1.05 * np.max(np.abs(np.vstack((rec_errors, non_errors))))
 
     title = 'Reconstructed tracks: {0}. '.format(rec_tracks.shape[0])
     error_title = "Mean: ({0:.1f}, {1:.1f}). Std: ({2:.1f}, {3:.1f}). Max norm: {4:.1f}. Min norm: {5:.1f}."

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -69,6 +69,45 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
     return subplot
 
 
+def reproject_tracks(im, tracks, reconstruction):
+    p = []
+    for track in tracks:
+        shot = reconstruction['shots'][im]
+        camera = reconstruction['cameras'][shot['camera']]
+        point = reconstruction['points'][str(track)]
+
+        p.append(reconstruct.reproject(camera, shot, point))
+
+    return np.array(p)
+
+
+def find_reconstruction(images, data):
+    reconstructions = data.load_reconstruction()
+    reconstruction = None
+
+    for r in reconstructions:
+        found = True
+        for im in images:
+            if im not in r['shots']:
+                found = False
+                break
+
+        if found:
+            reconstruction = r
+            break
+
+    return reconstruction
+
+
+def reconstruction_tracks(tracks, reconstruction):
+    r_tracks = []
+    for track in tracks:
+        if str(track[0]) in reconstruction['points']:
+            r_tracks.append(track)
+
+    return np.array(r_tracks)
+
+
 def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
     subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
@@ -346,7 +385,7 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     track_matches = []
     for track in t1:
         if track in t2:
-            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id'], int(track)]))
+            track_matches.append(np.array([int(track), t1[track]['feature_id'], t2[track]['feature_id']]))
 
     track_matches = np.array(track_matches)
 
@@ -354,27 +393,16 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
         print 'No tracks to plot.'
         return
 
-    track_points1 = p1[track_matches[:, 0]]
-    track_points2 = p2[track_matches[:, 1]]
+    track_points1 = p1[track_matches[:, 1]]
+    track_points2 = p2[track_matches[:, 2]]
 
-    reconstructions = data.load_reconstruction()
-    reconstruction = None
-
-    for rec in reconstructions:
-        if im1 in rec['shots'] and im2 in rec['shots']:
-            reconstruction = rec
-
+    reconstruction = find_reconstruction([im1, im2], data)
     if reconstruction is None:
         print '{0} and {1} does not exist in a common reconstruction.'.format(im1, im2)
 
-    rec_tracks = []
-    for track in track_matches:
-        if str(track[2]) in rec['points']:
-            rec_tracks.append(track)
-
-    rec_tracks = np.array(rec_tracks)
-    rec_track_points1 = p1[rec_tracks[:, 0]]
-    rec_track_points2 = p2[rec_tracks[:, 1]]
+    rec_tracks = reconstruction_tracks(track_matches, reconstruction)
+    rec_track_points1 = p1[rec_tracks[:, 1]]
+    rec_track_points2 = p2[rec_tracks[:, 2]]
 
     title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
         track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
@@ -382,32 +410,15 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
     t_subplot = plot_matches_sub(fig, 2, 1, 1, title, im1_array, im2_array, track_points1, track_points2, 'r', 'om')
     plot_matches(t_subplot, im1_array, im2_array, rec_track_points1, rec_track_points2, 'c', 'ob')
 
-    reprojected_points1 = []
-    for track in rec_tracks:
-        shot = reconstruction['shots'][im1]
-        camera = reconstruction['cameras'][shot['camera']]
-        point = reconstruction['points'][str(track[2])]
-
-        reprojected_points1.append(reconstruct.reproject(camera, shot, point))
-
-    reprojected_points1 = np.array(reprojected_points1)
-
-    reprojected_points2 = []
-    for track in rec_tracks:
-        shot = reconstruction['shots'][im2]
-        camera = reconstruction['cameras'][shot['camera']]
-        point = reconstruction['points'][str(track[2])]
-
-        reprojected_points2.append(reconstruct.reproject(camera, shot, point))
-
-    reprojected_points2 = np.array(reprojected_points2)
+    rp1 = reproject_tracks(im1, rec_tracks[:, 0], reconstruction)
+    rp2 = reproject_tracks(im2, rec_tracks[:, 0], reconstruction)
 
     title = 'Common tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
         track_matches.shape[0], rec_tracks.shape[0], track_matches.shape[0] - rec_tracks.shape[0])
 
     rec_plot = plot_points_sub(fig, 2, 1, 2, title, im1_array, im2_array, track_points1, track_points2, 'or', 'or')
     plot_points(rec_plot, im1_array, rec_track_points1, 'ob', im2_array, rec_track_points2, 'ob')
-    plot_points(rec_plot, im1_array, reprojected_points1, '+w', im2_array, reprojected_points2, '+w')
+    plot_points(rec_plot, im1_array, rp1, '+w', im2_array, rp2, '+w')
 
 
     fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
@@ -428,13 +439,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
 
-    reconstructions = data.load_reconstruction()
-    reconstruction = None
-
-    for rec in reconstructions:
-        if im in rec['shots']:
-            reconstruction = rec
-
+    reconstruction = find_reconstruction([im], data)
     if reconstruction is None:
         print '{0} does not exist in a reconstruction.'.format(im)
 
@@ -447,28 +452,15 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
 
     tracks = []
     for track in im_tracks:
-        tracks.append(np.array([im_tracks[track]['feature_id'], int(track)]))
+        tracks.append(np.array([int(track), im_tracks[track]['feature_id']]))
 
     tracks = np.array(tracks)
-    track_points = p[tracks[:, 0]]
+    track_points = p[tracks[:, 1]]
 
-    rec_tracks = []
-    for track in rec['points']:
-        if track in im_tracks:
-            rec_tracks.append(np.array([im_tracks[str(track)]['feature_id'], int(track)]))
+    rec_tracks = reconstruction_tracks(tracks, reconstruction)
+    rec_track_points = p[rec_tracks[:, 1]]
 
-    rec_tracks = np.array(rec_tracks)
-    rec_track_points = p[rec_tracks[:, 0]]
-
-    reprojected_points = []
-    for track in rec_tracks:
-        shot = reconstruction['shots'][im]
-        camera = reconstruction['cameras'][shot['camera']]
-        point = reconstruction['points'][str(track[1])]
-
-        reprojected_points.append(reconstruct.reproject(camera, shot, point))
-
-    reprojected_points = np.array(reprojected_points)
+    rp = reproject_tracks(im, rec_tracks[:, 0], reconstruction)
 
     title = 'Tracks: {0}. Reconstructed points: {1}. Triangulation and reprojection error removals: {2}'.format(
         tracks.shape[0], rec_tracks.shape[0], tracks.shape[0] - rec_tracks.shape[0])
@@ -476,7 +468,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, track_points, 'or')
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
-    plot_points(rec_plot, im_array, reprojected_points, '+w')
+    plot_points(rec_plot, im_array, rp, '+w')
 
     fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -196,7 +196,7 @@ def reprojection_errors(reprojections, observations, scale):
     """
 
     if not len(reprojections):
-        return np.empty((0, 2), np.float), np.zeros((2,), np.float), np.zeros((2.), np.float), 0, 0
+        return np.empty((0, 2), np.float), np.zeros((2,), np.float), np.zeros((2.), np.float), 0, 0, np.nan
 
     errors = scale * np.subtract(reprojections, observations)
     mean = np.mean(errors, axis=0)
@@ -206,7 +206,10 @@ def reprojection_errors(reprojections, observations, scale):
     min_norm = np.min(errors_norm)
     max_norm = np.max(errors_norm)
 
-    return errors, mean, std, min_norm, max_norm
+    observations_norm = scale * np.linalg.norm(observations, axis=1)
+    corr = np.corrcoef(observations_norm, errors_norm)
+
+    return errors, mean, std, min_norm, max_norm, corr[0, 1]
 
 
 def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
@@ -754,8 +757,8 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     triang_non = p[non_rec_tracks[succeeded, 1]]
 
     scale = np.max(im_array.shape[:2])
-    rec_errors, rec_mean, rec_std, rec_min, rec_max = reprojection_errors(reproj_rec, rec_points, scale)
-    non_errors, non_mean, non_std, non_min, non_max = reprojection_errors(reproj_non, triang_non, scale)
+    rec_errors, rec_mean, rec_std, rec_min, rec_max, rec_corr = reprojection_errors(reproj_rec, rec_points, scale)
+    non_errors, non_mean, non_std, non_min, non_max, non_corr = reprojection_errors(reproj_non, triang_non, scale)
 
     axis_max = np.max(np.abs(np.vstack((rec_errors, non_errors)))) + 1
 
@@ -764,12 +767,14 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
 
     triang_thld = data.config.get('triangulation_threshold', 0.004)
     bundle_thld = data.config.get('bundle_outlier_threshold', 0.008)
-    thld = 'Thold: Triangulation: {0:.1f} ({1}). Bundle outlier: {2:.1f} ({3}).'\
+    thld_title = 'Threshold: Triangulation: {0:.1f} ({1}). Bundle outlier: {2:.1f} ({3}).'\
         .format(scale * triang_thld, triang_thld, scale * bundle_thld, bundle_thld)
+    corr_title = ' Distance to principal point - Error norm correlation: {0:.3f}'
 
     rec_sub = create_subplot(
         fw.figure, fw.rows, fw.cols, 1,
-        title + error_title.format(rec_mean[0], rec_mean[1], rec_std[0], rec_std[1], rec_max, rec_min) + '\n' + thld,
+        title + error_title.format(rec_mean[0], rec_mean[1], rec_std[0], rec_std[1], rec_max, rec_min) + '\n' +
+        thld_title + '\n' + corr_title.format(rec_corr) if rec_corr is not np.nan else '',
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
 
@@ -781,7 +786,8 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
 
     non_rec_sub = create_subplot(
         fw.figure, fw.rows, fw.cols, 2,
-        title + error_title.format(non_mean[0], non_mean[1], non_std[0], non_std[1], non_max, non_min),
+        title + error_title.format(non_mean[0], non_mean[1], non_std[0], non_std[1], non_max, non_min) +
+        '\n' + corr_title.format(non_corr) if non_corr is not np.nan else '',
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
 
@@ -789,7 +795,7 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     non_rec_sub.plot(non_errors[:, 0], non_errors[:, 1], 'om')
 
     display_figure(fig, save_figs, data, '{0}_{1}_error_dist.jpg'.format(im, data.feature_type()),
-                   bottom=0.05, top=0.91 if single_column else 0.86, hspace=0.2)
+                   bottom=0.05, top=0.90 if single_column else 0.85, hspace=0.22)
 
 
 if __name__ == "__main__":

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -17,6 +17,10 @@ import opensfm.reconstruction as reconstruct
 
 
 def redirect_print():
+    """ Redirects the sys.stdout to the null device.
+
+    :return: The previous value of sys.stdout.
+    """
     reset = sys.stdout
     f = open(os.devnull, 'w')
     sys.stdout = f
@@ -25,10 +29,15 @@ def redirect_print():
 
 
 def reset_print(f):
+    """ Sets the sys.stdout device.
+
+    :param f: The device.
+    """
     sys.stdout = f
 
 
 def show_images(plot, im1, im2):
+    """ Shows the images in the supplied subplot. """
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
     image = np.zeros((max(h1, h2), w1+w2, 3), dtype=im1.dtype)
@@ -38,6 +47,7 @@ def show_images(plot, im1, im2):
 
 
 def plot_points(plot, im1, p1, point_format1='ob', im2=None, p2=None, point_format2='ob'):
+    """ Plots the points in the supplied subplot. """
     h1, w1, c = im1.shape
     p1d = features.denormalized_image_coordinates(p1, w1, h1)
     plot.plot(p1d[:, 0], p1d[:, 1], point_format1)
@@ -52,6 +62,7 @@ def plot_points(plot, im1, p1, point_format1='ob', im2=None, p2=None, point_form
 
 
 def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
+    """ Plots the matches in the supplied subplot. """
     h1, w1, c = im1.shape
     h2, w2, c = im2.shape
     p1d = features.denormalized_image_coordinates(p1, w1, h1)
@@ -63,6 +74,7 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
 
 
 def create_subplot(figure, rows, columns, index, title, width):
+    """ Creates a subplot with the supplied width. """
     subplot = figure.add_subplot(rows, columns, index)
     subplot.axis('off')
     pl.xlim(0, width)
@@ -76,6 +88,7 @@ def create_subplot(figure, rows, columns, index, title, width):
 
 
 def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
+    """ Creates a subplot with the images and plots the points in each image. """
     subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
     show_images(subplot, im1, im2)
@@ -85,6 +98,7 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
 
 
 def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
+    """ Creates a subplot with the images and plots the points as matches. """
     subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
     show_images(subplot, im1, im2)
@@ -94,6 +108,7 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
 
 
 def display_figure(figure, save_figs, data=None, file_name=''):
+    """ Displays or saves a figure. """
     figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
 
     if save_figs:
@@ -106,6 +121,13 @@ def display_figure(figure, save_figs, data=None, file_name=''):
 
 
 def reproject_tracks(im, tracks, reconstruction):
+    """ Reprojects the 3D points for a list of tracks for an image based on the reconstruction.
+
+    :param im: The name of the image.
+    :param tracks: Array of tracks that exist in the reconstruction.
+    :param: reconstruction: A Reconstruction.
+    :return: An array of reprojected track points where each row contains x and y values.
+    """
     p = []
     for track in tracks:
         shot = reconstruction['shots'][im]
@@ -118,6 +140,14 @@ def reproject_tracks(im, tracks, reconstruction):
 
 
 def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
+    """ Triangulates a list of tracks.
+
+    :param tracks: The array of tracks.
+    :param reconstruction: The reconstruction.
+    :param: graph, The tracks graph.
+    :param: min_ray_angle: The minimum ray angle difference for a triangulation to be considered valid.
+    :return: An array of booleans determining if each track was successfully triangulated or not.
+    """
     succeeded = []
 
     for track in tracks:
@@ -129,6 +159,12 @@ def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
 
 
 def find_reconstruction(images, data):
+    """ Finds a reconstruction in which all images exist.
+
+    :param images: List of image names.
+    :param data: The data set.
+    :return: The reconstruction that contains all images. None if no reconstruction was found.
+    """
     reconstructions = data.load_reconstruction()
     reconstruction = None
 
@@ -147,6 +183,14 @@ def find_reconstruction(images, data):
 
 
 def reconstruction_tracks(tracks, reconstruction):
+    """ Gets the set of tracks in a list of tracks that exist in a reconstruction as well as the ones that does not
+        belong to the reconstruction.
+
+    :param tracks: The list of tracks.
+    :param reconstruction: The reconstruction.
+    :return: An array with the rows containing the track arrays that existed in the reconstruction. Another array
+             with the rows containing the track arrays that did not belong to the reconstruction
+    """
     r_tracks = []
     n_tracks = []
 
@@ -163,11 +207,24 @@ def reconstruction_tracks(tracks, reconstruction):
 
 
 def load_points(im, data):
+    """ Loads the feature points for an image
+
+    :param im: The name of the image.
+    :param data: The data set.
+    :return: An array with rows containing the x and y coordinates for the features in the image.
+    """
     p, f, c = data.load_features(im)
     return np.array(p[:, :2], np.float64)
 
 
 def load_common_tracks(im1, im2, graph):
+    """ Loads the common track ids and corresponding feature ids for two images in a graph.
+
+    :param im1: The name of the first image.
+    :param im2: The name of the second image.
+    :param graph: The track graph.
+    :return: An array with rows containing a track id and the corresponding feature id for the first and second image.
+    """
     t1, t2 = graph[im1], graph[im2]
     tc, p1, p2 = dataset.common_tracks(graph, im1, im2)
 
@@ -179,6 +236,12 @@ def load_common_tracks(im1, im2, graph):
 
 
 def load_tracks(im, graph):
+    """ Loads the track ids and corresponding feature ids for an image in a graph.
+
+    :param im: The name of the image.
+    :param graph: The track graph.
+    :return: An array with rows containing a track id and the corresponding feature id.
+    """
     tn = graph[im]
 
     tracks = []
@@ -190,10 +253,11 @@ def load_tracks(im, graph):
 
 def matches(a1, a2, map_function):
     """ Retrieves the row arrays in a1 that has an equal row array in a2 and the row arrays in a1 that
-         does not have an equal row array in a2.
+        does not have an equal row array in a2.
+
     :param a1: Numpy array of arrays.
     :param a2: Numpy array of arrays.
-    :param map_function: Function mapping the array a1 to another array..
+    :param map_function: Function mapping the array a1 to another array.
     :return: An array with the mapped rows in a1 that correspond to any row in a2 as well as an array with
              the mapped rows in a1 that do not correspond with an array in a2.
     """

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -228,7 +228,7 @@ def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
         reconstruct.triangulate_track(str(track), graph, reconstruction, {}, {}, {}, 1, min_ray_angle)
         succeeded.append(True) if str(track) in reconstruction['points'] else succeeded.append(False)
 
-    return np.array(succeeded) if len(succeeded) else np.empty((0, 1), bool)
+    return np.array(succeeded) if len(succeeded) else np.empty((0,), bool)
 
 
 def find_reconstruction(images, data):
@@ -374,7 +374,7 @@ def thresholds(im1_array, im2_array, key, default, data):
 
 def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     fig, rows, cols = \
-        create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
+        create_four_figure('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
@@ -415,7 +415,7 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     threshold, pixels1, pixels2 = thresholds(im1_array, im2_array, 'robust_matching_threshold', 0.006, data)
     plot_matches_sub(
         fig, rows, cols, 3,
-        'Robust matching inliers (RANSAC 7-point algorithm, calculated): {0}. Threshold: {1} ({2:.1f} - {3:.1f} pixels)'
+        'Robust matching inliers (RANSAC 7-point algorithm, calculated): {0}. Threshold: {1:.2g} ({2:.1f} - {3:.1f} pixels)'
         .format(robust_matches.shape[0], threshold, pixels1, pixels2),
         im1_array, im2_array,
         r_matches1, r_matches2,
@@ -427,7 +427,7 @@ def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
     outliers2 = p2[outliers[:, 1]]
 
     plot_matches_sub(fig, rows, cols, 4,
-                     'Robust matching outliers (calculated): {0}. Threshold: {1} ({2:.1f} - {3:.1f} pixels)'
+                     'Robust matching outliers (calculated): {0}. Threshold: {1:.2g} ({2:.1f} - {3:.1f} pixels)'
                      .format(outliers.shape[0], threshold, pixels1, pixels2),
                      im1_array, im2_array,
                      outliers1, outliers2,
@@ -472,7 +472,7 @@ def plot_opencv_find_homography(fw, ip, index, tracks, track_points1, track_poin
     outliers2 = track_points2[~inliers, :]
 
     title = \
-        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3} '\
+        'OpenCV find homography inliers (calculated): {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.2g} '\
         .format(inliers.sum(), (~inliers).sum(), float((~inliers).sum()) / tracks.shape[0], threshold) + \
         '({0:.1f} - {1:.1f} pixels)'.format(pixels1, pixels2)
 
@@ -498,7 +498,7 @@ def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, da
     outliers1 = track_points1[outliers, :]
     outliers2 = track_points2[outliers, :]
 
-    title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2} '.format(
+    title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2:.2g} '.format(
         len(inliers), outliers.sum(), threshold) + \
         '({0:.1f} - {1:.1f} pixels)'.format(pixels1, pixels2)
 
@@ -536,7 +536,7 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
                 robust_rec_tracks.shape[0],
                 non_robust_rec_tracks.shape[0],
                 failed_rec_tracks.shape[0]) + \
-            'Triangulation threshold: {0} ({1:.1f} - {2:.1f} pixels). Min ray angle: {3}.'.format(
+            'Triangulation threshold: {0:.2g} ({1:.1f} - {2:.1f} pixels). Min ray angle: {3}.'.format(
                 threshold, pixels1, pixels2, data.config.get('triangulation_min_ray_angle', 2.0))
 
         rec_plot = plot_matches_sub(fw.figure, fw.rows, fw.cols, index, rec_title, ip.im1_array, ip.im2_array,
@@ -545,8 +545,8 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
         plot_matches(rec_plot, ip.im1_array, ip.im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
         failed_title = \
-            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1} ({2:.1f} - {3:.1f} pixels).'.format(
-                data.config.get('five_point_algo_min_inliers', 50), threshold, pixels1, pixels2) +\
+            'Bootstrap failed. Less than {0} points. Triangulation threshold: {1:.2g} ({2:.1f} - {3:.1f} pixels).'\
+            .format(data.config.get('five_point_algo_min_inliers', 50), threshold, pixels1, pixels2) +\
             'Min ray angle: {0}.'.format(data.config.get('triangulation_min_ray_angle', 2.0))
         create_subplot(fw.figure, fw.rows, fw.cols, index, failed_title, (0, 100), (0, 100))
 
@@ -767,7 +767,7 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
 
     triang_thld = data.config.get('triangulation_threshold', 0.004)
     bundle_thld = data.config.get('bundle_outlier_threshold', 0.008)
-    thld_title = 'Threshold: Triangulation: {0:.1f} ({1}). Bundle outlier: {2:.1f} ({3}).'\
+    thld_title = 'Thresholds: Triangulation: {0:.1f} ({1:.2g}). Bundle outlier: {2:.1f} ({3:.2g}).'\
         .format(scale * triang_thld, triang_thld, scale * bundle_thld, bundle_thld)
     corr_title = ' Distance to principal point - Error norm correlation: {0:.3f}'
 
@@ -787,7 +787,7 @@ def create_reprojection_error_figure(im, data, save_figs=False, single_column=Fa
     non_rec_sub = create_subplot(
         fw.figure, fw.rows, fw.cols, 2,
         title + error_title.format(non_mean[0], non_mean[1], non_std[0], non_std[1], non_max, non_min) +
-        '\n' + corr_title.format(non_corr) if non_corr is not np.nan else '',
+        '\n' + (corr_title.format(non_corr) if non_corr is not np.nan else ''),
         (-axis_max, axis_max), (-axis_max, axis_max),
         aspect='equal', axis=True, grid=True)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+import os.path, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import os
-import sys
 
 import argparse
 import matplotlib.pyplot as pl

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -144,9 +144,9 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
 def display_figure(figure, save_figs, data=None, file_name=''):
     """ Displays or saves a figure. """
     figure.subplots_adjust(left=0.01,
-                           bottom=0,
+                           bottom=0.01,
                            right=0.99,
-                           top=0.94 if save_figs else 0.91,
+                           top=0.93 if save_figs else 0.91,
                            wspace=0.04,
                            hspace=0.14)
 
@@ -619,10 +619,11 @@ def create_reconstruction_matches_figure(im1, im2, data, save_figs=False):
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_reconstruction.jpg'.format(im1, im2, data.feature_type()))
 
 
-def create_complete_reconstruction_figure(im, data, save_figs=False):
-    fig = pl.figure(figsize=(18, 9))
+def create_complete_reconstruction_figure(im, data, save_figs=False, single_column=False):
+    fig = pl.figure(figsize=(9, 15) if single_column else (18, 9))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
+    fw = FigureWrapper(fig, 2 if single_column else 1, 1 if single_column else 2)
 
     reconstruction = find_reconstruction([im], data)
     if reconstruction is None:
@@ -645,7 +646,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     rec_title = 'Tracks: {0}. Included tracks (loaded): {1} with reprojected points (calculated).'\
         .format(tracks.shape[0], rec_tracks.shape[0])
 
-    rec_plot = create_subplot(fig, 1, 2, 1, rec_title, im_array.shape[1], im_array.shape[0])
+    rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 1, rec_title, im_array.shape[1], im_array.shape[0])
     rec_plot.imshow(im_array)
     plot_points(rec_plot, im_array, rec_track_points, 'ob')
     plot_points(rec_plot, im_array, rp, '+w')
@@ -661,7 +662,7 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
         'Rejected tracks: {0}. Re-triangulated: {1}. Failed: {2} (behind a camera or min ray angle: {3} deg).'\
         .format(non_rec_tracks.shape[0], succeeded.sum(), (~succeeded).sum(), min_ray_angle)
 
-    non_rec_plot = create_subplot(fig, 1, 2, 2, non_rec_title, im_array.shape[1], im_array.shape[0])
+    non_rec_plot = create_subplot(fw.figure, fw.rows, fw.cols, 2, non_rec_title, im_array.shape[1], im_array.shape[0])
     non_rec_plot.imshow(im_array)
     plot_points(non_rec_plot, im_array, triangulated_points, 'om')
     plot_points(non_rec_plot, im_array, excluded_points, 'or')
@@ -706,7 +707,7 @@ if __name__ == "__main__":
 
     if args.plot_rec:
         print 'Plotting complete reconstruction tracks for {0}...'.format(image1)
-        create_complete_reconstruction_figure(image1, ds, save)
+        create_complete_reconstruction_figure(image1, ds, save, single)
 
         print 'Plotting complete reconstruction tracks for {0}...'.format(image2)
-        create_complete_reconstruction_figure(image2, ds, save)
+        create_complete_reconstruction_figure(image2, ds, save, single)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -79,7 +79,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(12, 18))
+    fig = pl.figure(figsize=(24, 12))
 
     fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=14, fontweight='bold')
@@ -98,12 +98,12 @@ def create_matches_figure(im1, im2, data, save_figs=False):
         return
 
     features_title = 'Features: {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
-    plot_points_sub(fig, 4, 1, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
+    plot_points_sub(fig, 2, 2, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
 
     s_matches1 = p1[symmetric_matches[:, 0]]
     s_matches2 = p2[symmetric_matches[:, 1]]
 
-    plot_matches_sub(fig, 4, 1, 2,
+    plot_matches_sub(fig, 2, 2, 3,
                      'Symmetric matches: {0}'.format(symmetric_matches.shape[0]),
                      im1_array, im2_array,
                      s_matches1, s_matches2,
@@ -116,7 +116,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     r_matches2 = p2[robust_matches[:, 1]]
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
-    plot_matches_sub(fig, 4, 1, 3,
+    plot_matches_sub(fig, 2, 2, 2,
                      'Robust matching inliers (RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
                          robust_matches.shape[0], threshold),
                      im1_array, im2_array,
@@ -139,13 +139,13 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
 
-    plot_matches_sub(fig, 4, 1, 4,
+    plot_matches_sub(fig, 2, 2, 4,
                      'Robust matching outliers: {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
                      im1_array, im2_array,
                      outliers1, outliers2,
                      'r', 'om')
 
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -161,7 +161,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(12, 18))
+    fig = pl.figure(figsize=(24, 12))
     fig.suptitle('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=14, fontweight='bold')
 
@@ -214,7 +214,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         non_robust_tracks.shape[0])
 
     tracks_subplot = plot_matches_sub(
-        fig, 4, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
+        fig, 2, 2, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -232,7 +232,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     h_title = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
         inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / track_matches.shape[0], threshold_h)
 
-    h_subplot = plot_matches_sub(fig, 4, 1, 2, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
+    h_subplot = plot_matches_sub(fig, 2, 2, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
     # Plot inliers and outliers of the tracks from csfm two view reconstruction.
@@ -253,7 +253,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     t_title = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
         len(inliers_t), outliers_t.sum(), threshold_t)
 
-    t_subplot = plot_matches_sub(fig, 4, 1, 3, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
+    t_subplot = plot_matches_sub(fig, 2, 2, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
@@ -285,10 +285,10 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         track_matches.shape[0] - (robust_rec_tracks.shape[0] + non_robust_rec_tracks.shape[0]))
 
     rec_plot = plot_matches_sub(
-        fig, 4, 1, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
+        fig, 2, 2, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
     plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
 
-    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0.04, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -10,6 +10,7 @@ from opensfm import features
 from opensfm import matching
 from opensfm import io
 from opensfm import csfm
+import opensfm.reconstruction as reconstruct
 
 
 def show_images(plot, im1, im2):
@@ -159,7 +160,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
 
-    fig = pl.figure(figsize=(12, 12))
+    fig = pl.figure(figsize=(12, 18))
     fig.suptitle('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=14, fontweight='bold')
 
@@ -179,7 +180,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     track_matches = []
     for track in t1:
         if track in t2:
-            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id']]))
+            track_matches.append(np.array([t1[track]['feature_id'], t2[track]['feature_id'], int(track)]))
 
     track_matches = np.array(track_matches)
 
@@ -190,12 +191,12 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     track_points1 = p1[track_matches[:, 0]]
     track_points2 = p2[track_matches[:, 1]]
 
-    non_robust_tracks = np.empty((0, 2), int)
+    non_robust_tracks = np.empty((0, 3), int)
     for match in track_matches:
 
         found = False
         for robust_match in robust_matches:
-            if np.array_equal(match, robust_match):
+            if np.array_equal(match[:2], robust_match):
                 found = True
                 break
 
@@ -212,7 +213,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         non_robust_tracks.shape[0])
 
     tracks_subplot = plot_matches_sub(
-        fig, 3, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
+        fig, 4, 1, 1, tracks_title, im1_array, im2_array, track_points1, track_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_tracks1, non_robust_tracks2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -230,7 +231,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     h_title = 'OpenCV find homography inliers: {0}. Outliers: {1}. Outlier ratio: {2:.3f}. Threshold: {3:.4f}'.format(
         inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / track_matches.shape[0], threshold_h)
 
-    h_subplot = plot_matches_sub(fig, 3, 1, 2, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
+    h_subplot = plot_matches_sub(fig, 4, 1, 2, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
     # Plot inliers and outliers of the tracks from csfm two view reconstruction.
@@ -251,8 +252,40 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     t_title = 'CSfM two view reconstruction inliers: {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
         len(inliers_t), outliers_t.sum(), threshold_t)
 
-    t_subplot = plot_matches_sub(fig, 3, 1, 3, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
+    t_subplot = plot_matches_sub(fig, 4, 1, 3, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
+
+    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, im1, im2)
+
+    robust_rec_tracks = []
+    non_robust_rec_tracks = []
+    for track in reconstruction['points']:
+        track = int(track)
+        if track in non_robust_tracks[:, 2]:
+            non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 2] == track]))
+            non_robust_rec_tracks.append(non_robust_track)
+        else:
+            robust_track = np.squeeze(np.array(track_matches[track_matches[:, 2] == track]))
+            robust_rec_tracks.append(robust_track)
+
+    robust_rec_tracks = np.array(robust_rec_tracks)
+    non_robust_rec_tracks = np.array(non_robust_rec_tracks)
+
+    robust_rec_points1 = p1[robust_rec_tracks[:, 0]]
+    robust_rec_points2 = p2[robust_rec_tracks[:, 1]]
+
+    non_robust_rec_points1 = p1[non_robust_rec_tracks[:, 0]]
+    non_robust_rec_points2 = p2[non_robust_rec_tracks[:, 1]]
+
+    rec_title = 'Reconstructed 3D points: {0}. Robust {1}. Non robust: {2}. Failed: {3}'.format(
+        len(reconstruction['points']),
+        robust_rec_tracks.shape[0],
+        non_robust_rec_tracks.shape[0],
+        track_matches.shape[0] - (robust_rec_tracks.shape[0] + non_robust_rec_tracks.shape[0]))
+
+    rec_plot = plot_matches_sub(
+        fig, 4, 1, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
+    plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
 
     fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -88,6 +88,16 @@ def create_subplot(figure, rows, columns, index, title, width, height, font_size
     return subplot
 
 
+def create_four_figure(title, single_column):
+    """ Creates a figure for four subplots. """
+    fig = pl.figure(figsize=(12, 21) if single_column else (24, 12))
+    fig.suptitle(title, fontsize=14, fontweight='bold')
+    rows = 4 if single_column else 2
+    cols = 1 if single_column else 2
+
+    return fig, rows, cols
+
+
 def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
     """ Creates a subplot with the images and plots the points in each image. """
     subplot = create_subplot(figure, rows, columns, index, title,
@@ -112,7 +122,12 @@ def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line
 
 def display_figure(figure, save_figs, data=None, file_name=''):
     """ Displays or saves a figure. """
-    figure.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.96, wspace=0.04, hspace=0)
+    figure.subplots_adjust(left=0.01,
+                           bottom=0,
+                           right=0.99,
+                           top=0.94 if save_figs else 0.91,
+                           wspace=0.04,
+                           hspace=0.14)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -285,10 +300,9 @@ def matches(a1, a2, map_function):
     return m, nm
 
 
-def create_matches_figure(im1, im2, data, save_figs=False):
-    fig = pl.figure(figsize=(24, 12))
-    fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
-                 fontsize=14, fontweight='bold')
+def create_matches_figure(im1, im2, data, save_figs=False, single_column=False):
+    fig, rows, cols = \
+        create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
@@ -308,13 +322,13 @@ def create_matches_figure(im1, im2, data, save_figs=False):
 
     # Plot features
     features_title = 'Features (loaded): {0} - {1}, {2} - {3}'.format(im1, p1.shape[0], im2, p2.shape[0])
-    plot_points_sub(fig, 2, 2, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
+    plot_points_sub(fig, rows, cols, 1, features_title, im1_array, im2_array, p1, p2, 'ob', 'om')
 
      # Plot symmetric matches.
     s_matches1 = p1[symmetric_matches[:, 0]]
     s_matches2 = p2[symmetric_matches[:, 1]]
 
-    plot_matches_sub(fig, 2, 2, 3,
+    plot_matches_sub(fig, rows, cols, 3,
                      'Symmetric matches (calculated): {0}'.format(symmetric_matches.shape[0]),
                      im1_array, im2_array,
                      s_matches1, s_matches2,
@@ -327,9 +341,9 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     r_matches2 = p2[robust_matches[:, 1]]
 
     threshold = data.config.get('robust_matching_threshold', 0.006)
-    plot_matches_sub(fig, 2, 2, 2,
-                     'Robust matching inliers (calculated with RANSAC 8 point algorithm): {0}. Threshold: {1:.4f}'.format(
-                         robust_matches.shape[0], threshold),
+    plot_matches_sub(fig, rows, cols, 2,
+                     'Robust matching inliers (calculated with RANSAC eight point algorithm): {0}. Threshold: {1:.4f}'
+                     .format(robust_matches.shape[0], threshold),
                      im1_array, im2_array,
                      r_matches1, r_matches2,
                      'g', 'oy')
@@ -339,7 +353,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
 
-    plot_matches_sub(fig, 2, 2, 4,
+    plot_matches_sub(fig, rows, cols, 4,
                      'Robust matching outliers (calculated): {0}. Threshold: {1:.4f}'.format(outliers.shape[0], threshold),
                      im1_array, im2_array,
                      outliers1, outliers2,
@@ -348,10 +362,9 @@ def create_matches_figure(im1, im2, data, save_figs=False):
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_matches.jpg'.format(im1, im2, data.feature_type()))
 
 
-def create_tracks_figure(im1, im2, data, save_figs=False):
-    fig = pl.figure(figsize=(24, 12))
-    fig.suptitle('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
-                 fontsize=14, fontweight='bold')
+def create_tracks_figure(im1, im2, data, save_figs=False, single_column=False):
+    fig, rows, cols = \
+        create_four_figure('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2), single_column)
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
@@ -386,7 +399,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         non_robust_tracks.shape[0])
 
     tracks_subplot = plot_matches_sub(
-        fig, 2, 2, 1, tracks_title, im1_array, im2_array, robust_points1, robust_points2, 'c', 'ob')
+        fig, rows, cols, 1, tracks_title, im1_array, im2_array, robust_points1, robust_points2, 'c', 'ob')
     plot_matches(tracks_subplot, im1_array, im2_array, non_robust_points1, non_robust_points2, 'g', 'oy')
 
     # Plot inliers and outliers of the tracks from OpenCV find homography.
@@ -409,7 +422,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         .format(
             inliers_h.sum(), (~inliers_h).sum(), float((~inliers_h).sum()) / tracks.shape[0], threshold_h)
 
-    h_subplot = plot_matches_sub(fig, 2, 2, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
+    h_subplot = plot_matches_sub(fig, rows, cols, 3, h_title, im1_array, im2_array, outliers_h1, outliers_h2, 'r', 'om')
     plot_matches(h_subplot, im1_array, im2_array, inliers_h1, inliers_h2, 'c', 'ob')
 
     # Plot inliers and outliers of the tracks from csfm two view reconstruction.
@@ -430,7 +443,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     t_title = 'CSfM two view reconstruction inliers (calculated): {0}. Outliers: {1}. Threshold: {2:.4f}'.format(
         len(inliers_t), outliers_t.sum(), threshold_t)
 
-    t_subplot = plot_matches_sub(fig, 2, 2, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
+    t_subplot = plot_matches_sub(fig, rows, cols, 2, t_title, im1_array, im2_array, inliers_t1, inliers_t2, 'c', 'ob')
     plot_matches(t_subplot, im1_array, im2_array, outliers_t1, outliers_t2, 'r', 'om')
 
     # Plot successfully reconstructed and failed 3D points by reconstruction bootstrap.
@@ -463,7 +476,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
                 data.config.get('triangulation_min_ray_angle', 2.0))
 
         rec_plot = plot_matches_sub(
-            fig, 2, 2, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
+            fig, rows, cols, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
         plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
         plot_matches(rec_plot, im1_array, im2_array, failed_rec_points1, failed_rec_points2, 'r', 'om')
     else:
@@ -473,7 +486,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
                 data.config.get('five_point_algo_min_inliers', 50),
                 data.config.get('triangulation_threshold', 0.004),
                 data.config.get('triangulation_min_ray_angle', 2.0))
-        create_subplot(fig, 2, 2, 4, failed_title, 100, 100)
+        create_subplot(fig, rows, cols, 4, failed_title, 100, 100)
 
     display_figure(fig, save_figs, data, '{0}_{1}_{2}_tracks.jpg'.format(im1, im2, data.feature_type()))
 
@@ -613,6 +626,9 @@ if __name__ == "__main__":
     parser.add_argument('--save_figs',
                         help='save figures instead of showing them',
                         action='store_true')
+    parser.add_argument('--single_col',
+                        help='show figures in one column',
+                        action='store_true')
     parser.add_argument('--plot_rec',
                         help='plots the reconstruction tracks for each image',
                         action='store_true')
@@ -622,12 +638,13 @@ if __name__ == "__main__":
     image1 = args.image1
     image2 = args.image2
     save = args.save_figs
+    single = args.single_col
 
     print 'Plotting matches for {0} - {1}...'.format(image1, image2)
-    create_matches_figure(image1, image2, ds, save)
+    create_matches_figure(image1, image2, ds, save, single)
 
     print 'Plotting tracks for {0} - {1}...'.format(image1, image2)
-    create_tracks_figure(image1, image2, ds, save)
+    create_tracks_figure(image1, image2, ds, save, single)
 
     print 'Plotting reconstruction matches for {0} - {1}...'.format(image1, image2)
     create_reconstruction_matches_figure(image1, image2, ds, save)

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -129,15 +129,18 @@ def display_figure(figure, save_figs, data=None, file_name=''):
         pl.show()
 
 
+def load_points(im, data):
+    p, f, c = data.load_features(im)
+    return np.array(p[:, :2], np.float64)
+
+
 def create_matches_figure(im1, im2, data, save_figs=False):
+    fig = pl.figure(figsize=(24, 12))
+    fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
+                 fontsize=14, fontweight='bold')
 
     im1_array = data.image_as_array(im1)
     im2_array = data.image_as_array(im2)
-
-    fig = pl.figure(figsize=(24, 12))
-
-    fig.suptitle('Matches ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
-                 fontsize=14, fontweight='bold')
 
     # Calculate symmetric matches and plot.
     p1, f1, c1 = data.load_features(im1)
@@ -204,27 +207,23 @@ def create_matches_figure(im1, im2, data, save_figs=False):
 
 
 def create_tracks_figure(im1, im2, data, save_figs=False):
-
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
     fig = pl.figure(figsize=(24, 12))
     fig.suptitle('Tracks ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=14, fontweight='bold')
 
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    p1 = load_points(im1, data)
+    p2 = load_points(im2, data)
+
     # Retrieve tracks and robust matches from file and plot tracks corresponding to
     # robust matches and tracks not corresponding to robust matches in different colors.
-    graph = data.load_tracks_graph()
-
-    p1, features1, c1 = data.load_features(im1)
-    p2, features2, c2 = data.load_features(im2)
-    p1 = np.array(p1[:, :2], np.float64)
-    p2 = np.array(p2[:, :2], np.float64)
-
     robust_matches = data.find_matches(im1, im2)
     if not len(robust_matches):
         robust_matches = np.empty((0, 2), int)
 
+    graph = data.load_tracks_graph()
     t1, t2 = graph[im1], graph[im2]
 
     track_matches = []
@@ -360,22 +359,17 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
 
 
 def create_reconstruction_figure(im1, im2, data, save_figs=False):
-    im1_array = data.image_as_array(im1)
-    im2_array = data.image_as_array(im2)
-
     fig = pl.figure(figsize=(18, 18))
     fig.suptitle('Reconstruction ({0}): {1} - {2}'.format(data.feature_type().upper(), im1, im2),
                  fontsize=18, fontweight='bold')
 
-    # Retrieve tracks and robust matches from file and plot tracks corresponding to
-    # robust matches and tracks not corresponding to robust matches in different colors.
+    im1_array = data.image_as_array(im1)
+    im2_array = data.image_as_array(im2)
+
+    p1 = load_points(im1, data)
+    p2 = load_points(im2, data)
+
     graph = data.load_tracks_graph()
-
-    p1, f1, c1 = data.load_features(im1)
-    p2, f2, c2 = data.load_features(im2)
-    p1 = np.array(p1[:, :2], np.float64)
-    p2 = np.array(p2[:, :2], np.float64)
-
     t1, t2 = graph[im1], graph[im2]
 
     track_matches = []
@@ -420,8 +414,6 @@ def create_reconstruction_figure(im1, im2, data, save_figs=False):
 
 
 def create_complete_reconstruction_figure(im, data, save_figs=False):
-    im_array = data.image_as_array(im)
-
     fig = pl.figure(figsize=(12, 9))
     fig.suptitle('Reprojected reconstructed 3D points ({0}): {1}'.format(data.feature_type().upper(), im),
                  fontsize=14, fontweight='bold')
@@ -430,11 +422,10 @@ def create_complete_reconstruction_figure(im, data, save_figs=False):
     if reconstruction is None:
         print '{0} does not exist in a reconstruction.'.format(im)
 
+    im_array = data.image_as_array(im)
+    p = load_points(im, data)
+
     graph = data.load_tracks_graph()
-
-    p, f, c = data.load_features(im)
-    p = np.array(p[:, :2], np.float64)
-
     im_tracks = graph[im]
 
     tracks = []

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -205,7 +205,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      'g', 'oy')
 
     # Retrieve and plot robust match outliers.
-    outliers = np.empty((0, 2), int)
+    outliers = []
     for match in symmetric_matches:
 
         found = False
@@ -215,7 +215,9 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                 break
 
         if not found:
-            outliers = np.vstack((outliers, match))
+            outliers.append(match)
+
+    outliers = np.array(outliers) if len(outliers) else np.empty((0, 2), int)
 
     outliers1 = p1[outliers[:, 0]]
     outliers2 = p2[outliers[:, 1]]
@@ -254,7 +256,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     track_points1 = p1[tracks[:, 1]]
     track_points2 = p2[tracks[:, 2]]
 
-    non_robust_tracks = np.empty((0, 3), int)
+    non_robust_tracks = []
     for match in tracks:
 
         found = False
@@ -264,8 +266,9 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
                 break
 
         if not found:
-            non_robust_tracks = np.vstack((non_robust_tracks, match))
+            non_robust_tracks.append(match)
 
+    non_robust_tracks = np.array(non_robust_tracks) if len(non_robust_tracks) else np.empty((0, 3), int)
     non_robust_tracks1 = p1[non_robust_tracks[:, 1]]
     non_robust_tracks2 = p2[non_robust_tracks[:, 2]]
 
@@ -322,21 +325,25 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
     reconstruction = reconstruct.bootstrap_reconstruction(data, data.load_tracks_graph(), im1, im2)
 
     if reconstruction:
-        robust_rec_tracks = np.empty((0, 3), int)
-        non_robust_rec_tracks = np.empty((0, 3), int)
+        robust_rec_tracks = []
+        non_robust_rec_tracks = []
         for track in reconstruction['points']:
             track = int(track)
             if track in non_robust_tracks[:, 0]:
                 non_robust_track = np.squeeze(np.array(non_robust_tracks[non_robust_tracks[:, 0] == track]))
-                non_robust_rec_tracks = np.vstack((non_robust_rec_tracks, non_robust_track))
+                non_robust_rec_tracks.append(non_robust_track)
             else:
                 robust_track = np.squeeze(np.array(tracks[tracks[:, 0] == track]))
-                robust_rec_tracks = np.vstack((robust_rec_tracks, robust_track))
+                robust_rec_tracks.append(robust_track)
 
-        failed_rec_tracks = np.empty((0, 3), int)
+        failed_rec_tracks = []
         for track in tracks:
             if not str(track[0]) in reconstruction['points']:
-                failed_rec_tracks = np.vstack((failed_rec_tracks, track))
+                failed_rec_tracks.append(track)
+
+        robust_rec_tracks = np.array(robust_rec_tracks) if len(robust_rec_tracks) else np.empty((0, 3), int)
+        non_robust_rec_tracks = np.array(non_robust_rec_tracks) if len(non_robust_rec_tracks) else np.empty((0, 3), int)
+        failed_rec_tracks = np.array(failed_rec_tracks) if len(failed_rec_tracks) else np.empty((0, 3), int)
 
         robust_rec_points1 = p1[robust_rec_tracks[:, 1]]
         robust_rec_points2 = p2[robust_rec_tracks[:, 2]]

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -43,9 +43,10 @@ def plot_matches(plot, im1, im2, p1, p2, line_format='c', point_format='ob'):
     plot_points(plot, im1, im2, p1, p2, point_format, point_format)
 
 
-def create_subplot(figure, rows, columns, index, title):
+def create_subplot(figure, rows, columns, index, title, width):
     subplot = figure.add_subplot(rows, columns, index)
     subplot.axis('off')
+    pl.xlim(0, width)
     subplot.text(0.5, 0.9,
                  title,
                  horizontalalignment='center',
@@ -56,7 +57,7 @@ def create_subplot(figure, rows, columns, index, title):
 
 
 def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point_format1, point_format2):
-    subplot = create_subplot(figure, rows, columns, index, title)
+    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
     show_images(subplot, im1, im2)
     plot_points(subplot, im1, im2, p1, p2, point_format1, point_format2)
@@ -65,7 +66,7 @@ def plot_points_sub(figure, rows, columns, index, title, im1, im2, p1, p2, point
 
 
 def plot_matches_sub(figure, rows, columns, index, title, im1, im2, p1, p2, line_format, point_format):
-    subplot = create_subplot(figure, rows, columns, index, title)
+    subplot = create_subplot(figure, rows, columns, index, title, im1.shape[1] + im2.shape[1])
 
     show_images(subplot, im1, im2)
     plot_matches(subplot, im1, im2, p1, p2, line_format, point_format)
@@ -144,7 +145,7 @@ def create_matches_figure(im1, im2, data, save_figs=False):
                      outliers1, outliers2,
                      'r', 'om')
 
-    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'
@@ -287,7 +288,7 @@ def create_tracks_figure(im1, im2, data, save_figs=False):
         fig, 4, 1, 4, rec_title, im1_array, im2_array, robust_rec_points1, robust_rec_points2, 'c', 'ob')
     plot_matches(rec_plot, im1_array, im2_array, non_robust_rec_points1, non_robust_rec_points2, 'g', 'oy')
 
-    fig.subplots_adjust(left=0.01, bottom=0.01, right=0.95, top=0.96, wspace=0, hspace=0)
+    fig.subplots_adjust(left=0.01, bottom=0, right=0.99, top=0.97, wspace=0, hspace=0)
 
     if save_figs:
         p = data.data_path + '/plot_inliers'


### PR DESCRIPTION
I have added some figures to the plot inliers script. What you get now if specifying the options to plot everything is the following (Berlin dataset with images 02.jpg and 03.jpg):

##### Features and matches

Same as before with some additional subtitle information like threshold in pixels for each image.

![01 jpg_03 jpg_sift_matches](https://cloud.githubusercontent.com/assets/2492302/7678229/ced7d30e-fd52-11e4-95d5-9a2b13f191cc.jpg)

##### Common tracks

Same as before with an added plot at the bottom displaying the result of a bootstrapped reconstruction using the two specified images.

![01 jpg_03 jpg_sift_tracks](https://cloud.githubusercontent.com/assets/2492302/7678230/d34813fe-fd52-11e4-80b9-ef86c1763522.jpg)

##### Common reconstructed points

Shows common tracks that are included in the final reconstruction (which is loaded from file). The second subplot shows reprojections for reconstructed 3D points and triangulation reprojections or triangulation failures for rejected tracks. The rejected tracks are triangulated using the final reconstruction cameras. 

![01 jpg_03 jpg_sift_reconstruction](https://cloud.githubusercontent.com/assets/2492302/7678231/d847c782-fd52-11e4-8ff7-73ac3147a895.jpg)

The re-triangulation of the rejected tracks can only give an indication of the reason why the tracks were excluded along the pipeline since the camera matrices may change in each bundle adjustment iteration. The re-triangulation is made with a reprojection threshold of 1 so that tracks are not excluded because of the reprojection error.

##### Single image reprojections

Shows all reconstructed tracks for an image reprojected onto the image. Rejected tracks re-triangulated and shown in different colors depending on success or failure.

![01 jpg_sift_complete_rec](https://cloud.githubusercontent.com/assets/2492302/7678233/ddfc59e0-fd52-11e4-9d80-669622e2a1f9.jpg)

![03 jpg_sift_complete_rec](https://cloud.githubusercontent.com/assets/2492302/7678235/e2887020-fd52-11e4-9c8f-e24d9e5ede65.jpg)

##### Reprojection error distribution

Shows the reprojection error distribution along with some of its properties like mean and max. Also determines the correlation between the distance from the observations to the principal point and their reprojection error norm. 

![01 jpg_sift_error_dist](https://cloud.githubusercontent.com/assets/2492302/7678238/ea735444-fd52-11e4-8275-80ccd1df2561.jpg)

![03 jpg_sift_error_dist](https://cloud.githubusercontent.com/assets/2492302/7678245/f508b8c2-fd52-11e4-8613-9304970b44eb.jpg)

