### PR TITLE
Allow per image masking

### DIFF
--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -41,13 +41,14 @@ def detect(args):
     logger.info('Extracting {} features for image {}'.format(
         data.feature_type().upper(), image))
 
-    mask_path = None
-    mask_name = image.split('.')[0] + 'mask'
+    mask_name = image
     if mask_name in data.masks():
         mask_path = data.mask_files[mask_name]
         logger.info('Found mask {} to apply'.format(
             mask_name
         ))
+    else:
+        mask_path = None
 
     if not data.feature_index_exists(image):
         preemptive_max = data.config.get('preemptive_max', 200)

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -41,19 +41,13 @@ def detect(args):
     logger.info('Extracting {} features for image {}'.format(
         data.feature_type().upper(), image))
 
-    mask_name = image
-    if mask_name in data.masks():
-        mask_path = data.mask_files[mask_name]
-        logger.info('Found mask {} to apply'.format(
-            mask_name
-        ))
-    else:
-        mask_path = None
-
     if not data.feature_index_exists(image):
+        mask = data.mask_as_array(image)
+        if mask is not None:
+            logger.info('Found mask to apply for image {}'.format(image))
         preemptive_max = data.config.get('preemptive_max', 200)
         p_unsorted, f_unsorted, c_unsorted = features.extract_features(
-            data.image_as_array(image), data.config, mask_path)
+            data.image_as_array(image), data.config, mask)
         if len(p_unsorted) == 0:
             return
 

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -40,10 +40,19 @@ def detect(args):
     image, data = args
     logger.info('Extracting {} features for image {}'.format(
         data.feature_type().upper(), image))
+
+    mask_path = None
+    mask_name = image.split('.')[0] + 'mask'
+    if mask_name in data.masks():
+        mask_path = data.mask_files[mask_name]
+        logger.info('Found mask {} to apply'.format(
+            mask_name
+        ))
+
     if not data.feature_index_exists(image):
         preemptive_max = data.config.get('preemptive_max', 200)
         p_unsorted, f_unsorted, c_unsorted = features.extract_features(
-            data.image_as_array(image), data.config)
+            data.image_as_array(image), data.config, mask_path)
         if len(p_unsorted) == 0:
             return
 

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -93,6 +93,16 @@ class DataSet:
         """Return list of file names of all masks in this dataset"""
         return self.mask_list
 
+    def mask_as_array(self, image):
+        """Given an image, returns the associated mask as an array if it exists, otherwise returns None"""
+        mask_name = image
+        if mask_name in self.masks():
+            mask_path = self.mask_files[mask_name]
+            mask = cv2.imread(mask_path)
+        else:
+            mask = None
+        return mask
+
     def _depthmap_path(self):
         return os.path.join(self.data_path, 'depthmaps')
 

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -129,7 +129,7 @@ class DataSet:
         return filename.split('.')[-1].lower() in {'jpg', 'jpeg', 'png', 'tif', 'tiff', 'pgm', 'pnm', 'gif'}
 
     def set_image_path(self, path):
-        """Set image path and find the all images in there"""
+        """Set image path and find all images in there"""
         self.image_list = []
         self.image_files = {}
         if os.path.exists(path):
@@ -152,15 +152,14 @@ class DataSet:
         return DataSet.__is_image_file(filename)
 
     def set_mask_path(self, path):
-        """Set mask path and find the all mask in there"""
+        """Set mask path and find all masks in there"""
         self.mask_list = []
         self.mask_files = {}
         if os.path.exists(path):
             for name in os.listdir(path):
                 if self.__is_mask_file(name):
-                    short_name = name.split('.')[0]
-                    self.mask_list.append(short_name)
-                    self.mask_files[short_name] = os.path.join(path, name)
+                    self.mask_list.append(name)
+                    self.mask_files[name] = os.path.join(path, name)
 
     def set_mask_list(self, mask_list):
             self.mask_list = []
@@ -168,9 +167,8 @@ class DataSet:
             for line in mask_list:
                 path = os.path.join(self.data_path, line)
                 name = os.path.basename(path)
-                short_name = name.split('.')[0]
-                self.mask_list.append(short_name)
-                self.mask_files[short_name] = path
+                self.mask_list.append(name)
+                self.mask_files[name] = path
 
     def __exif_path(self):
         """Return path of extracted exif directory"""

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -149,7 +149,7 @@ class DataSet:
 
     @staticmethod
     def __is_mask_file(filename):
-        return filename.split('.')[-1].lower() in {'xml'}
+        return DataSet.__is_image_file(filename)
 
     def set_mask_path(self, path):
         """Set mask path and find the all mask in there"""

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -68,7 +68,7 @@ def denormalized_image_coordinates(norm_coords, width, height):
     p[:, 1] = norm_coords[:, 1] * size - 0.5 + height / 2.0
     return p
 
-def mask_and_normalize_features(points, desc, colors, width, height, config, mask_path=None):
+def mask_and_normalize_features(points, desc, colors, width, height, config, mask=None):
     masks = np.array(config.get('masks',[]))
     for mask in masks:
         top = mask['top'] * height
