### PR TITLE
Minify reconstruction.meshed.py

### DIFF
--- a/opensfm/commands/mesh.py
+++ b/opensfm/commands/mesh.py
@@ -31,7 +31,8 @@ class Command:
                     shot.mesh.faces = faces
 
         data.save_reconstruction(reconstructions,
-                                 filename='reconstruction.meshed.json')
+                                 filename='reconstruction.meshed.json',
+                                 minify=True)
 
         end = time.time()
         with open(data.profile_log(), 'a') as fout:

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -374,9 +374,9 @@ class DataSet:
             reconstructions = io.reconstructions_from_json(json.load(fin))
         return reconstructions
 
-    def save_reconstruction(self, reconstruction, filename=None):
+    def save_reconstruction(self, reconstruction, filename=None, minify=False):
         with open(self.__reconstruction_file(filename), 'w') as fout:
-            io.json_dump(io.reconstructions_to_json(reconstruction), fout)
+            io.json_dump(io.reconstructions_to_json(reconstruction), fout, minify)
 
     def load_undistorted_reconstruction(self):
         return self.load_reconstruction(

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -346,8 +346,12 @@ def mkdir_p(path):
             raise
 
 
-def json_dump(data, fout, indent=4, codec='utf-8'):
-    return json.dump(data, fout, indent=indent, ensure_ascii=False, encoding=codec)
+def json_dump(data, fout, minify=False, codec='utf-8'):
+    if minify:
+        indent, separators = None, (',',':')
+    else:
+        indent, separators = 4, None
+    return json.dump(data, fout, indent=indent, ensure_ascii=False, encoding=codec, separators=separators)
 
 
 def json_loads(text, codec='utf-8'):


### PR DESCRIPTION
reconstruction.meshed.py gets too large to be loaded in the browser viewer for large datasets, and minifying this mitigates this. See #126 

I wasn't sure exactly how much to minify.  Setting indent to 0 rather than 4 gets most of the space saving gain, and you can still open the files easily in text editors, they just look less nice.  Setting indent to None removes new lines as well, and then you can't open the files easily in text editors and it would be very hard to human read.
For Lund I got size of 7.7mb for indent=4, 2.2mb for indent=0, 1.9mb for indent=None.

Since it's nice to have output human readable unless there is a good reason not to, I gave json_dump an argument to minify, and only activate for this one file at the moment.  But happy to change to minify all files/some other subset.