### PR TITLE
Add sub-second time to Exif capture time.

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -226,17 +226,18 @@ class EXIF:
         return d
 
     def extract_capture_time(self):
-        time_strings = ["EXIF DateTimeOriginal",
-                        "EXIF DateTimeDigitized",
-                        "Image DateTime"]
+        time_strings = [('EXIF DateTimeOriginal', 'EXIF SubSecTimeOriginal'),
+                        ('EXIF DateTimeDigitized', 'EXIF SubSecTimeDigitized'),
+                        ('Image DateTime', 'EXIF SubSecTime')]
         for ts in time_strings:
-            if ts in self.tags:
-                s = str(self.tags[ts].values)
+            if ts[0] in self.tags:
+                s = str(self.tags[ts[0]].values)
                 try:
                     d = datetime.datetime.strptime(s, '%Y:%m:%d %H:%M:%S')
                 except ValueError:
                     continue
                 timestamp = (d - datetime.datetime(1970, 1, 1)).total_seconds()   # Assuming d is in UTC
+                timestamp += int(str(self.tags.get(ts[1], 0))) / 1000.0;
                 return timestamp
         return 0.0
 


### PR DESCRIPTION
I'm using OpenSfM with images extracted from video at more than 1 fps.  Thus, it is desirable to have sub-second accuracy for the capture time when using `matching_time_neighbors`.

This PR checks the corresponding Exif SubSec tags and adds the value to the timestamp.