### PR TITLE
fix(match_features): allow matching_gps_neighbors to be unset in config

### DIFF
--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -154,9 +154,10 @@ def match_candidates_from_metadata(images, exifs, data):
         data.invent_reference_lla()
     reference = data.load_reference_lla()
 
-    if not all(map(has_gps_info, exifs.values())) and gps_neighbors != 0:
-        logger.warn("Not all images have GPS info. "
-                    "Disabling matching_gps_neighbors.")
+    if not all(map(has_gps_info, exifs.values())):
+        if gps_neighbors != 0:
+            logger.warn("Not all images have GPS info. "
+                        "Disabling matching_gps_neighbors.")
         gps_neighbors = 0
         max_distance = 0
 


### PR DESCRIPTION
Fixes an exception where using `matching_gps_neighbors: 0` or omitting matching_gps_neighbors in the config prevents feature matching from completing. Frames without GPS info will error out using the default config values.

This PR prevents the following exception:
```
Traceback (most recent call last):
  File "/source/OpenSfM/bin/opensfm", line 34, in <module>
    command.run(args)
  File "/source/OpenSfM/opensfm/commands/match_features.py", line 26, in run
    pairs = match_candidates_from_metadata(images, exifs, data)
  File "/source/OpenSfM/opensfm/commands/match_features.py", line 166, in match_candidates_from_metadata
    gps_neighbors, max_distance)
  File "/source/OpenSfM/opensfm/commands/match_features.py", line 94, in match_candidates_by_distance
    gps['latitude'], gps['longitude'], gps['altitude'],
KeyError: 'latitude'
```