### PR TITLE
Add third parameter for radial distortion for perspective camera

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,6 +68,7 @@ reprojection_error_sd: 0.004    # The startard deviation of the reprojection err
 exif_focal_sd: 0.01             # The standard deviation of the exif focal length in log-scale
 radial_distorsion_k1_sd: 0.01   # The standard deviation of the first radial distortion parameter (mean assumed to be 0)
 radial_distorsion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter (mean assumed to be 0)
+radial_distorsion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter (mean assumed to be 0)
 bundle_interval: 0              # bundle adjustment after adding 'bundle_interval' cameras
 bundle_new_points_ratio: 1.2    # bundle when (new points) / (bundled points) > bundle_outlier_threshold
 bundle_outlier_threshold: 0.006

--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -112,6 +112,7 @@ def perspective_camera_from_fisheye(fisheye):
     """Create a perspective camera from a fisheye."""
     camera = types.PerspectiveCamera()
     camera.id = fisheye.id
+    camera.distortion_model = 'radial_k2'
     camera.width = fisheye.width
     camera.height = fisheye.height
     camera.focal = fisheye.focal
@@ -123,6 +124,7 @@ def perspective_camera_from_fisheye(fisheye):
 def perspective_views_of_a_panorama(spherical_shot, width):
     """Create 6 perspective views of a panorama."""
     camera = types.PerspectiveCamera()
+    camera.distortion_model = 'radial_k2'
     camera.id = 'perspective_panorama_camera'
     camera.width = width
     camera.height = width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -73,6 +73,7 @@ reprojection_error_sd: 0.004    # The startard deviation of the reprojection err
 exif_focal_sd: 0.01             # The standard deviation of the exif focal length in log-scale
 radial_distorsion_k1_sd: 0.01   # The standard deviation of the first radial distortion parameter (mean assumed to be 0)
 radial_distorsion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter (mean assumed to be 0)
+radial_distorsion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter (mean assumed to be 0)
 bundle_outlier_threshold: 0.006 # Points with larger reprojection error after bundle adjustment are removed
 bundle_interval: 0              # Bundle after adding 'bundle_interval' cameras
 bundle_new_points_ratio: 1.2    # Bundle when (new points) / (bundled points) > bundle_outlier_threshold

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -345,12 +345,15 @@ def camera_from_exif_metadata(metadata, data):
         camera.width = metadata['width']
         camera.height = metadata['height']
         camera.projection_type = metadata.get('projection_type', 'perspective')
+        camera.distortion_model = metadata.get('distortion_model', 'radial_k2')
         camera.focal = calib['focal']
         camera.k1 = calib['k1']
         camera.k2 = calib['k2']
+        camera.k3 = calib.get('k3', 0.0)
         camera.focal_prior = calib['focal']
         camera.k1_prior = calib['k1']
         camera.k2_prior = calib['k2']
+        camera.k3_prior = calib.get('k3', 0.0)
         return camera
     elif pt in ['equirectangular', 'spherical']:
         camera = types.SphericalCamera()

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -31,8 +31,8 @@ def bundle(graph, reconstruction, gcp, config):
     for camera in reconstruction.cameras.values():
         if camera.projection_type == 'perspective':
             ba.add_perspective_camera(
-                str(camera.id), camera.focal, camera.k1, camera.k2,
-                camera.focal_prior, camera.k1_prior, camera.k2_prior,
+                str(camera.id), str(camera.distortion_model), camera.focal, camera.k1, camera.k2, camera.k3,
+                camera.focal_prior, camera.k1_prior, camera.k2_prior, camera.k3_prior,
                 fix_cameras)
         elif camera.projection_type == 'fisheye':
             ba.add_fisheye_camera(
@@ -86,7 +86,8 @@ def bundle(graph, reconstruction, gcp, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
 
     setup = time.time()
 
@@ -102,6 +103,7 @@ def bundle(graph, reconstruction, gcp, config):
             camera.focal = c.focal
             camera.k1 = c.k1
             camera.k2 = c.k2
+            camera.k3 = c.k3
         elif camera.projection_type == 'fisheye':
             c = ba.get_fisheye_camera(str(camera.id))
             camera.focal = c.focal
@@ -132,8 +134,8 @@ def bundle_single_view(graph, reconstruction, shot_id, config):
 
     if camera.projection_type == 'perspective':
         ba.add_perspective_camera(
-            str(camera.id), camera.focal, camera.k1, camera.k2,
-            camera.focal_prior, camera.k1_prior, camera.k2_prior, True)
+            str(camera.id), str(camera.distortion_model), camera.focal, camera.k1, camera.k2, camera.k3,
+            camera.focal_prior, camera.k1_prior, camera.k2_prior, camera.k3_prior, True)
     elif camera.projection_type == 'fisheye':
         ba.add_fisheye_camera(
             str(camera.id), camera.focal, camera.k1, camera.k2,
@@ -169,7 +171,8 @@ def bundle_single_view(graph, reconstruction, shot_id, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
 
     ba.set_num_threads(config['processes'])
     ba.run()
@@ -202,8 +205,8 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
     for camera in reconstruction.cameras.values():
         if camera.projection_type == 'perspective':
             ba.add_perspective_camera(
-                str(camera.id), camera.focal, camera.k1, camera.k2,
-                camera.focal_prior, camera.k1_prior, camera.k2_prior,
+                str(camera.id), str(camera.distortion_model), camera.focal, camera.k1, camera.k2, camera.k3,
+                camera.focal_prior, camera.k1_prior, camera.k2_prior, camera.k3_prior,
                 True)
 
         elif camera.projection_type in ['equirectangular', 'spherical']:
@@ -256,7 +259,8 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
 
     setup = time.time()
 
@@ -272,6 +276,7 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
             camera.focal = c.focal
             camera.k1 = c.k1
             camera.k2 = c.k2
+            camera.k3 = c.k3
 
     for shot_id in interior:
         shot = reconstruction.shots[shot_id]

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -117,6 +117,7 @@ BOOST_PYTHON_MODULE(csfm) {
     .add_property("focal", &BAPerspectiveCamera::GetFocal, &BAPerspectiveCamera::SetFocal)
     .add_property("k1", &BAPerspectiveCamera::GetK1, &BAPerspectiveCamera::SetK1)
     .add_property("k2", &BAPerspectiveCamera::GetK2, &BAPerspectiveCamera::SetK2)
+    .add_property("k3", &BAPerspectiveCamera::GetK3, &BAPerspectiveCamera::SetK3)
     .def_readwrite("constant", &BAPerspectiveCamera::constant)
     .def_readwrite("focal_prior", &BAPerspectiveCamera::focal_prior)
     .def_readwrite("id", &BAPerspectiveCamera::id)


### PR DESCRIPTION
Currently only K1 and K2 are used by the algorithm, while K3
is needed for certain cameras.