### PR TITLE
Write profile data for create_tracks

### DIFF
--- a/opensfm/commands/create_tracks.py
+++ b/opensfm/commands/create_tracks.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from opensfm import dataset
 from opensfm import matching
@@ -14,6 +15,7 @@ class Command:
         parser.add_argument('dataset', help='dataset to process')
 
     def run(self, args):
+        start = time.time()
         data = dataset.DataSet(args.dataset)
         images = data.images()
 
@@ -39,3 +41,7 @@ class Command:
         tracks_graph = matching.create_tracks_graph(features, colors, matches,
                                                     data.config)
         data.save_tracks_graph(tracks_graph)
+
+        end = time.time()
+        with open(data.profile_log(), 'a') as fout:
+            fout.write('create_tracks: {0}\n'.format(end - start))


### PR DESCRIPTION
When checking which steps of `run_all` make use of multiple CPU cores, I noticed that `create_tracks` is the only command called by `run_all` that doesn't add to `profile.log`.  For my data set, it takes longer than the other fast commands, due to 24 million calls to `UnionFind.union`.