### PR TITLE
Points projections & Viewer features

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -126,9 +126,7 @@ def measurement_from_json(obj):
     """
     Read a measurement from a json object
     """
-    return types.Measurement(obj["coordinates"],
-                             obj["std_deviation"],
-                             obj["confidence"])
+    return types.Measurement(obj["coordinates"])
 
 
 def point_from_json(key, obj):
@@ -304,11 +302,7 @@ def measurement_to_json(measurement):
     """
     Write a measurement to a json object
     """
-    return {
-        'coordinates': list(measurement.coordinates),
-        'std_deviation': list(measurement.std_deviation),
-        'confidence': measurement.confidence
-    }
+    return {'coordinates': list(measurement.coordinates)}
 
 
 def point_to_json(point):

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -122,6 +122,15 @@ def shot_from_json(key, obj, cameras):
     return shot
 
 
+def measurement_from_json(obj):
+    """
+    Read a measurement from a json object
+    """
+    return types.Measurement(obj["coordinates"],
+                             obj["std_deviation"],
+                             obj["confidence"])
+
+
 def point_from_json(key, obj):
     """
     Read a point from a json object
@@ -132,6 +141,9 @@ def point_from_json(key, obj):
     point.coordinates = obj["coordinates"]
     if "reprojection_error" in obj:
         point.reprojection_error = obj["reprojection_error"]
+    if "measurements" in obj:
+        for key, value in iteritems(obj['measurements']):
+            point.measurements[key] = measurement_from_json(value)
     return point
 
 
@@ -288,6 +300,17 @@ def shot_to_json(shot):
     return obj
 
 
+def measurement_to_json(measurement):
+    """
+    Write a measurement to a json object
+    """
+    return {
+        'coordinates': list(measurement.coordinates),
+        'std_deviation': list(measurement.std_deviation),
+        'confidence': measurement.confidence
+    }
+
+
 def point_to_json(point):
     """
     Write a point to a json object
@@ -295,7 +318,9 @@ def point_to_json(point):
     return {
         'color': list(point.color),
         'coordinates': list(point.coordinates),
-        'reprojection_error': point.reprojection_error
+        'reprojection_error': point.reprojection_error,
+        'measurements': {k: measurement_to_json(v)
+                         for k, v in point.measurements.items()}
     }
 
 

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -826,7 +826,7 @@ class TrackTriangulator:
                 b = shot.camera.pixel_bearing(np.array(x))
                 r = self._shot_rotation_inverse(shot)
                 bs.append(r.dot(b))
