### PR TITLE
Added ability to undistort to PNG, scale images

### DIFF
--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -19,6 +19,7 @@ class Command:
         parser.add_argument('--undistorted',
                             action='store_true',
                             help='export the undistorted reconstruction')
+        parser.add_argument('--image_extension', choices=["jpg", "png"], default="jpg", type=str, help='Extension of images. Default: %(default)s')
         parser.add_argument('--scale_focal', default=1.0, type=float, help='Scale the focal length by this value. Default: %(default)s (no scale)')
 
     def run(self, args):
@@ -31,15 +32,15 @@ class Command:
             graph = data.load_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.scale_focal)
+            self.export(reconstructions[0], graph, data, args.image_extension, args.scale_focal)
 
-    def export(self, reconstruction, graph, data, scale_focal = 1.0):
+    def export(self, reconstruction, graph, data, image_extension = 'jpg', scale_focal = 1.0):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
             words = [
-                self.image_path(shot.id, data),
+                self.image_path(shot.id, data, image_extension),
                 shot.camera.focal * max(shot.camera.width, shot.camera.height) * scale_focal,
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
@@ -51,13 +52,7 @@ class Command:
         with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data):
+    def image_path(self, image, data, extension):
         """Path to the undistorted image relative to the dataset path."""
-        extensions = ['png', 'jpg']
-        for extension in extensions:
-            path = data._undistorted_image_file(image, extension)
-            if os.path.exists(path) or extension == extensions[-1]:
-                return os.path.relpath(path, data.data_path)
-                
-
-         
+        path = data._undistorted_image_file(image, extension)
+        return os.path.relpath(path, data.data_path)

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -19,7 +19,6 @@ class Command:
         parser.add_argument('--undistorted',
                             action='store_true',
                             help='export the undistorted reconstruction')
-        parser.add_argument('--image_extension', choices=["jpg", "png"], default="jpg", type=str, help='Extension of images. Default: %(default)s')
         parser.add_argument('--scale_focal', default=1.0, type=float, help='Scale the focal length by this value. Default: %(default)s (no scale)')
 
     def run(self, args):
@@ -32,15 +31,15 @@ class Command:
             graph = data.load_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.image_extension, args.scale_focal)
+            self.export(reconstructions[0], graph, data, args.scale_focal)
 
-    def export(self, reconstruction, graph, data, image_extension = 'jpg', scale_focal = 1.0):
+    def export(self, reconstruction, graph, data, scale_focal = 1.0):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
             words = [
-                self.image_path(shot.id, data, image_extension),
+                self.image_path(shot.id, data),
                 shot.camera.focal * max(shot.camera.width, shot.camera.height) * scale_focal,
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
@@ -52,7 +51,13 @@ class Command:
         with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data, extension):
+    def image_path(self, image, data):
         """Path to the undistorted image relative to the dataset path."""
-        path = data._undistorted_image_file(image, extension)
-        return os.path.relpath(path, data.data_path)
+        extensions = ['png', 'jpg']
+        for extension in extensions:
+            path = data._undistorted_image_file(image, extension)
+            if os.path.exists(path) or extension == extensions[-1]:
+                return os.path.relpath(path, data.data_path)
+                
+
+         

--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -116,7 +116,7 @@ def undistort_image(arguments):
         new_camera = undistorted_shots[0].camera
         uf = undistort_function[projection_type]
         undistorted = uf(image, shot.camera, new_camera, interpolation)
-        undistorted = scale_image(undistorted, interpolation, image_scale)
+        undistorted = scale_image(undistorted, image_scale)
         getattr(data, save_image)(shot.id, undistorted, image_format)
     elif projection_type in ['equirectangular', 'spherical']:
         original = getattr(data, load_image)(shot.id)
@@ -130,7 +130,7 @@ def undistort_image(arguments):
             undistorted = render_perspective_view_of_a_panorama(
                 image, shot, subshot,
                 cv2.INTER_LINEAR if interpolation == cv2.INTER_AREA else interpolation)
