### PR TITLE
Optimize Dockerfile: cache pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM paulinus/opensfm-docker-base
 
-COPY . /source/OpenSfM
+COPY requirements.txt /source/OpenSfM/requirements.txt
+RUN pip install -r /source/OpenSfM/requirements.txt
 
+COPY . /source/OpenSfM
 WORKDIR /source/OpenSfM
 
-RUN pip install -r requirements.txt && \
-    python setup.py build
+RUN python setup.py build


### PR DESCRIPTION
Currently, changing a single line of code and re-building a docker image ends up re-installing the python dependencies which takes a while. The pip install can be moved to the top of the Dockerfile so this layer is cached and unaffected by changes to unrelated files.