### PR TITLE
Fixed GCP UTM south region parser typo

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -387,7 +387,7 @@ def _parse_utm_projection_string(line):
         zone_number = int(zone[:-1])
         zone_hemisphere = 'north'
     elif zone[-1] == 'S':
-        zone_number = int(zone['-1'])
+        zone_number = int(zone[:-1])
         zone_hemisphere = 'south'
     else:
         zone_number = int(zone)


### PR DESCRIPTION
A typo is causing GCP files with a UTM projection in the southern regions (ex. `WGS84 UTM 32S`) to fail with `zone_number = int(zone['-1']) TypeError: string indices must be integers, not str`.

First reported here: http://community.opendronemap.org/t/problem-using-a-gcp-file-in-the-southern-hemisphere-wgs84-utm-36s/495