-            undistorted = scale_image(undistorted, interpolation, image_scale)
+            undistorted = scale_image(undistorted, image_scale)
             getattr(data, save_image)(subshot.id, undistorted, image_format)
     else:
         raise NotImplementedError(
@@ -138,7 +138,7 @@ def undistort_image(arguments):
                 shot.camera.projection_type))
 
 
-def scale_image(image, interpolation, scale_factor):
+def scale_image(image, scale_factor):
     """Scale an image by a factor."""
     if scale_factor == 1.0:
         return image
@@ -146,7 +146,7 @@ def scale_image(image, interpolation, scale_factor):
     height, width, _ = image.shape
     width = int(width * scale_factor)
     height = int(height * scale_factor)
-    return cv2.resize(image, (width, height), interpolation=interpolation)
+    return cv2.resize(image, (width, height), interpolation=cv2.INTER_NEAREST)
 
 
 def undistort_perspective_image(image, camera, new_camera, interpolation):

--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -125,7 +125,6 @@ def undistort_image(arguments):
         subshot_width = int(data.config['depthmap_resolution'])
         width = 4 * subshot_width
         height = width // 2
-
         image = cv2.resize(original, (width, height), interpolation=interpolation)
         for subshot in undistorted_shots:
             undistorted = render_perspective_view_of_a_panorama(

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -76,17 +76,17 @@ class DataSet:
     def _undistorted_image_path(self):
         return os.path.join(self.data_path, 'undistorted')
 
-    def _undistorted_image_file(self, image):
+    def _undistorted_image_file(self, image, extension = 'jpg'):
         """Path of undistorted version of an image."""
-        return os.path.join(self._undistorted_image_path(), image + '.jpg')
+        return os.path.join(self._undistorted_image_path(), image + '.' + extension)
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
         return io.imread(self._undistorted_image_file(image))
 
-    def save_undistorted_image(self, image, array):
+    def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())
-        cv2.imwrite(self._undistorted_image_file(image), array[:, :, ::-1])
+        cv2.imwrite(self._undistorted_image_file(image, image_format), array[:, :, ::-1])
 
     def _load_mask_list(self):
         """Load mask list from mask_list.txt or list masks/ folder."""

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -82,11 +82,7 @@ class DataSet:
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
-        for extension in ['jpg', 'png']:
-            if os.path.exists(self._undistorted_image_file(image, extension)):
-                return io.imread(self._undistorted_image_file(image, extension))
-        
-        raise OSError("Cannot read image {}. File does not exist.".format(image))
+        return io.imread(self._undistorted_image_file(image))
 
     def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -82,7 +82,11 @@ class DataSet:
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
-        return io.imread(self._undistorted_image_file(image))
+        for extension in ['jpg', 'png']:
+            if os.path.exists(self._undistorted_image_file(image, extension)):
+                return io.imread(self._undistorted_image_file(image, extension))
+        
+        raise OSError("Cannot read image {}. File does not exist.".format(image))
 
     def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())


### PR DESCRIPTION
Hello :hand:

This PR proposes a modification to the undistort command to optionally allow a user to export images in PNG format and optionally scale the images before saving them to disk.

It also modifies the export_visualsfm command to optionally allow a user to choose the extension that the NVM file should reference (to be used in combination with the undistort command) and optionally scale the focal length value (which is useful if we have resized the images to perform further processing / visualization with external programs).

Other export commands haven't been modified, but if I need to modify them as well to provide better consistency, just ask, I'd be happy to.

```
usage: opensfm undistort [-h] [--image_format {jpg,png}]
                         [--image_scale IMAGE_SCALE]
                         dataset
usage: opensfm export_visualsfm [-h] [--undistorted]
                                [--image_extension {jpg,png}]
                                [--scale_focal SCALE_FOCAL]
                                dataset
```
The behavior of both programs is unchanged if the user leaves the defaults.

I hope these changes can be helpful to other users. If the proposed changes don't fit into the scope of OpenSfM I can always create a separate module, but I thought I'd share the work to see if there was interest in merging this in.

Thank you!