### PR TITLE
Create tracks improvement

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -15,3 +15,4 @@ mv -vf $1/navigation_graph.json $trash
 mv -vf $1/plot_inliers $trash
 mv -vf $1/depthmaps $trash
 mv -vf $1/tracks.csv $trash
+mv -vf $1/track_sets.pkl $trash

--- a/bin/clean
+++ b/bin/clean
@@ -7,14 +7,11 @@ rm -rf trash/*
 mv -vf $1/reconstruction*.json $trash
 mv -vf $1/exif $trash
 mv -vf $1/matches $trash
-mv -vf $1/sift $trash
-mv -vf $1/surf $trash
-mv -vf $1/akaze* $trash
-mv -vf $1/root* $trash
-mv -vf $1/hahog $trash
+mv -vf $1/features $trash
 mv -vf $1/camera_models.json $trash
 mv -vf $1/reference_lla.json $trash
 mv -vf $1/profile.log $trash
 mv -vf $1/navigation_graph.json $trash
 mv -vf $1/plot_inliers $trash
 mv -vf $1/depthmaps $trash
+mv -vf $1/tracks.csv $trash

--- a/opensfm/commands/create_tracks.py
+++ b/opensfm/commands/create_tracks.py
@@ -19,6 +19,16 @@ class Command:
         data = dataset.DataSet(args.dataset)
         images = data.images()
 
+        try:
+            graph = data.load_tracks_graph()
+            tracks, processed_images = matching.tracks_and_images(graph)
+        except IOError:
+            graph = None
+            tracks = None
+            processed_images = []
+
+        remaining_images = set(images) - set(processed_images)
+
         # Read local features
         logging.info('reading features')
         features = {}
@@ -30,7 +40,7 @@ class Command:
 
         # Read matches
         matches = {}
-        for im1 in images:
+        for im1 in remaining_images:
             try:
                 im1_matches = data.load_matches(im1)
             except IOError:
@@ -39,7 +49,7 @@ class Command:
                 matches[im1, im2] = im1_matches[im2]
 
         tracks_graph = matching.create_tracks_graph(features, colors, matches,
-                                                    data.config)
+                                                    data.config, data)
         data.save_tracks_graph(tracks_graph)
 
         end = time.time()

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -38,10 +38,10 @@ class Command:
 
 def detect(args):
     image, data = args
-    logger.info('Extracting {} features for image {}'.format(
-        data.feature_type().upper(), image))
 
     if not data.feature_index_exists(image):
+        logger.info('Extracting {} features for image {}'.format(
+            data.feature_type().upper(), image))
         mask = data.mask_as_array(image)
         if mask is not None:
             logger.info('Found mask to apply for image {}'.format(image))

--- a/opensfm/commands/extract_metadata.py
+++ b/opensfm/commands/extract_metadata.py
@@ -20,9 +20,14 @@ class Command:
     def run(self, args):
         start = time.time()
         data = dataset.DataSet(args.dataset)
-
-        camera_models = {}
-        for image in data.images():
+        # Try not to recreate exif files that already exist
+        try:
+            camera_models = data.load_camera_models()
+            images = data.images_requiring_exif_files()
+        except IOError:
+            camera_models = {}
+            images = data.images()
+        for image in images:
             logging.info('Extracting focal lengths for image {}'.format(image))
 
             # EXIF data in Image

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -103,7 +103,7 @@ def timediff_from_exif(exif1, exif2):
 
 def match_candidates_from_metadata(images, exifs, data):
     '''
-    Compute candidate matching pairs based on GPS and capture time
+    Compute candidate matching pairs based on GPS, capture time and order of images
     '''
     max_distance = data.config['matching_gps_distance']
     max_neighbors = data.config['matching_gps_neighbors']

--- a/opensfm/commands/mesh.py
+++ b/opensfm/commands/mesh.py
@@ -21,6 +21,8 @@ class Command:
         graph = data.load_tracks_graph()
         reconstructions = data.load_reconstruction()
 
+        logger.debug("Starting calculation of reconstruction mesh")
+
         for i, r in enumerate(reconstructions):
             for shot in r.shots.values():
                 if shot.id in graph:

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -3,7 +3,7 @@
 import os
 import json
 import errno
-import pickle
+import cPickle as pickle
 import gzip
 import numpy as np
 import networkx as nx
@@ -329,6 +329,19 @@ class DataSet:
                     return im2_matches[im1][:, [1, 0]]
         return []
 
+    def __unionfind_file(self, filename=None):
+        """Return path of unionfind file"""
+        return os.path.join(self.data_path, filename or 'unionfind.pkl')
+
+    def load_unionfind_file(self, filename=None):
+        """Return unionfind of tracks"""
+        with open(self.__unionfind_file(filename)) as fin:
+            return load_unionfind_file(fin)
+
+    def save_unionfind_file(self, unionfind, filename=None):
+        with open(self.__unionfind_file(filename), 'w') as fout:
+            save_unionfind_file(fout, unionfind)
+
     def __tracks_graph_file(self, filename=None):
         """Return path of tracks file"""
         return os.path.join(self.data_path, filename or 'tracks.csv')
@@ -495,3 +508,9 @@ def save_tracks_graph(fileobj, graph):
                 r, g, b = data['feature_color']
                 fileobj.write('%s\t%s\t%d\t%g\t%g\t%g\t%g\t%g\n' % (
                     str(image), str(track), fid, x, y, r, g, b))
+
+def load_unionfind_file(fileobj):
+    return pickle.load(fileobj)
+
+def save_unionfind_file(fileobj, unionfind):
+    pickle.dump(unionfind, fileobj, protocol=pickle.HIGHEST_PROTOCOL)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -191,6 +191,10 @@ class DataSet:
         """
         return os.path.join(self.__exif_path(), image + '.exif')
 
+    def images_requiring_exif_files(self):
+        """ Return all images that we don't already have exif files for"""
+        return set(image for image in self.images() if not os.path.isfile(self.__exif_file(image)))
+
     def load_exif(self, image):
         """
         Return extracted exif information, as dictionary, usually with fields:

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -329,18 +329,18 @@ class DataSet:
                     return im2_matches[im1][:, [1, 0]]
         return []
 
-    def __unionfind_file(self, filename=None):
+    def __track_sets_file(self, filename=None):
         """Return path of unionfind file"""
-        return os.path.join(self.data_path, filename or 'unionfind.pkl')
+        return os.path.join(self.data_path, filename or 'track_sets.pkl')
 
-    def load_unionfind_file(self, filename=None):
+    def load_track_sets_file(self, filename=None):
         """Return unionfind of tracks"""
-        with open(self.__unionfind_file(filename)) as fin:
-            return load_unionfind_file(fin)
+        with open(self.__track_sets_file(filename)) as fin:
+            return load_track_sets_file(fin)
 
-    def save_unionfind_file(self, unionfind, filename=None):
-        with open(self.__unionfind_file(filename), 'w') as fout:
-            save_unionfind_file(fout, unionfind)
+    def save_track_sets_file(self, unionfind, filename=None):
+        with open(self.__track_sets_file(filename), 'w') as fout:
+            save_track_sets_file(fout, unionfind)
 
     def __tracks_graph_file(self, filename=None):
         """Return path of tracks file"""
@@ -509,8 +509,8 @@ def save_tracks_graph(fileobj, graph):
                 fileobj.write('%s\t%s\t%d\t%g\t%g\t%g\t%g\t%g\n' % (
                     str(image), str(track), fid, x, y, r, g, b))
 
-def load_unionfind_file(fileobj):
+def load_track_sets_file(fileobj):
     return pickle.load(fileobj)
 
-def save_unionfind_file(fileobj, unionfind):
+def save_track_sets_file(fileobj, unionfind):
     pickle.dump(unionfind, fileobj, protocol=pickle.HIGHEST_PROTOCOL)

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -142,10 +142,14 @@ def good_track(track, min_length):
         return False
     return True
 
-
-def create_tracks_graph(features, colors, matches, config):
+def create_tracks_graph(features, colors, matches, config, data):
     logger.debug('Merging features onto tracks')
-    uf = UnionFind()
+
+    try:
+        uf = data.load_unionfind_file()
+    except IOError:
+        uf = UnionFind()
+
     for im1, im2 in matches:
         for f1, f2 in matches[im1, im2]:
             uf.union((im1, f1), (im2, f2))
@@ -157,6 +161,8 @@ def create_tracks_graph(features, colors, matches, config):
             sets[p].append(i)
         else:
             sets[p] = [i]
+
+    data.save_unionfind_file(uf)
 
     tracks = [t for t in sets.values() if good_track(t, config.get('min_track_length', 2))]
     logger.debug('Good tracks: {}'.format(len(tracks)))

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -750,13 +750,32 @@ def incremental_reconstruction(data):
     logger.info("Starting incremental reconstruction")
     data.invent_reference_lla()
     graph = data.load_tracks_graph()
+
+    try:
+        existing_reconstructions = data.load_reconstruction()
+        # we remove any points that were in the previous reconstruction but are no longer in our graph
+        for reconstruction in existing_reconstructions:
+            reconstruction.points = {k: point for k, point in reconstruction.points.iteritems() if k in graph}
+    except IOError:
+        existing_reconstructions = []
+
+    reconstructed_images = set(image for reconstruction in existing_reconstructions for image in reconstruction.shots.keys())
+
     tracks, images = matching.tracks_and_images(graph)
-    remaining_images = set(images)
+    remaining_images = set(images) - reconstructed_images
     gcp = None
     if data.ground_control_points_exist():
         gcp = data.load_ground_control_points()
-    common_tracks = matching.all_common_tracks(graph, tracks)
+
     reconstructions = []
+    for reconstruction in existing_reconstructions:
+        grow_reconstruction(data, graph, reconstruction, remaining_images, gcp)
+        reconstructions.append(reconstruction)
+        reconstructions = sorted(reconstructions,
+                                 key=lambda x: -len(x.shots))
+        data.save_reconstruction(reconstructions)
+
+    common_tracks = matching.all_common_tracks(graph, tracks)
     pairs = compute_image_pairs(common_tracks, data.config)
     for im1, im2 in pairs:
         if im1 in remaining_images and im2 in remaining_images:


### PR DESCRIPTION
Not necessarily final, but would like to show the direction I've gone with this before going any further, so looking for comments @paulinus 

These changes as a whole should allow you to run opensfm to generate a reconstruction, then place a few new images in the images folder, and then run the opensfm commands again - it will add the new images to the reconstruction without recalculating everything.  

Mostly we just check if things are already calculated (e.g. features) and don't redo.  For matches, we only calculate matches for the new images, and save them all in the folders of the new images (previously they would go in the image that had the first name alphabetically).  For create_tracks we save the unionfind structure, as well as track_ids, which allows us to use previous reconstructions with updated tracks, since we have a persistent way of naming the tracks.

From a test on a large dataset:
First run generating reconstruction of 922 images:
focal_from_exif: 13.5280120373
detect_features: 344.613101006
match_features: 4669.25260997
create_tracks: 129.082221985
reconstruct: 4923.34434319
mesh: 77.7916591167

Re run with no extra images:
focal_from_exif: 0.0260539054871
detect_features: 0.034029006958
match_features: 0.200579881668
create_tracks: 97.3890349865
reconstruct: 188.215790033
mesh: 79.0046401024

Re run with 15 extra images:
focal_from_exif: 0.240912914276
detect_features: 8.93757390976
match_features: 121.738699913
create_tracks: 104.183819056
reconstruct: 442.458048105
mesh: 81.0022370815

(incidentially, this was done on an old set I had used, and it looked like it ran a lot faster than last time - has opensfm had any recent changes that make it faster? or did something change on my end?)

There are still some bits that will be slower with larger reconstructions.  
1) Some of these are because I just haven't taken away the calculations yet: In create_tracks, we convert the unionfind into a graph everytime still. 
2) Some of these are loading times - in adding to an existing reconstruction, we load large files into memory.  There might be clever things here that could be done, but there might not.
3) I haven't changed the mesh command - it might be possible to do something here, or maybe you do have to recalculate whole thing after changing the reconstruction - I haven't looked.
4) Reconstruction bundle step is slower with larger datasets, this is a general problem.

Problems:
It might result in unexpected behaviour, if you change the images/config, and it doesn't take this into account but uses the already saved results.  detect_features already did this, so this change may be an improvement as it makes it more obvious that stuff is not being recalculated (and that you should use clean command to do a new build).

**Thoughts?**  If the approach looks vaguely sensible (the way I'm saving things in create_tracks is maybe not very nice at the moment), and you'd be happy for this to go into master, I can tidy things up/make high level improvements.  I'd then appreciate someone thinking about the changes/asking questions reasonably carefully to make sure things work as I think they do.