### PR TITLE
Compilation fixes for non x86 architectures

### DIFF
--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -77,6 +77,10 @@ target_link_libraries(akaze ${OpenCV_LIBS})
 # VLFeat
 include_directories(third_party/vlfeat)
 file(GLOB VLFEAT_SRCS third_party/vlfeat/vl/*.c third_party/vlfeat/vl/*.h)
+if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES 
+    "(x86)|(X86)|(x86_64)|(X86_64)|(amd64)|(AMD64)")
+    add_definitions(-DVL_DISABLE_SSE2)
+endif ()
 add_definitions(-DVL_DISABLE_AVX)
 add_library(vl ${VLFEAT_SRCS})
 

--- a/opensfm/src/third_party/vlfeat/vl/host.c
+++ b/opensfm/src/third_party/vlfeat/vl/host.c
@@ -441,6 +441,7 @@ _vl_cpuid (vl_int32* info, int function)
 
 #endif
 
+#if defined(HAS_CPUID)
 void
 _vl_x86cpu_info_init (VlX86CpuInfo *self)
 {
@@ -463,6 +464,7 @@ _vl_x86cpu_info_init (VlX86CpuInfo *self)
     self->hasAVX   = info[2] & (1 << 28) ;
   }
 }
+#endif
 
 char *
 _vl_x86cpu_info_to_string_copy (VlX86CpuInfo const *self)


### PR DESCRIPTION
Two small fixes to allow OpenSFM to compile on non x86 architectures.

I'm trying to upstream all the fixes to allow OpenDroneMap run an ARM processors. For reference:
OpenDroneMap/OpenDroneMap/issues/484