### PR TITLE
Link segmentations and masks in submodel folders

### DIFF
--- a/bin/plot_submodels_gps
+++ b/bin/plot_submodels_gps
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     fig = pl.figure(figsize=(20, 15))
 
     if args.mode == 'clusters' or args.mode == 'centers':
-        positions, labels, centers = meta_data.load_clusters()[1:]
+        _, positions, labels, centers = meta_data.load_clusters()
         if args.mode == 'clusters':
             centers = None
 
@@ -100,7 +100,7 @@ if __name__ == '__main__':
         set_gps_labels(fig)
     elif args.mode == 'hist':
         labels = meta_data.load_clusters()[2]
-        cl_count = np.bincount(labels.ravel())
+        cl_count = np.bincount(labels)
         nb_count = []
         for cluster in meta_data.load_clusters_with_neighbors():
             nb_count.append(len(cluster))

--- a/doc/source/large.rst
+++ b/doc/source/large.rst
@@ -46,15 +46,15 @@ The submodels are created inside the ``submodels`` folder.  Each submodel folder
         ├── clusters.npz
         ├── image_list_with_gps.tsv
         ├── submodel_0000/
-            │   ├── image_list.txt        # images of submodel_0000
-            │   ├── config.yaml           # copy from global equivalent
-            │   ├── images/               # link to global equivalent
-            │   ├── exif/                 # link to global equivalent
-            │   ├── features/             # link to global equivalent
-            │   ├── matches/              # link to global equivalent
-            │   ├── camera_models.json    # link to global equivalent
-            │   └── reference_lla.json    # link to global equivalent
-            └── submodel_0001/
+        │   ├── image_list.txt        # images of submodel_0000
+        │   ├── config.yaml           # copy from global equivalent
+        │   ├── images/               # link to global equivalent
+        │   ├── exif/                 # link to global equivalent
+        │   ├── features/             # link to global equivalent
+        │   ├── matches/              # link to global equivalent
+        │   ├── camera_models.json    # link to global equivalent
+        │   └── reference_lla.json    # link to global equivalent
+        ├── submodel_0001/
         └── ...
 
 Config parameters

--- a/doc/source/large.rst
+++ b/doc/source/large.rst
@@ -82,9 +82,6 @@ The folder structure of the submodels can also be controlled using the following
 - ``submodel_images_relpath_template``
   Template to generate the relative path to a submodel images directory.
 
-- ``submodel_use_symlinks``
-  When true, global features and matches will be symlinked in each submodel so that they can be reused.  When false, features and matches will need to be run for each submodel.
-
 Providing the image groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``create_submodels`` command clusters images into groups to decide the partition into submodels.  If you already know how you want to split the dataset, you can provide that information and it will be used instead of the clustering algorithm.

--- a/opensfm/commands/create_submodels.py
+++ b/opensfm/commands/create_submodels.py
@@ -34,8 +34,7 @@ class Command:
         self._save_cluster_neighbors_geojson(meta_data)
 
         meta_data.create_submodels(
-            meta_data.load_clusters_with_neighbors(),
-            not data.config['submodel_use_symlinks'])
+            meta_data.load_clusters_with_neighbors())
 
     def _create_image_list(self, data, meta_data):
         ills = []

--- a/opensfm/commands/create_submodels.py
+++ b/opensfm/commands/create_submodels.py
@@ -77,7 +77,7 @@ class Command:
             centers[label, 1] += lon
             centers_count[label] += 1
 
-        images = np.array(images).reshape((len(images), 1))
+        images = np.array(images)
         positions = np.array(positions, np.float32)
         labels = np.array(labels)
         centers /= centers_count
@@ -98,6 +98,9 @@ class Command:
         K = int(np.ceil(K))
 
         labels, centers = tools.kmeans(positions, K)[1:]
+
+        images = images.ravel()
+        labels = labels.ravel()
 
         meta_data.save_clusters(images, positions, labels, centers)
 
@@ -145,10 +148,7 @@ class Command:
 
         features = []
         images, positions, labels, centers = meta_data.load_clusters()
