### PR TITLE
feature: add camera type 'brown' to account for Brown-Conrady optical…

### DIFF
--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -38,7 +38,7 @@ class Command:
         logger.debug('Undistorting the reconstruction')
         undistorted_shots = {}
         for shot in reconstruction.shots.values():
-            if shot.camera.projection_type == 'perspective':
+            if shot.camera.projection_type in ['perspective', 'brown']:
                 urec.add_camera(shot.camera)
                 urec.add_shot(shot)
                 undistorted_shots[shot.id] = [shot]

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -313,7 +313,10 @@ def focal_ratio_calibration(exif):
         return {
             'focal': exif['focal_ratio'],
             'k1': 0.0,
-            'k2': 0.0
+            'k2': 0.0,
+            'p1': 0.0,
+            'p2': 0.0,
+            'k3': 0.0
         }
 
 
@@ -321,7 +324,10 @@ def default_calibration(data):
     return {
         'focal': data.config['default_focal_prior'],
         'k1': 0.0,
-        'k2': 0.0
+        'k2': 0.0,
+        'p1': 0.0,
+        'p2': 0.0,
+        'k3': 0.0
     }
 
 
@@ -338,10 +344,29 @@ def camera_from_exif_metadata(metadata, data):
         camera.id = metadata['camera']
         camera.width = metadata['width']
         camera.height = metadata['height']
-        camera.projection_type = metadata.get('projection_type', 'perspective')
+        camera.projection_type = pt
         camera.focal = calib['focal']
         camera.k1 = calib['k1']
         camera.k2 = calib['k2']
+        camera.focal_prior = calib['focal']
+        camera.k1_prior = calib['k1']
+        camera.k2_prior = calib['k2']
+        return camera
+    elif pt == 'brown':
+        calib = (hard_coded_calibration(metadata)
+                 or focal_ratio_calibration(metadata)
+                 or default_calibration(data))
+        camera = types.BrownPerspectiveCamera()
+        camera.id = metadata['camera']
+        camera.width = metadata['width']
+        camera.height = metadata['height']
+        camera.projection_type = pt
+        camera.focal = calib['focal']
+        camera.k1 = calib['k1']
+        camera.k2 = calib['k2']
+        camera.p1 = calib['p1']
+        camera.p2 = calib['p2']
+        camera.k3 = calib['k3']
         camera.focal_prior = calib['focal']
         camera.k1_prior = calib['k1']
         camera.k2_prior = calib['k2']

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -33,6 +33,24 @@ def camera_from_json(key, obj):
         camera.k1_prior = obj.get('k1_prior', camera.k1)
         camera.k2_prior = obj.get('k2_prior', camera.k2)
         return camera
+    if pt == 'brown':
+        camera = types.BrownPerspectiveCamera()
+        camera.id = key
+        camera.width = obj.get('width', 0)
+        camera.height = obj.get('height', 0)
+        camera.focal = obj['focal']
+        camera.k1 = obj.get('k1', 0.0)
+        camera.k2 = obj.get('k2', 0.0)
+        camera.p1 = obj.get('p1', 0.0)
+        camera.p2 = obj.get('p2', 0.0)
+        camera.k3 = obj.get('k3', 0.0)
+        camera.focal_prior = obj.get('focal_prior', camera.focal)
+        camera.k1_prior = obj.get('k1_prior', camera.k1)
+        camera.k2_prior = obj.get('k2_prior', camera.k2)
+        camera.p1_prior = obj.get('p1_prior', camera.k1)
+        camera.p2_prior = obj.get('p2_prior', camera.k2)
+        camera.k3_prior = obj.get('k3_prior', camera.k1)
+        return camera
     elif pt == 'fisheye':
         camera = types.FisheyeCamera()
         camera.id = key
@@ -173,6 +191,24 @@ def camera_to_json(camera):
             'focal_prior': camera.focal_prior,
             'k1_prior': camera.k1_prior,
             'k2_prior': camera.k2_prior
