### PR TITLE
Guard track construction against missing shot_key

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -448,19 +448,20 @@ def import_bundler(data_path, bundle_file, list_file, track_file,
 
         for k in xrange(num_view):
             shot_key = ordered_shots[int(view_list[4 * k])]
-            camera = reconstruction.shots[shot_key].camera
-            scale = max(camera.width, camera.height)
-            v = '{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(
-                shot_key,
-                i,
-                view_list[4 * k + 1],
-                float(view_list[4 * k + 2]) / scale,
-                -float(view_list[4 * k + 3]) / scale,
-                point.color[0],
-                point.color[1],
-                point.color[2]
-            )
-            track_lines.append(v)
+            if shot_key in reconstruction.shots:
+                camera = reconstruction.shots[shot_key].camera
+                scale = max(camera.width, camera.height)
+                v = '{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(
+                    shot_key,
+                    i,
+                    view_list[4 * k + 1],
+                    float(view_list[4 * k + 2]) / scale,
+                    -float(view_list[4 * k + 3]) / scale,
+                    point.color[0],
+                    point.color[1],
+                    point.color[2]
+                )
+                track_lines.append(v)
         offset += 3
 
     # save track file


### PR DESCRIPTION
This is a single line change (ignoring whitespace) to improve robustness when importing bundler files.  It guards against the following KeyError...
```
Traceback (most recent call last):
  File "/source/OpenSfM/bin/import_bundler", line 32, in <module>
    io.import_bundler(args.dataset, args.bundleout, list_file, tracks_file, reconstruction_file)
  File "/source/OpenSfM/opensfm/io.py", line 451, in import_bundler
    camera = reconstruction.shots[shot_key].camera
KeyError: 'myfile.jpg'
```