-        for inum in np.arange(images.shape[0]):
-            image = images[inum][0]
-            image_label = int(labels[inum][0])
-
+        for image, label in zip(images, labels):
             features.append({
                 "type": "Feature",
                 "geometry": {
@@ -157,7 +157,7 @@ class Command:
                 },
                 "properties": {
                     "name": image,
-                    "submodel": image_label  # cluster_idx
+                    "submodel": int(label)  # cluster_idx
                 }
             })
         geojson = {

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -128,13 +128,11 @@ depthmap_save_debug_files: no         # Save debug files with partial reconstruc
 processes: 1                  # Number of threads to use
 
 # Params for submodel split and merge
-submodel_size: 80                                                                   # Average number of images per submodel
-submodel_overlap: 30.0                                                              # Radius of the overlapping region between submodels
-submodels_relpath: "submodels"                                                      # Relative path to the submodels directory
-submodel_relpath_template: "submodels/submodel_%04d"                                # Template to generate the relative path to a submodel directory
-submodel_images_relpath_template: "submodels/submodel_%04d/images"                  # Template to generate the relative path to a submodel images directory
-submodel_masks_relpath_template: "submodels/submodel_%04d/masks"                    # Template to generate the relative path to a submodel masks directory
-submodel_use_symlinks: yes                                                          # Symlink global features and matches to be reused on each submodel
+submodel_size: 80                                                    # Average number of images per submodel
+submodel_overlap: 30.0                                               # Radius of the overlapping region between submodels
+submodels_relpath: "submodels"                                       # Relative path to the submodels directory
+submodel_relpath_template: "submodels/submodel_%04d"                 # Template to generate the relative path to a submodel directory
+submodel_images_relpath_template: "submodels/submodel_%04d/images"   # Template to generate the relative path to a submodel images directory
 '''
 
 

--- a/opensfm/dense.py
+++ b/opensfm/dense.py
@@ -271,7 +271,7 @@ def load_combined_mask(data, shot):
     """
     mask = data.load_undistorted_combined_mask(shot.id)
     if mask is None:
-        size = shot.camera.height, shot.camera.width
+        size = int(shot.camera.height), int(shot.camera.width)
         return np.ones(size, dtype=np.uint8)
     else:
         return mask

--- a/opensfm/large/metadataset.py
+++ b/opensfm/large/metadataset.py
@@ -59,15 +59,17 @@ class MetaDataSet():
     def _clusters_geojson_path(self):
         return os.path.join(self._submodels_path(), self._clusters_geojson_file_name)
 
-    def _create_symlink(self, base_path, dir_name):
-        link_path = os.path.join(base_path, dir_name)
+    def _create_symlink(self, base_path, filename):
+        src = os.path.join(self.data_path, filename)
+        dst = os.path.join(base_path, filename)
 
-        if os.path.islink(link_path):
-            os.unlink(link_path)
+        if not os.path.exists(src):
+            return
 
-        os.symlink(
-            os.path.relpath(os.path.join(self.data_path, dir_name), base_path),
-            os.path.join(link_path))
+        if os.path.islink(dst):
+            os.unlink(dst)
+
+        os.symlink(os.path.relpath(src, base_path), dst)
 
     def image_groups_exists(self):
         return os.path.isfile(self._image_groups_path())

--- a/opensfm/large/metadataset.py
+++ b/opensfm/large/metadataset.py
@@ -104,7 +104,9 @@ class MetaDataSet():
 
     def load_clusters(self):
         c = np.load(self._clusters_path())
-        return c['images'], c['positions'], c['labels'], c['centers']
+        images = c['images'].ravel()
+        labels = c['labels'].ravel()
+        return images, c['positions'], labels, c['centers']
 
     def save_clusters_with_neighbors(self, clusters):
         filepath = self._clusters_with_neighbors_path()

--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -36,13 +36,8 @@ def add_cluster_neighbors(positions, labels, centers, max_distance):
     topocentrics = []
     for position in positions:
         x, y, z = geo.topocentric_from_lla(
-            position[0],
-            position[1],
-            0,
-            reference[0],
-            reference[1],
-            0)
-
+            position[0], position[1], 0,
+            reference[0], reference[1], 0)
         topocentrics.append([x, y])
 
     topocentrics = np.array(topocentrics)
@@ -50,7 +45,7 @@ def add_cluster_neighbors(positions, labels, centers, max_distance):
 
     clusters = []
     for label in np.arange(centers.shape[0]):
-        cluster_indices = np.where(labels.ravel() == label)[0]
+        cluster_indices = np.where(labels == label)[0]
 
         neighbors = []
         for i in cluster_indices:


### PR DESCRIPTION
When creating submodels, links to the root masks and segmentation folders are created so that they can be used during the reconstruction of the submodels.