+        }
+    elif camera.projection_type == 'brown':
+        return {
+            'projection_type': camera.projection_type,
+            'width': camera.width,
+            'height': camera.height,
+            'focal': camera.focal,
+            'k1': camera.k1,
+            'k2': camera.k2,
+            'p1': camera.p1,
+            'p2': camera.p2,
+            'k3': camera.k3,
+            'focal_prior': camera.focal_prior,
+            'k1_prior': camera.k1_prior,
+            'k2_prior': camera.k2_prior,
+            'p1_prior': camera.p1_prior,
+            'p2_prior': camera.p2_prior,
+            'k3_prior': camera.k3_prior
         }
     elif camera.projection_type == 'fisheye':
         return {

--- a/opensfm/mesh.py
+++ b/opensfm/mesh.py
@@ -16,7 +16,7 @@ def triangle_mesh(shot_id, r, graph, data):
 
     shot = r.shots[shot_id]
 
-    if shot.camera.projection_type == 'perspective':
+    if shot.camera.projection_type in ['perspective', 'brown']:
         return triangle_mesh_perspective(shot_id, r, graph)
     elif shot.camera.projection_type == 'fisheye':
         return triangle_mesh_fisheye(shot_id, r, graph)

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -35,6 +35,13 @@ def bundle(graph, reconstruction, gcp, config):
                 str(camera.id), camera.focal, camera.k1, camera.k2,
                 camera.focal_prior, camera.k1_prior, camera.k2_prior,
                 fix_cameras)
