### PR TITLE
Making OpenSFM install more nicely

### DIFF
--- a/bin/opensfm_run_all
+++ b/bin/opensfm_run_all
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+$DIR/opensfm extract_metadata $1
+$DIR/opensfm detect_features $1
+$DIR/opensfm match_features $1
+$DIR/opensfm create_tracks $1
+$DIR/opensfm reconstruct $1
+$DIR/opensfm mesh $1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
     url='https://github.com/mapillary/OpenSfM',
     author='Mapillary',
     license='BSD',
-    packages=['opensfm'],
+    packages=['opensfm', 'opensfm.commands'],
+    scripts=['bin/opensfm_run_all', 'bin/opensfm'],
     package_data={
         'opensfm': ['csfm.so', 'data/sensor_data.json']
     },


### PR DESCRIPTION
`python setup.py install` now makes it so a version of run_all can be ran globally