### PR TITLE
Move features directory to trash on clean

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -18,3 +18,4 @@ mv -vf $1/profile.log $trash
 mv -vf $1/navigation_graph.json $trash
 mv -vf $1/plot_inliers $trash
 mv -vf $1/depthmaps $trash
+mv -vf $1/features $trash


### PR DESCRIPTION
Clean should return the data directory to the initial state.
Currently the features directory is is not cleaned. This patch
fixes that behaviour.