+        elif camera.projection_type == 'brown':
+            ba.add_brown_perspective_camera(
+                str(camera.id), camera.focal, camera.k1, camera.k2,
+                camera.p1, camera.p2, camera.k3,
+                camera.focal_prior, camera.k1_prior, camera.k2_prior,
+                camera.p1_prior, camera.p2_prior, camera.k3_prior,
+                fix_cameras)
         elif camera.projection_type == 'fisheye':
             ba.add_fisheye_camera(
                 str(camera.id), camera.focal, camera.k1, camera.k2,
@@ -87,7 +94,10 @@ def bundle(graph, reconstruction, gcp, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_p1_sd', 0.01),
+        config.get('radial_distorsion_p2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
 
     setup = time.time()
 
@@ -103,6 +113,14 @@ def bundle(graph, reconstruction, gcp, config):
             camera.focal = c.focal
             camera.k1 = c.k1
             camera.k2 = c.k2
+        elif camera.projection_type == 'brown':
+            c = ba.get_brown_perspective_camera(str(camera.id))
+            camera.focal = c.focal
+            camera.k1 = c.k1
+            camera.k2 = c.k2
+            camera.p1 = c.p1
+            camera.p2 = c.p2
+            camera.k3 = c.k3
         elif camera.projection_type == 'fisheye':
             c = ba.get_fisheye_camera(str(camera.id))
             camera.focal = c.focal
@@ -135,6 +153,12 @@ def bundle_single_view(graph, reconstruction, shot_id, config):
         ba.add_perspective_camera(
             str(camera.id), camera.focal, camera.k1, camera.k2,
             camera.focal_prior, camera.k1_prior, camera.k2_prior, True)
+    elif camera.projection_type == 'brown':
+        ba.add_brown_perspective_camera(
+            str(camera.id), camera.focal, camera.k1, camera.k2,
+            camera.p1, camera.p2, camera.k3,
+            camera.focal_prior, camera.k1_prior, camera.k2_prior,
+            camera.p1_prior, camera.p2_prior, camera.k3_prior, True)
     elif camera.projection_type == 'fisheye':
         ba.add_fisheye_camera(
             str(camera.id), camera.focal, camera.k1, camera.k2,
@@ -170,10 +194,16 @@ def bundle_single_view(graph, reconstruction, shot_id, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_p1_sd', 0.01),
+        config.get('radial_distorsion_p2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
+
 
     ba.set_num_threads(config['processes'])
     ba.run()
+
+    logger.debug(ba.brief_report())
 
     s = ba.get_shot(str(shot_id))
     shot.pose.rotation = [s.rx, s.ry, s.rz]
@@ -206,7 +236,13 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
                 str(camera.id), camera.focal, camera.k1, camera.k2,
                 camera.focal_prior, camera.k1_prior, camera.k2_prior,
                 True)
-
+        elif camera.projection_type == 'brown':
+            ba.add_brown_perspective_camera(
+                str(camera.id), camera.focal, camera.k1, camera.k2,
+                camera.p1, camera.p2, camera.k3,
+                camera.focal_prior, camera.k1_prior, camera.k2_prior,
+                camera.p1_prior, camera.p2_prior, camera.k3_prior,
+                True)
         elif camera.projection_type in ['equirectangular', 'spherical']:
             ba.add_equirectangular_camera(str(camera.id))
 
@@ -257,7 +293,11 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
     ba.set_internal_parameters_prior_sd(
         config.get('exif_focal_sd', 0.01),
         config.get('radial_distorsion_k1_sd', 0.01),
-        config.get('radial_distorsion_k2_sd', 0.01))
+        config.get('radial_distorsion_k2_sd', 0.01),
+        config.get('radial_distorsion_p1_sd', 0.01),
+        config.get('radial_distorsion_p2_sd', 0.01),
+        config.get('radial_distorsion_k3_sd', 0.01))
+
 
     setup = time.time()
 
@@ -273,7 +313,14 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
             camera.focal = c.focal
             camera.k1 = c.k1
             camera.k2 = c.k2
-
+        elif camera.projection_type == 'brown':
+            c = ba.get_brown_perspective_camera(str(camera.id))
+            camera.focal = c.focal
+            camera.k1 = c.k1
+            camera.k2 = c.k2
+            camera.p1 = c.p1
+            camera.p2 = c.p2
+            camera.k3 = c.k3
     for shot_id in interior:
         shot = reconstruction.shots[shot_id]
         s = ba.get_shot(str(shot.id))

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -84,11 +84,13 @@ BOOST_PYTHON_MODULE(csfm) {
   class_<BundleAdjuster, boost::noncopyable>("BundleAdjuster")
     .def("run", &BundleAdjuster::Run)
     .def("get_perspective_camera", &BundleAdjuster::GetPerspectiveCamera)
+    .def("get_brown_perspective_camera", &BundleAdjuster::GetBrownPerspectiveCamera)
     .def("get_fisheye_camera", &BundleAdjuster::GetFisheyeCamera)
     .def("get_equirectangular_camera", &BundleAdjuster::GetEquirectangularCamera)
     .def("get_shot", &BundleAdjuster::GetShot)
     .def("get_point", &BundleAdjuster::GetPoint)
     .def("add_perspective_camera", &BundleAdjuster::AddPerspectiveCamera)
+    .def("add_brown_perspective_camera", &BundleAdjuster::AddBrownPerspectiveCamera)
     .def("add_fisheye_camera", &BundleAdjuster::AddFisheyeCamera)
     .def("add_equirectangular_camera", &BundleAdjuster::AddEquirectangularCamera)
     .def("add_shot", &BundleAdjuster::AddShot)
@@ -120,6 +122,18 @@ BOOST_PYTHON_MODULE(csfm) {
     .def_readwrite("constant", &BAPerspectiveCamera::constant)
     .def_readwrite("focal_prior", &BAPerspectiveCamera::focal_prior)
     .def_readwrite("id", &BAPerspectiveCamera::id)
+  ;
+
+  class_<BABrownPerspectiveCamera>("BABrownPerspectiveCamera")
+    .add_property("focal", &BABrownPerspectiveCamera::GetFocal, &BABrownPerspectiveCamera::SetFocal)
+    .add_property("k1", &BABrownPerspectiveCamera::GetK1, &BABrownPerspectiveCamera::SetK1)
+    .add_property("k2", &BABrownPerspectiveCamera::GetK2, &BABrownPerspectiveCamera::SetK2)
+    .add_property("p1", &BABrownPerspectiveCamera::GetP1, &BABrownPerspectiveCamera::SetP1)
+    .add_property("p2", &BABrownPerspectiveCamera::GetP2, &BABrownPerspectiveCamera::SetP2)
+    .add_property("k3", &BABrownPerspectiveCamera::GetK3, &BABrownPerspectiveCamera::SetK3)
+    .def_readwrite("constant", &BABrownPerspectiveCamera::constant)
+    .def_readwrite("focal_prior", &BABrownPerspectiveCamera::focal_prior)
+    .def_readwrite("id", &BABrownPerspectiveCamera::id)
   ;
 
   class_<BAFisheyeCamera>("BAFisheyeCamera")


### PR DESCRIPTION
Following the discussion in PR #225 here is a possible implementation of the 5 distortion parameters (Brown-Conrady) model that OpenCV also supports: K1, K2, P1, P2, K3.

This addresses Issue #165.

@lamerman @paulinus There is a problem somewhere in the bundle adjustment that causes this not to converge to a solution.  I've spent some time debugging it bug I can't seem to find the issue so I thought to put it up and ask because you both seem to have some experience with Ceres.

