### PR TITLE
Image matching on consecutive images

### DIFF
--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -51,6 +51,7 @@ flann_checks: 200             # Smaller -> Faster (but might lose good matches)
 matching_gps_distance: 150            # Maximum gps distance between two images for matching
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to use no limit
+matching_order_neighbors: 0           # Selects based on image names
 preemptive_max: 200                   # Number of features to use for preemptive matching
 preemptive_threshold: 0               # If number of matches passes the threshold -> full feature matching
 

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -51,7 +51,7 @@ flann_checks: 200             # Smaller -> Faster (but might lose good matches)
 matching_gps_distance: 150            # Maximum gps distance between two images for matching
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to use no limit
-matching_order_neighbors: 0           # Selects based on image names
+matching_order_neighbors: 0           # Number of images to match selected by image name. Set to 0 to use no limit
 preemptive_max: 200                   # Number of features to use for preemptive matching
 preemptive_threshold: 0               # If number of matches passes the threshold -> full feature matching
 


### PR DESCRIPTION
Adds extra configuration option to match on consecutive images ordered by name.  Use case is when you have a sequence of images, e.g. ripped from a video, that are in linear order.  Substantially speeds up the matching step in these cases.

#82