### PR TITLE
fix  #262: update plot_inliers with newer TrackTriangulator api

### DIFF
--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -584,7 +584,6 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
     """
 
     print_reset = redirect_print()
-    # reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2, p1, p2)
     reconstruction = find_reconstruction([ip.im1, ip.im2], data)
     reset_print(print_reset)
 

--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -240,10 +240,11 @@ def triangulate_tracks(tracks, reconstruction, graph, min_ray_angle):
     :return: An array of booleans determining if each track was successfully triangulated or not.
     """
     succeeded = []
+    triangulator = reconstruct.TrackTriangulator(graph, reconstruction)
 
     for track in tracks:
         # Triangulate with 1 as reprojection threshold to avoid excluding tracks because of error.
-        reconstruct.triangulate_track(str(track), graph, reconstruction, {}, 1, min_ray_angle)
+        triangulator.triangulate(str(track), 1, min_ray_angle)
         succeeded.append(True) if str(track) in reconstruction.points else succeeded.append(False)
 
     return np.array(succeeded) if len(succeeded) else np.empty((0,), bool)
@@ -583,7 +584,8 @@ def plot_bootstrapped_reconstruction(fw, ip, index, p1, p2, robust_tracks, linke
     """
 
     print_reset = redirect_print()
-    reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2)
+    # reconstruction = reconstruct.bootstrap_reconstruction(data, graph, ip.im1, ip.im2, p1, p2)
+    reconstruction = find_reconstruction([ip.im1, ip.im2], data)
     reset_print(print_reset)
 
     threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'triangulation_threshold', 0.004, data)


### PR DESCRIPTION
fix #262
I mimic the usage from the new version of TrackTriangulator api, here are the newer version of plot_inliers.
some results produced by running commands `./bin/plot_inliers ./data/berlin 01.jpg 02.jpg --save_figs`, you can check it correct or not.

![01 jpg_02 jpg_root_hahog_matches](https://user-images.githubusercontent.com/4838354/38794233-f95b3d16-4186-11e8-851b-95df3b9907a4.jpg)
![01 jpg_02 jpg_root_hahog_reconstruction](https://user-images.githubusercontent.com/4838354/38794242-fe6d7f76-4186-11e8-971d-f82ecacf2ecf.jpg)
![01 jpg_02 jpg_root_hahog_tracks](https://user-images.githubusercontent.com/4838354/38794247-026c1e52-4187-11e8-9120-65f20d282429.jpg)

