### PR TITLE
Add sensor width for DJI Phantom 4.

### DIFF
--- a/opensfm/data/sensor_data.json
+++ b/opensfm/data/sensor_data.json
@@ -703,6 +703,7 @@
     "DJI FC300S": 6.16,
     "DJI FC300X": 6.2,
     "DJI FC350": 6.17,
+    "DJI FC330": 6.25,
     "Epson L-500V": 5.75,
     "Epson PhotoPC 3000 Zoom": 7.11,
     "Epson PhotoPC 3100 Zoom": 7.11,


### PR DESCRIPTION
Fix warning for image from DJI Phantom 4.

```
Could not find ccd_width in file. Use --force-ccd or edit the sensor_data.json file to manually input ccd width
Loaded DJI_0045.jpg | camera: dji fc330 | dimensions: 4000 x 3000 | focal: 3.61 | ccd: None
```

**Phantom 4**
Focal length: 3.64mm
CMOS size: 6.25 x 4.68mm (7.81 diagonal)
Sensor: 1/2.3” CMOS
Lens: FOV 94° 20 mm (35 mm format equivalent) f/2.8 focus at ∞