### PR TITLE
Fix AKAZE std::sort comparison functions

### DIFF
--- a/opensfm/src/third_party/akaze/lib/AKAZE.cpp
+++ b/opensfm/src/third_party/akaze/lib/AKAZE.cpp
@@ -247,18 +247,18 @@ void AKAZE::Compute_Determinant_Hessian_Response() {
   }
 }
 
-static int compareKeyPointResponse(const cv::KeyPoint &a,
+static bool compareKeyPointResponse(const cv::KeyPoint &a,
                                    const cv::KeyPoint &b) {
   float fa = a.response;
   float fb = b.response;
-  return (fb > fa) - (fb < fa) ;
+  return fa < fb;
 }
 
-static int compareKeyPointRadius(const std::pair<size_t, float> &a,
+static bool compareKeyPointRadius(const std::pair<size_t, float> &a,
                                  const std::pair<size_t, float> &b) {
   float fa = a.second;
   float fb = b.second;
-  return (fb > fa) - (fb < fa) ;
+  return fa < fb;
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
std::sort comparison functions should return bool (or values convertible to bool) that satisfy strict weak ordering.

As written, these comparisons return -1, 0, or 1 which has undefined behavior resulting in seg faults.