### PR TITLE
Add minfilter to textures in viewer

### DIFF
--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -666,6 +666,7 @@
 
             function createImagePlaneMaterial(cam, shot, shot_id) {
                 var imageTexture = THREE.ImageUtils.loadTexture(imageURL(shot_id));
+                imageTexture.minFilter = THREE.LinearFilter;
 
                 var material = new THREE.ShaderMaterial({
                     side: THREE.DoubleSide,
@@ -1029,6 +1030,7 @@
 
                 imagePlaneCameras[id] = cameraObject;
                 imageMaterials[id].map = THREE.ImageUtils.loadTexture(image_url, null, render);
+                imageMaterials[id].map.minFilter = THREE.LinearFilter;
                 imagePlanes[id].geometry = imagePlaneGeo(r, shot_id);
                 imagePlanes[id].visible = true;
             }


### PR DESCRIPTION
This resolves issues of artifacts along the seams of equirectangular textures. 

Was working on a simple reconstruction viewer using reconstruction.html as a guideline and it took me a while working back from the mapillary-js source to figure out where the artifacts were coming from.


Relevant mapillary-js code:
https://github.com/mapillary/mapillary-js/blob/master/src/component/imageplane/ImagePlaneFactory.ts#L135