@@ -84,8 +84,7 @@ def mask_and_normalize_features(points, desc, colors, width, height, config, mas
         colors = colors[ids]
 
     # We get the relevant image mask
-    if mask_path is not None:
-        mask = cv2.imread(mask_path)
+    if mask is not None:
         mask_height, mask_width, _ = mask.shape
         if (mask_height, mask_width) != (height, width):
             raise TypeError("Given mask does not match image dimensions")
@@ -234,7 +233,7 @@ def extract_features_hahog(image, config):
     logger.debug('Found {0} points in {1}s'.format( len(points), time.time()-t ))
     return points, desc
 
-def extract_features(color_image, config, mask_path=None):
+def extract_features(color_image, config, mask=None):
     assert len(color_image.shape) == 3
     color_image = resized_image(color_image, config)
     image = cv2.cvtColor(color_image, cv2.COLOR_RGB2GRAY)
@@ -255,7 +254,7 @@ def extract_features(color_image, config, mask_path=None):
     ys = points[:,1].round().astype(int)
     colors = color_image[ys, xs]
 
-    return mask_and_normalize_features(points, desc, colors, image.shape[1], image.shape[0], config, mask_path)
+    return mask_and_normalize_features(points, desc, colors, image.shape[1], image.shape[0], config, mask)
 
 
 def build_flann_index(features, config):

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -85,12 +85,13 @@ def mask_and_normalize_features(points, desc, colors, width, height, config, mas
 
     # We get the relevant image mask
     if mask_path is not None:
-        test = cv2.FileStorage(mask_path, cv2.FILE_STORAGE_READ)
-        node = test.getFirstTopLevelNode()
-        mask = node.mat()
-        if mask.shape != (height, width):
+        maskname = mask_path[:-3]
+
+        mask = cv2.imread(mask_path)
+        mask_height, mask_width, _ = mask.shape
+        if (mask_height, mask_width) != (height, width):
             raise TypeError("Given mask does not match image dimensions")
-        ids = np.array([mask[int(point[1]), int(point[0])] != 0 for point in points])
+        ids = np.array([mask[int(point[1]), int(point[0]), 0] == 0 for point in points])
         points = points[ids]
         desc = desc[ids]
         colors = colors[ids]

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -85,8 +85,6 @@ def mask_and_normalize_features(points, desc, colors, width, height, config, mas
 
     # We get the relevant image mask
     if mask_path is not None:
-        maskname = mask_path[:-3]
-
         mask = cv2.imread(mask_path)
         mask_height, mask_width, _ = mask.shape
         if (mask_height, mask_width) != (height, width):

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -68,7 +68,7 @@ def denormalized_image_coordinates(norm_coords, width, height):
     p[:, 1] = norm_coords[:, 1] * size - 0.5 + height / 2.0
     return p
 
-def mask_and_normalize_features(points, desc, colors, width, height, config, mask=None):
+def mask_and_normalize_features(points, desc, colors, width, height, config, image_mask=None):
     masks = np.array(config.get('masks',[]))
     for mask in masks:
         top = mask['top'] * height
@@ -83,12 +83,12 @@ def mask_and_normalize_features(points, desc, colors, width, height, config, mas
         desc = desc[ids]
         colors = colors[ids]
 
-    # We get the relevant image mask
-    if mask is not None:
-        mask_height, mask_width, _ = mask.shape
-        if (mask_height, mask_width) != (height, width):
+    # We now compare with the image mask for this specific image if it exists
+    if image_mask is not None:
+        image_mask_height, image_mask_width, _ = image_mask.shape
+        if (image_mask_height, image_mask_width) != (height, width):
             raise TypeError("Given mask does not match image dimensions")
-        ids = np.array([mask[int(point[1]), int(point[0]), 0] != 0 for point in points])
+        ids = np.array([image_mask[int(point[1]), int(point[0]), 0] != 0 for point in points])
         points = points[ids]
         desc = desc[ids]
         colors = colors[ids]

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -88,7 +88,7 @@ def mask_and_normalize_features(points, desc, colors, width, height, config, mas
         mask_height, mask_width, _ = mask.shape
         if (mask_height, mask_width) != (height, width):
             raise TypeError("Given mask does not match image dimensions")
-        ids = np.array([mask[int(point[1]), int(point[0]), 0] == 0 for point in points])
+        ids = np.array([mask[int(point[1]), int(point[0]), 0] != 0 for point in points])
         points = points[ids]
         desc = desc[ids]
         colors = colors[ids]


### PR DESCRIPTION
Adding additional feature where you can mask out parts of the image on a frame by frame and pixel by pixel basis, rather than having to specify static rectangles for the whole range.

Masks should have the same name as the corresponding image, and are listed in the same way as images, i.e. you can provide a textfile listing them, or you can just dump them in a folder next to images, called 'masks'.  They should be image files of the same dimension as the original images.  The first channel is scanned, and if it is equal to 0 then features there are kept, and if it is non-zero they aren't. (i.e. for a black and white mask, any white areas of the mask are deemed not useful, e.g. watermarks, moving objects, and so on).

Is there any relevant documentation to update?  I've also not really looked into the tests associated with OpenSFM, so would appreciate some pointers there if appropriate.  I did also for my own testing make something that would output images of the location of features found, before and after mask filtering.  I don't think these should be included, but am happy to put them somewhere if useful.  Was certainly useful for being really sure what was going on.

#118 