### PR TITLE
Handle failed matching if at least one image has no GPS data

### DIFF
--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -90,9 +90,14 @@ def match_candidates_by_distance(images, exifs, reference, max_neighbors, max_di
     points = np.zeros((len(images), 3))
     for i, image in enumerate(images):
         gps = exifs[image]['gps']
-        points[i] = geo.topocentric_from_lla(
-            gps['latitude'], gps['longitude'], gps['altitude'],
-            reference['latitude'], reference['longitude'], reference['altitude'])
+        try:
+            points[i] = geo.topocentric_from_lla(
+                gps['latitude'], gps['longitude'], gps['altitude'],
+                reference['latitude'], reference['longitude'], reference['altitude'])
+        except KeyError:
+            points[i] = geo.topocentric_from_lla(
+                0, 0, 0,
+                reference['latitude'], reference['longitude'], reference['altitude'])
 
     tree = spatial.cKDTree(points)
 
@@ -159,7 +164,7 @@ def match_candidates_from_metadata(images, exifs, data):
             logger.warn("Not all images have GPS info. "
                         "Disabling matching_gps_neighbors.")
         gps_neighbors = 0
-        max_distance = 0
+        max_distance = 150
 
     images.sort()
 


### PR DESCRIPTION
Fix for #198 

The fix worked for me, don't see why everyone else using this library should need to apply the patch too.