### PR TITLE
feature: add extra steps to yield a point cloud file

### DIFF
--- a/bin/opensfm_run_all
+++ b/bin/opensfm_run_all
@@ -12,4 +12,3 @@ $DIR/opensfm reconstruct $1
 $DIR/opensfm mesh $1
 $DIR/opensfm undistort $1
 $DIR/opensfm compute_depthmaps $1
-$DIR/opensfm export_openmvs $1

--- a/bin/opensfm_run_all
+++ b/bin/opensfm_run_all
@@ -10,3 +10,6 @@ $DIR/opensfm match_features $1
 $DIR/opensfm create_tracks $1
 $DIR/opensfm reconstruct $1
 $DIR/opensfm mesh $1
+$DIR/opensfm undistort $1
+$DIR/opensfm compute_depthmaps $1
+$DIR/opensfm export_openmvs $1


### PR DESCRIPTION
Following #202 and http://blog.mapillary.com/update/2016/10/31/denser-3d-point-clouds-in-opensfm.html I found it valuable to always generate a point cloud at the end of the process.