### PR TITLE
Angular threshold

### DIFF
--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -57,6 +57,7 @@ preemptive_threshold: 0               # If number of matches passes the threshol
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004      # Outlier threshold for fundamental matrix estimation as portion of image width
+robust_matching_calib_threshold: 0.01 # Outlier threshold for essential matrix estimation in radians
 robust_matching_min_match: 20         # Minimum number of matches to be considered as an edge in the match graph
 five_point_algo_threshold: 0.004      # Outlier threshold (in pixels) for essential matrix estimation
 five_point_algo_min_inliers: 20       # Minimum number of inliers for considering a two view reconstruction valid.

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -56,15 +56,15 @@ preemptive_max: 200                   # Number of features to use for preemptive
 preemptive_threshold: 0               # If number of matches passes the threshold -> full feature matching
 
 # Params for geometric estimation
-robust_matching_threshold: 0.004      # Outlier threshold for fundamental matrix estimation as portion of image width
-robust_matching_calib_threshold: 0.01 # Outlier threshold for essential matrix estimation in radians
-robust_matching_min_match: 20         # Minimum number of matches to be considered as an edge in the match graph
-five_point_algo_threshold: 0.004      # Outlier threshold (in pixels) for essential matrix estimation
-five_point_algo_min_inliers: 20       # Minimum number of inliers for considering a two view reconstruction valid.
-triangulation_threshold: 0.006        # Outlier threshold (in pixels) for accepting a triangulated point.
+robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width
+robust_matching_calib_threshold: 0.004  # Outlier threshold for essential matrix estimation in radians
+robust_matching_min_match: 20           # Minimum number of matches to be considered as an edge in the match graph
+five_point_algo_threshold: 0.004        # Outlier threshold (in pixels) for essential matrix estimation
+five_point_algo_min_inliers: 20         # Minimum number of inliers for considering a two view reconstruction valid.
+triangulation_threshold: 0.006          # Outlier threshold (in pixels) for accepting a triangulated point.
 triangulation_min_ray_angle: 1.0
-resection_threshold: 0.004            # Outlier threshold (in pixels) for camera resection.
-resection_min_inliers: 10             # Minimum number of resection inliers to accept it.
+resection_threshold: 0.004              # Outlier threshold (in pixels) for camera resection.
+resection_min_inliers: 10               # Minimum number of resection inliers to accept it.
 retriangulation: no
 retriangulation_ratio: 1.25
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -9,6 +9,7 @@ from itertools import combinations
 from six import iteritems
 
 from opensfm import context
+from opensfm import multiview
 from opensfm.unionfind import UnionFind
 
 
@@ -109,8 +110,7 @@ def robust_match_fundamental(p1, p2, matches, config):
 
     return matches[inliers]
 
-
-def _compute_inliers_bearings(b1, b2, T):
+def _compute_inliers_bearings(b1, b2, T, threshold=0.01):
     R = T[:, :3]
     t = T[:, 3]
     p = pyopengv.triangulation_triangulate(b1, b2, t, R)
@@ -121,8 +121,8 @@ def _compute_inliers_bearings(b1, b2, T):
     br2 = R.T.dot((p - t).T).T
     br2 /= np.linalg.norm(br2, axis=1)[:, np.newaxis]
 
-    ok1 = np.linalg.norm(br1 - b1, axis=1) < 0.01   # TODO(pau): compute angular error and use proper threshold
-    ok2 = np.linalg.norm(br2 - b2, axis=1) < 0.01
+    ok1 = multiview.vector_angle(br1, b1) < threshold
+    ok2 = multiview.vector_angle(br2, b2) < threshold
     return ok1 * ok2
 
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -110,6 +110,7 @@ def robust_match_fundamental(p1, p2, matches, config):
 
     return matches[inliers]
 
+
 def _compute_inliers_bearings(b1, b2, T, threshold=0.01):
     R = T[:, :3]
     t = T[:, 3]

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -137,10 +137,10 @@ def robust_match_calibrated(p1, p2, camera1, camera2, matches, config):
     b1 = camera1.pixel_bearing_many(p1)
     b2 = camera2.pixel_bearing_many(p2)
 
-    threshold = config['robust_matching_threshold']
+    threshold = config['robust_matching_calib_threshold']
     T = pyopengv.relative_pose_ransac(b1, b2, "STEWENIUS", 1 - np.cos(threshold), 1000)
 
-    inliers = _compute_inliers_bearings(b1, b2, T)
+    inliers = _compute_inliers_bearings(b1, b2, T, threshold)
 
     return matches[inliers]
 


### PR DESCRIPTION
This needs reviewing as it changes the default behavior of robust_match_calibrated:

Before:
- ransac was run with a threshold of 0.004 (default value of
  robust_matching_threshold)
- inliers were filtered with a threshold of 0.01 (fixed)

After:
- ransac and inliers use a threshold of 0.01 (default value of a new
  parameter: robust_matching_calib_threshold)

It depends on #285 and branch 'vectorizations'