-                measurements[shot_id] = types.Measurement(x, [1, 1, 1], 1)
+                measurements[shot_id] = types.Measurement(x)
 
         if len(os) >= 2:
             e, X = csfm.triangulate_bearings_midpoint(
@@ -848,7 +848,7 @@ class TrackTriangulator:
                 x = self.graph[track][shot_id]['feature']
                 b = shot.camera.pixel_bearing(np.array(x))
                 bs.append(b)
-                measurements[shot_id] = types.Measurement(x, [1, 1, 1], 1)
+                measurements[shot_id] = types.Measurement(x)
 
         if len(Rts) >= 2:
             e, X = csfm.triangulate_bearings_dlt(

--- a/opensfm/test/test_io.py
+++ b/opensfm/test/test_io.py
@@ -21,6 +21,17 @@ def test_reconstructions_from_json():
     assert len(reconstructions[0].points) == 1588
 
 
+def test_json_reconstruction_consistency():
+    with open(filename) as fin:
+        reconstructions_before = io.reconstructions_to_json(
+            io.reconstructions_from_json(json.loads(fin.read())))
+
+    reconstructions_after = io.reconstructions_to_json(
+        io.reconstructions_from_json(reconstructions_before))
+
+    assert reconstructions_before == reconstructions_after
+
+
 def test_reconstruction_to_ply():
     with open(filename) as fin:
         obj = json.loads(fin.read())

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -652,14 +652,9 @@ class Measurement(object):
 
     Attributes:
         coordinates (list(real)): list containing the measured data
-        std_deviation (list(real)): list containing the standard deviation
-        of the measured data
-        confidence (real): [0,1] measure that the measurement is good (1 value)
     """
-    def __init__(self, coordinates, std_deviation, confidence):
+    def __init__(self, coordinates):
         self.coordinates = coordinates
-        self.std_deviation = std_deviation
-        self.confidence = confidence
 
 
 class Point(object):

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -643,6 +643,25 @@ class Shot(object):
         return self.pose.get_rotation_matrix().T.dot([0, 0, 1])
 
 
+class Measurement(object):
+    """Defines a measured quantity.
+
+    It is anything that is measured in the real world
+    and is used as input for the reconstruction, such a
+    2D feature, a ground control point or GPS/IMU value.
+
+    Attributes:
+        coordinates (list(real)): list containing the measured data
+        std_deviation (list(real)): list containing the standard deviation
+        of the measured data
+        confidence (real): [0,1] measure that the measurement is good (1 value)
+    """
+    def __init__(self, coordinates, std_deviation, confidence):
+        self.coordinates = coordinates
+        self.std_deviation = std_deviation
+        self.confidence = confidence
+
+
 class Point(object):
     """Defines a 3D point.
 
@@ -651,6 +670,8 @@ class Point(object):
         color (list(int)): list containing the RGB values.
         coordinates (list(real)): list containing the 3D position.
         reprojection_error (real): the reprojection error.
+        measurements (Dict(Measurement)): list of measured 2D positions
+        indexed by images they're seen into
     """
 
     def __init__(self):
@@ -659,6 +680,7 @@ class Point(object):
         self.color = None
         self.coordinates = None
         self.reprojection_error = None
+        self.measurements = {}
 
 
 class GroundControlPointObservation(object):

--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -256,6 +256,7 @@
             var point_clouds = [];
             var camera_lines = [];
             var gps_lines = [];
+            var graph_lines = [];
             var imagePlanes = [];
             var imagePlaneCameras = [];
             var imageMaterials = [];
@@ -272,7 +273,8 @@
                 showThumbnail: false,
                 showImagePlane: true,
                 drawGrid: false,
-                drawGPS: false
+                drawGPS: false,
+                showGraph: false
             };
 
             var options = {
@@ -284,6 +286,7 @@
                 showImagePlane: false,
                 drawGrid: true,
                 drawGPS: false,
+                showGraph: false,
                 animationSpeed: 0.1,
                 imagePlaneOpacity: 1,
                 background_color: 0x202020,
@@ -351,6 +354,9 @@
                 f1.add(options, 'drawGPS')
                     .listen()
                     .onChange(setDrawGPS);
+                f1.add(options, 'showGraph')
+                    .listen()
+                    .onChange(setShowGraph);
                 f1.open();
 
 
@@ -453,6 +459,14 @@
                 render();
             }
 
+            function setShowGraph(value) {
+                options.showGraph = value;
+                for (var i = 0; i < graph_lines.length; ++i) {
+                    graph_lines[i].visible = value;
+                }
+                render();
+            }
+
             function setMovingMode(mode) {
                 if (mode != movingMode) {
                     movingMode = mode;
@@ -497,7 +511,8 @@
                     showThumbnail: savedOptions.showThumbnail,
                     showImagePlane: savedOptions.showImagePlane,
                     drawGrid: savedOptions.drawGrid,
-                    drawGPS: savedOptions.drawGPS
+                    drawGPS: savedOptions.drawGPS,
+                    showGraph: savedOptions.showGraph
                 };
 
                 savedOptions.pointSize = options.pointSize;
@@ -507,6 +522,7 @@
                 savedOptions.showImagePlane = options.showImagePlane;
                 savedOptions.drawGrid = options.drawGrid;
                 savedOptions.drawGPS = options.drawGPS;
+                savedOptions.showGraph = options.showGraph;
 
                 setPointSize(tmpOptions.pointSize);
                 setPointLength(tmpOptions.pointLength);
@@ -515,6 +531,7 @@
                 setShowImagePlane(tmpOptions.showImagePlane);
                 setDrawGrid(tmpOptions.drawGrid);
                 setDrawGPS(tmpOptions.drawGPS);
+                setShowGraph(tmpOptions.showGraph);
             }
 
             function imageURL(shot_id) {
@@ -898,6 +915,63 @@
                                 gps_lines.push(line);
                             }
                         }
+                    }
+                    
+                    // Camera graph
+                    camera_graph = {};
+                    for(var point_id in reconstruction.points){
+                        var point = reconstruction.points[point_id];
+                        if (!point.hasOwnProperty('measurements')) {
+                            continue;
+                        }
+
+                        sorted = Object.keys(point.measurements).sort()
+                        for(var i = 0; i < sorted.length; ++i){
+                            var shot1 = sorted[i];
+                            for(var j = i+1; j < sorted.length; ++j){
+                                var shot2 = sorted[j];
+                                var shot_pair = shot1 + '/' + shot2;
+                                if(camera_graph[shot_pair] == undefined){
+                                    camera_graph[shot_pair] = 1;
+                                }
+                                else{
+                                    camera_graph[shot_pair] += 1;
+                                }
+                            }
+                        }
+                    }
+                    
+                    var sorted_edges = Object.keys(camera_graph).sort(function(a, b){
+                         if( camera_graph[a] < camera_graph[b])return -1;
+                         if( camera_graph[a] > camera_graph[b])return 1;
+                         return 0;});
+                    var big_ratio = 0.9;
+                    var big_index = Math.floor(big_ratio*(sorted_edges.length-1));
+                    var normalizer = 1.0/camera_graph[sorted_edges[big_index]];
+                    var min_line_width = 1;
+                    var max_line_width = 6;
+                    for(var i = 0; i < sorted_edges.length; ++i){
+                        var shot_pair = sorted_edges[i];
+                        var shot1 = opticalCenter(reconstruction.shots[shot_pair.split('/')[0]]);
+                        var shot2 = opticalCenter(reconstruction.shots[shot_pair.split('/')[1]]);
+
+                        var edge = camera_graph[shot_pair];
+                        if(edge < 20){
+                            continue;
+                        }
+                        var edge_value = edge*normalizer;
+                        var edge_color = new THREE.Color();
+                        edge_color.setRGB(1-edge_value, edge_value, 0);
+
+                        var linegeo = new THREE.Geometry();
+                        linegeo.vertices.push(shot1, shot2);
+                        var lineMaterial = new THREE.LineBasicMaterial(
+                            { color: edge_color, 
+                            linewidth: min_line_width +(max_line_width-min_line_width)*edge_value });
+                        var line = new THREE.Line(linegeo, lineMaterial, THREE.LinePieces);
+                        line.visible = options.showGraph;
+                        group.add(line);
+                        graph_lines.push(line);
                     }
 
                     scene_group.add(group);

--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -268,6 +268,7 @@
             var savedOptions = {
                 cameraSize: 0,
                 pointSize: 0,
+                pointLength: 2,
                 showThumbnail: false,
                 showImagePlane: true,
                 drawGrid: false,
@@ -277,6 +278,7 @@
             var options = {
                 cameraSize: 0.9,
                 pointSize: 0.7,
+                pointLength: 2,
                 imagePlaneSize: 50,
                 showThumbnail: true,
                 showImagePlane: false,
@@ -284,6 +286,7 @@
                 drawGPS: false,
                 animationSpeed: 0.1,
                 imagePlaneOpacity: 1,
+                background_color: 0x202020,
                 cameraColor: new THREE.Color(0xFFFFFF),
                 hoverCameraColor: new THREE.Color(0xFF8888),
                 selectedCameraColor: new THREE.Color(0xFFFF88),
@@ -316,6 +319,9 @@
                 f1.add(options, 'pointSize', 0, 2)
                     .listen()
                     .onChange(setPointSize);
+                f1.add(options, 'pointLength', 2, 10, 1)
+                    .listen()
+                    .onChange(setPointLength);
                 f1.add(options, 'cameraSize', 0, 2)
                     .listen()
                     .onChange(setCameraSize);
@@ -374,6 +380,37 @@
                 pointCloudMaterial.size = value;
                 for (var i = 0; i < point_clouds.length; ++i) {
                     point_clouds[i].visible = (value > 0);
+                }
+                render();
+            }
+
+            function setPointLength(value){
+                options.pointLength = value;
+                
+                for (var i = 0; i < reconstructions.length; ++i) {
+                    var reconstruction = reconstructions[i];
+                    var j = 0;
+                    for (var point_id in reconstruction.points) {
+                        if (!reconstruction.points.hasOwnProperty(point_id)) {
+                            continue;
+                        }
+                        var point = reconstruction.points[point_id];
+                        if (!point.hasOwnProperty('measurements')) {
+                            continue;
+                        }
+
+                        var color = new THREE.Color();
+                        if(Object.keys(point.measurements).length < options.pointLength) {
+                            color.setHex(options.background_color);
+                        }
+                        else {
+                            var c = point.color;
+                            color.setRGB(c[0] / 255., c[1] / 255., c[2] / 255.)
+                        }
+                        point_clouds[i].geometry.colors[j] = color;
+                        ++j;
+                    }
+                    point_clouds[i].geometry.colorsNeedUpdate = true;
                 }
                 render();
             }
@@ -455,6 +492,7 @@
             function swapOptions() {
                 var tmpOptions = {
                     pointSize: savedOptions.pointSize,
+                    pointLength: savedOptions.pointLength,
                     cameraSize: savedOptions.cameraSize,
                     showThumbnail: savedOptions.showThumbnail,
                     showImagePlane: savedOptions.showImagePlane,
@@ -463,6 +501,7 @@
                 };
 
                 savedOptions.pointSize = options.pointSize;
+                savedOptions.pointLength = options.pointLength;
                 savedOptions.cameraSize = options.cameraSize;
                 savedOptions.showThumbnail = options.showThumbnail;
                 savedOptions.showImagePlane = options.showImagePlane;
@@ -470,6 +509,7 @@
                 savedOptions.drawGPS = options.drawGPS;
 
                 setPointSize(tmpOptions.pointSize);
+                setPointLength(tmpOptions.pointLength);
                 setCameraSize(tmpOptions.cameraSize);
                 setShowThumbnail(tmpOptions.showThumbnail);
                 setShowImagePlane(tmpOptions.showImagePlane);
@@ -785,7 +825,7 @@
 
                 renderer = new THREE.WebGLRenderer();
                 renderer.setSize(window.innerWidth, window.innerHeight);
-                renderer.setClearColor( 0x202020, 0.0);
+                renderer.setClearColor( options.background_color, 0.0);
                 renderer.sortObjects = false;
 
                 container = document.getElementById( 'ThreeJS' );


### PR DESCRIPTION
This PR adds the Measurement type : a measured quantity can be a 2D keypoint, a GPS position, IMU angle or surveyed GCP. In this PR, we did the following :

- Use Measurement type for describing 2D keypoints of reconstructed 3D points, that further allow for a complete scene geometry description.
 - Added point filtering by their # of projection using the above.
 - Added display of the camera connection graph using the first.

As a down-side, it makes the JSON files much heavier : Firefox might struggle at read > 200 Mb files (but Chrome can). 