### PR TITLE
fix(exif): Check the instance when getting exif tag as float

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -27,7 +27,10 @@ def gps_to_decimal(values, reference):
 
 def get_float_tag(tags, key):
     if key in tags:
-        return float(tags[key].values[0])
+        if isinstance(tags[key].values[0], exifread.utils.Ratio):
+            return float(tags[key].values[0].num) / tags[key].values[0].den
+        else:
+            return float(tags[key].values[0])
     else:
         return None
 


### PR DESCRIPTION
When a focal length is saved as exifread.utils.Ratio, it can't be got as float.

exifread sometimes save the exif info `'EXIF FocalLengthIn35mmFilm'` as exifread.utils.Ratio class, and it can't be converted to float. So I added the code to check the instance of the tag.
When `'EXIF FocalLengthIn35mmFilm'` is a decimal, it seems that the focal length is saved as  exifread.utils.Ratio class.