### PR TITLE
Use pybind11 instead of boost python

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opensfm/src/third_party/pybind11"]
+	path = opensfm/src/third_party/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Checkout this [blog post with more demos](http://blog.mapillary.com/update/2014/
 * [OpenCV][]
 * [OpenGV][]
 * [Ceres Solver][]
-* [Boost Python][]
 * [NumPy][], [SciPy][], [Networkx][], PyYAML, exifread
 
 ### Installing dependencies on MacOSX
@@ -29,7 +28,6 @@ Install OpenCV using
     brew tap homebrew/science
     brew install opencv
     brew install ceres-solver
-    brew install boost-python
 
 And install OpenGV using
 
@@ -50,7 +48,7 @@ Be sure to update your `PYTHONPATH` to include `/usr/local/lib/python2.7/site-pa
 
 See this [Dockerfile](https://github.com/paulinus/opensfm-docker-base/blob/master/Dockerfile) for the commands to install all dependencies on Ubuntu 16.04.  The steps are
 
- 1. Install [OpenCV][], [Boost Python][], [NumPy][], [SciPy][] using apt-get
+ 1. Install [OpenCV][], [NumPy][], [SciPy][] using apt-get
  2. Install python requirements using pip
  3. Clone, build and install [OpenGV][] following the receipt in the Dockerfile
  4. [Build and Install](http://ceres-solver.org/building.html) the [Ceres solver][] from its source using the `-fPIC` compilation flag.
@@ -94,5 +92,4 @@ Things you can do from there:
 [NumPy]: http://www.numpy.org/ (Scientific computing with Python)
 [SciPy]: http://www.scipy.org/ (Fundamental library for scientific computing)
 [Ceres solver]: http://ceres-solver.org/ (Library for solving complicated nonlinear least squares problems)
-[Boost Python]: http://www.boost.org/
 [Networkx]: https://github.com/networkx/networkx

--- a/README.md
+++ b/README.md
@@ -1,95 +1,23 @@
-[![Build Status](https://travis-ci.org/mapillary/OpenSfM.svg?branch=master)](https://travis-ci.org/mapillary/OpenSfM)
-OpenSfM
+OpenSfM [![Build Status](https://travis-ci.org/mapillary/OpenSfM.svg?branch=master)](https://travis-ci.org/mapillary/OpenSfM)
 =======
 
 ## Overview
-OpenSfM is a Structure from Motion library written in Python on top of [OpenCV][]. The library serves as a processing pipeline for reconstructing camera poses and 3D scenes from multiple images. It consists of basic modules for Structure from Motion (feature detection/matching, minimal solvers) with a focus on building a robust and scalable reconstruction pipeline. It also integrates external sensor (e.g. GPS, accelerometer) measurements for geographical alignment and robustness. A JavaScript viewer is provided to preview the models and debug the pipeline.
+OpenSfM is a Structure from Motion library written in Python. The library serves as a processing pipeline for reconstructing camera poses and 3D scenes from multiple images. It consists of basic modules for Structure from Motion (feature detection/matching, minimal solvers) with a focus on building a robust and scalable reconstruction pipeline. It also integrates external sensor (e.g. GPS, accelerometer) measurements for geographical alignment and robustness. A JavaScript viewer is provided to preview the models and debug the pipeline.
 
 <p align="center">
-  <a href="https://dl.dropboxusercontent.com/u/2801164/public_html/mapillary_blog/navigation/reconstruction.html#file=data/iVioRpbW-oZa0issidL1tg/reconstruction.json.compressed&res=640&img=03PQphaD0hKxVSHwphmobg">
-    <img src="https://dl.dropboxusercontent.com/u/2801164/public_html/opensfm/lund.jpg" />
-  </a>
+  <img src="https://docs.opensfm.org/_images/berlin_viewer.jpg" />
 </p>
 
 Checkout this [blog post with more demos](http://blog.mapillary.com/update/2014/12/15/sfm-preview.html)
 
 
-## Dependencies
+## Getting Started
 
-* [OpenCV][]
-* [OpenGV][]
-* [Ceres Solver][]
-* [NumPy][], [SciPy][], [Networkx][], PyYAML, exifread
-
-### Installing dependencies on MacOSX
-
-Install OpenCV using
-
-    brew tap homebrew/science
-    brew install opencv
-    brew install ceres-solver
-
-And install OpenGV using
-
-    brew install eigen
-    git clone https://github.com/paulinus/opengv.git
-    cd opengv
-    mkdir build
-    cd build
-    cmake .. -DBUILD_TESTS=OFF -DBUILD_PYTHON=ON
-    make install
-
-Be sure to update your `PYTHONPATH` to include `/usr/local/lib/python2.7/site-packages` where OpenCV and OpenGV have been installed. For example:
-
-    export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
+* [Building the library][]
+* [Running a reconstruction][]
+* [Documentation][]
 
 
-### Installing dependencies on Ubuntu
-
-See this [Dockerfile](https://github.com/paulinus/opensfm-docker-base/blob/master/Dockerfile) for the commands to install all dependencies on Ubuntu 16.04.  The steps are
-
- 1. Install [OpenCV][], [NumPy][], [SciPy][] using apt-get
- 2. Install python requirements using pip
- 3. Clone, build and install [OpenGV][] following the receipt in the Dockerfile
- 4. [Build and Install](http://ceres-solver.org/building.html) the [Ceres solver][] from its source using the `-fPIC` compilation flag.
-
-#### Install note
-
-When running OpenSfM on top of [OpenCV][] 3.0 the [OpenCV Contrib][] modules are required for extracting SIFT or SURF features.
-
-
-## Building
-
-    sudo pip install virtualenv
-    virtualenv env
-    source env/bin/activate
-    pip install -r requirements.txt
-    python setup.py build
-
-
-## Running
-
-An example dataset is available at `data/berlin`.
-
- 1. Put some images in `data/DATASET_NAME/images/`
- 2. Put config.yaml in `data/DATASET_NAME/config.yaml`
- 3. Go to the root of the project and run `bin/opensfm_run_all data/DATASET_NAME`
- 4. Start an http server from the root with `python -m SimpleHTTPServer`
- 5. Browse `http://localhost:8000/viewer/reconstruction.html#file=/data/DATASET_NAME/reconstruction.meshed.json`.
-
-Things you can do from there:
-- Use datasets with more images
-- Click twice on an image to see it. Then use arrows to move between images.
-
-
-# Thanks to sponsors
-
-- Thank you Jetbrains for supporting the project with free licenses for [IntelliJ Ultimate](https://www.jetbrains.com/idea/). Contact peter at mapillary dot com if you are contributor and need one. Apply your own project [here](https://www.jetbrains.com/eforms/openSourceRequest.action?licenseRequest=ideaOSLPRN)
-
-[OpenCV]: http://opencv.org/ (Computer vision and machine learning software library)
-[OpenCV Contrib]: https://github.com/itseez/opencv_contrib (Non free and unstable OpenCV modules)
-[OpenGV]: http://laurentkneip.github.io/opengv/ (A library for solving calibrated central and non-central geometric vision problems)
-[NumPy]: http://www.numpy.org/ (Scientific computing with Python)
-[SciPy]: http://www.scipy.org/ (Fundamental library for scientific computing)
-[Ceres solver]: http://ceres-solver.org/ (Library for solving complicated nonlinear least squares problems)
-[Networkx]: https://github.com/networkx/networkx
+[Building the library]: https://docs.opensfm.org/building.html (OpenSfM building instructions)
+[Running a reconstruction]: https://docs.opensfm.org/using.html (OpenSfM usage)
+[Documentation]: https://docs.opensfm.org  (OpenSfM documentation)

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -4,7 +4,21 @@
 Building
 ========
 
-OpenSfM code is available at Github_.
+Download
+--------
+
+OpenSfM code is available at Github_.  The simplest way to get the code is to clone the repository and its submodules with::
+
+    git clone --recursive https://github.com/mapillary/OpenSfM
+
+If you already have the code or you downloaded a release_, make sure to update the submodules with::
+
+    cd OpenSfM
+    git submodule update --init --recursive
+
+
+Install dependencies
+--------------------
 
 OpenSfM depends on the following libraries that need to be installed before building it.
 
@@ -13,13 +27,9 @@ OpenSfM depends on the following libraries that need to be installed before buil
 * `Ceres Solver`_
 * NumPy_, SciPy_, Networkx_, PyYAML, exifread
 
-Once the dependencies have been installed, you can build OpenSfM by running the following command from the main folder::
-
-    python setup.py build
-
 
 Installing dependencies on Ubuntu
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See this `Dockerfile <https://github.com/paulinus/opensfm-docker-base/blob/master/Dockerfile>`_ for the commands to install all dependencies on Ubuntu 16.04.  The steps are
 
@@ -30,13 +40,13 @@ See this `Dockerfile <https://github.com/paulinus/opensfm-docker-base/blob/maste
 
 
 Installing dependencies on MacOSX
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Install OpenCV and the Ceres solver using::
 
     brew tap homebrew/science
     brew install opencv
-    brew install homebrew/science/ceres-solver
+    brew install ceres-solver
     sudo pip install -r requirements.txt
 
 And install OpenGV using::
@@ -48,25 +58,21 @@ And install OpenGV using::
     cmake .. -DBUILD_TESTS=OFF -DBUILD_PYTHON=ON
     make install
 
-Be sure to update your ``PYTHONPATH`` to include ``/usr/local/lib/python2.7/site-packages`` where OpenCV and OpenGV have been installed. For example::
+Make sure you update your ``PYTHONPATH`` to include ``/usr/local/lib/python2.7/site-packages`` where OpenCV and OpenGV have been installed. For example with::
 
     export PYTHONPATH=/usr/local/lib/python2.7/site-packages:$PYTHONPATH
 
 
-Note on OpenCV 3
-----------------
-
-When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules are required for extracting SIFT or SURF features.
+.. note:: Note on OpenCV 3
+    When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules are required for extracting SIFT or SURF features.
 
 
-.. _Github: https://github.com/mapillary/OpenSfM
-.. _OpenCV: http://opencv.org/
-.. _OpenCV Contrib: https://github.com/itseez/opencv_contrib
-.. _OpenGV: http://laurentkneip.github.io/opengv/
-.. _NumPy: http://www.numpy.org/
-.. _SciPy: http://www.scipy.org/
-.. _Ceres solver: http://ceres-solver.org/
-.. _Networkx: https://github.com/networkx/networkx
+Building the library
+--------------------
+
+Once the dependencies have been installed, you can build OpenSfM by running the following command from the main folder::
+
+    python setup.py build
 
 
 Building the documentation
@@ -77,3 +83,16 @@ To build the documentation and browse it locally use::
     make livehtml
 
 and browse `http://localhost:8001/ <http://localhost:8001/>`_
+
+
+.. _Github: https://github.com/mapillary/OpenSfM
+.. _release: https://github.com/mapillary/OpenSfM/releases
+.. _OpenCV: http://opencv.org/
+.. _OpenCV Contrib: https://github.com/itseez/opencv_contrib
+.. _OpenGV: http://laurentkneip.github.io/opengv/
+.. _NumPy: http://www.numpy.org/
+.. _SciPy: http://www.scipy.org/
+.. _Ceres solver: http://ceres-solver.org/
+.. _Networkx: https://github.com/networkx/networkx
+
+

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -11,7 +11,6 @@ OpenSfM depends on the following libraries that need to be installed before buil
 * OpenCV_
 * OpenGV_
 * `Ceres Solver`_
-* `Boost Python`_
 * NumPy_, SciPy_, Networkx_, PyYAML, exifread
 
 Once the dependencies have been installed, you can build OpenSfM by running the following command from the main folder::
@@ -24,7 +23,7 @@ Installing dependencies on Ubuntu
 
 See this `Dockerfile <https://github.com/paulinus/opensfm-docker-base/blob/master/Dockerfile>`_ for the commands to install all dependencies on Ubuntu 16.04.  The steps are
 
-1. Install OpenCV, Boost Python, NumPy, SciPy using apt-get
+1. Install OpenCV, NumPy, SciPy using apt-get
 2. Install python requirements using pip
 3. Clone, build and install OpenGV following the receipt in the Dockerfile
 4. `Build and Install <http://ceres-solver.org/installation.html>`_ the Ceres solver from its source using the ``-fPIC`` compilation flag.
@@ -33,12 +32,11 @@ See this `Dockerfile <https://github.com/paulinus/opensfm-docker-base/blob/maste
 Installing dependencies on MacOSX
 ---------------------------------
 
-Install OpenCV, boost python and the Ceres solver using::
+Install OpenCV and the Ceres solver using::
 
     brew tap homebrew/science
     brew install opencv
     brew install homebrew/science/ceres-solver
-    brew install boost-python
     sudo pip install -r requirements.txt
 
 And install OpenGV using::
@@ -68,7 +66,6 @@ When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules 
 .. _NumPy: http://www.numpy.org/
 .. _SciPy: http://www.scipy.org/
 .. _Ceres solver: http://ceres-solver.org/
-.. _Boost Python: http://www.boost.org/
 .. _Networkx: https://github.com/networkx/networkx
 
 

--- a/doc/source/reconstruction_module.rst
+++ b/doc/source/reconstruction_module.rst
@@ -29,7 +29,7 @@ The accepted image pairs are sorted by the number of outliers of the rotation on
 This step is done by the :func:`~opensfm.reconstruction.compute_image_pairs` function.
 
 
-2. Boostraping the reconstruction
+2. Bootstraping the reconstruction
 ---------------------------------
 
 To bootstrap the reconstruction, we use the first image pair.  If initialization fails we try with the next on the list.  If the initialization works, we pass it to the next step to grow it with more images.

--- a/licenses.csv
+++ b/licenses.csv
@@ -1,6 +1,5 @@
 ExifRead, 2.1.2, BSD
 PyYAML, 3.12, MIT
-boost, 1.66, "Boost Software License"
 ceres-solver, 1.10.0, BSD
 cloudpickle, 0.4.0, BSD
 coverage, 4.4.2, "Apache 2.0"
@@ -13,6 +12,7 @@ numpy, 1.14.0, BSD
 opencv, 2.4.10.1, "3-clause BSD License"
 opengv, master, "New BSD 3-Clause"
 py, 1.5.2, MIT
+pybind, 2.2.4, BSD
 pyproj, 1.9.5.1, "OSI Approved"
 pytest, 3.2.3, MIT
 pytest-cov, 2.5.1, MIT

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++0x")
 
 
 # Find dependencies.
+add_subdirectory(third_party/pybind11)
+
 find_package(OpenMP)
 if (OPENMP_FOUND)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -46,49 +48,16 @@ include_directories(${GLOG_INCLUDE_DIR})
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-find_package(Boost REQUIRED)
-
-option(BUILD_FOR_PYTHON3 "build pyopengv for Python 3" OFF)
-set(BOOST_PYTHON3_COMPONENT "python3" CACHE STRING
-    "name of the Boost Python 3 component (python3, python-py36 or python-py37)")
-
 if(${BUILD_FOR_PYTHON3})
-    set(BOOST_PYTHON_COMPONENT ${BOOST_PYTHON3_COMPONENT})
-    set(BOOST_NUMPY_COMPONENT numpy3)
     set(Python_ADDITIONAL_VERSIONS 3.7 3.6)
     set(Python_VERSION_SUFFIX 3)
 else()
-    if(${Boost_VERSION} LESS 106700)
-        set(BOOST_PYTHON_COMPONENT python)
-        set(BOOST_NUMPY_COMPONENT numpy)
-    else()
-        set(BOOST_PYTHON_COMPONENT python27)
-        set(BOOST_NUMPY_COMPONENT numpy27)
-    endif()
     set(Python_ADDITIONAL_VERSIONS 2.7)
     set(Python_VERSION_SUFFIX "")
 endif()
 
-if(${Boost_VERSION} LESS 106300)
-    message("Not using boost/python/numpy.")
-    set(USE_BOOST_PYTHON_NUMPY "off")
-
-    find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_COMPONENT})
-else()
-    message("Using boost/python/numpy.")
-    set(USE_BOOST_PYTHON_NUMPY "on")
-    add_definitions(-DUSE_BOOST_PYTHON_NUMPY)
-
-    find_package(Boost 1.63 REQUIRED COMPONENTS
-                 ${BOOST_PYTHON_COMPONENT} ${BOOST_NUMPY_COMPONENT})
-endif()
-
 find_package(PythonLibs ${Python_VERSION_SUFFIX} REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
-
-find_package(NumPy REQUIRED)
-include_directories(${NUMPY_INCLUDE_DIRS})
-
 
 # Akaze
 include_directories(third_party/akaze/lib/)
@@ -119,7 +88,7 @@ add_library(vl ${VLFEAT_SRCS})
 
 
 # Python wrapper
-add_library(csfm SHARED csfm.cc)
+pybind11_add_module(csfm csfm.cc)
 target_link_libraries(csfm
     ${OpenCV_LIBS}
     ${GFLAGS_LIBRARY}

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -96,7 +96,6 @@ target_link_libraries(csfm
     ${CERES_LIBRARIES}
     ${LAPACK_LIBRARIES}
     ${SUITESPARSE_LIBRARIES}
-    ${Boost_LIBRARIES}
     vl
     akaze
 )

--- a/opensfm/src/akaze.cc
+++ b/opensfm/src/akaze.cc
@@ -5,7 +5,7 @@
 namespace csfm {
 
 
-py::object akaze(ndarray_uint8 image,
+py::object akaze(pyarray_uint8 image,
                  AKAZEOptions options) {
   const cv::Mat img(image.shape(0), image.shape(1), CV_8U, (void *)image.data());
 

--- a/opensfm/src/akaze.cc
+++ b/opensfm/src/akaze.cc
@@ -5,10 +5,9 @@
 namespace csfm {
 
 
-bp::object akaze(PyObject *image,
+py::object akaze(ndarray_uint8 image,
                  AKAZEOptions options) {
-  PyArrayContiguousView<unsigned char> view((PyArrayObject *)image);
-  const cv::Mat img(view.shape(0), view.shape(1), CV_8U, (void *)view.data());
+  const cv::Mat img(image.shape(0), image.shape(1), CV_8U, (void *)image.data());
 
   cv::Mat img_32;
   img.convertTo(img_32, CV_32F, 1.0 / 255.0, 0);
@@ -39,13 +38,13 @@ bp::object akaze(PyObject *image,
     keys.at<float>(i, 3) = kpts[i].angle;
   }
 
-  bp::list retn;
-  retn.append(bpn_array_from_data(keys.ptr<float>(0), keys.rows, keys.cols));
+  py::list retn;
+  retn.append(py_array_from_data(keys.ptr<float>(0), keys.rows, keys.cols));
 
   if (options.descriptor == MLDB_UPRIGHT || options.descriptor == MLDB) {
-    retn.append(bpn_array_from_data(desc.ptr<unsigned char>(0), desc.rows, desc.cols));
+    retn.append(py_array_from_data(desc.ptr<unsigned char>(0), desc.rows, desc.cols));
   } else {
-    retn.append(bpn_array_from_data(desc.ptr<float>(0), desc.rows, desc.cols));
+    retn.append(py_array_from_data(desc.ptr<float>(0), desc.rows, desc.cols));
   }
   return retn;
 }

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -68,6 +68,7 @@ PYBIND11_MODULE(csfm, m) {
   m.def("triangulate_bearings_midpoint", csfm::TriangulateBearingsMidpoint);
 
   py::class_<BundleAdjuster>(m, "BundleAdjuster")
+    .def(py::init())
     .def("run", &BundleAdjuster::Run)
     .def("get_perspective_camera", &BundleAdjuster::GetPerspectiveCamera)
     .def("get_brown_perspective_camera", &BundleAdjuster::GetBrownPerspectiveCamera)

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -28,6 +28,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<AKAZEOptions>(m, "AKAZEOptions")
+    .def(py::init())
     .def_readwrite("omin", &AKAZEOptions::omin)
     .def_readwrite("omax", &AKAZEOptions::omax)
     .def_readwrite("nsublevels", &AKAZEOptions::nsublevels)
@@ -104,6 +105,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<BAPerspectiveCamera>(m, "BAPerspectiveCamera")
+    .def(py::init())
     .def_property("focal", &BAPerspectiveCamera::GetFocal, &BAPerspectiveCamera::SetFocal)
     .def_property("k1", &BAPerspectiveCamera::GetK1, &BAPerspectiveCamera::SetK1)
     .def_property("k2", &BAPerspectiveCamera::GetK2, &BAPerspectiveCamera::SetK2)
@@ -113,6 +115,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<BABrownPerspectiveCamera>(m, "BABrownPerspectiveCamera")
+    .def(py::init())
     .def_property("focal_x", &BABrownPerspectiveCamera::GetFocalX, &BABrownPerspectiveCamera::SetFocalX)
     .def_property("focal_y", &BABrownPerspectiveCamera::GetFocalY, &BABrownPerspectiveCamera::SetFocalY)
     .def_property("c_x", &BABrownPerspectiveCamera::GetCX, &BABrownPerspectiveCamera::SetCX)
@@ -136,6 +139,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<BAFisheyeCamera>(m, "BAFisheyeCamera")
+    .def(py::init())
     .def_property("focal", &BAFisheyeCamera::GetFocal, &BAFisheyeCamera::SetFocal)
     .def_property("k1", &BAFisheyeCamera::GetK1, &BAFisheyeCamera::SetK1)
     .def_property("k2", &BAFisheyeCamera::GetK2, &BAFisheyeCamera::SetK2)
@@ -145,6 +149,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<BAShot>(m, "BAShot")
+    .def(py::init())
     .def_property("rx", &BAShot::GetRX, &BAShot::SetRX)
     .def_property("ry", &BAShot::GetRY, &BAShot::SetRY)
     .def_property("rz", &BAShot::GetRZ, &BAShot::SetRZ)
@@ -158,6 +163,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<BAPoint>(m, "BAPoint")
+    .def(py::init())
     .def_property("x", &BAPoint::GetX, &BAPoint::SetX)
     .def_property("y", &BAPoint::GetY, &BAPoint::SetY)
     .def_property("z", &BAPoint::GetZ, &BAPoint::SetZ)
@@ -167,6 +173,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<csfm::OpenMVSExporter>(m, "OpenMVSExporter")
+    .def(py::init())
     .def("add_camera", &csfm::OpenMVSExporter::AddCamera)
     .def("add_shot", &csfm::OpenMVSExporter::AddShot)
     .def("add_point", &csfm::OpenMVSExporter::AddPoint)
@@ -174,6 +181,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<csfm::DepthmapEstimatorWrapper>(m, "DepthmapEstimator")
+    .def(py::init())
     .def("set_depth_range", &csfm::DepthmapEstimatorWrapper::SetDepthRange)
     .def("set_patchmatch_iterations", &csfm::DepthmapEstimatorWrapper::SetPatchMatchIterations)
     .def("set_min_patch_sd", &csfm::DepthmapEstimatorWrapper::SetMinPatchSD)
@@ -184,6 +192,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<csfm::DepthmapCleanerWrapper>(m, "DepthmapCleaner")
+    .def(py::init())
     .def("set_same_depth_threshold", &csfm::DepthmapCleanerWrapper::SetSameDepthThreshold)
     .def("set_min_consistent_views", &csfm::DepthmapCleanerWrapper::SetMinConsistentViews)
     .def("add_view", &csfm::DepthmapCleanerWrapper::AddView)
@@ -191,6 +200,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<csfm::DepthmapPrunerWrapper>(m, "DepthmapPruner")
+    .def(py::init())
     .def("set_same_depth_threshold", &csfm::DepthmapPrunerWrapper::SetSameDepthThreshold)
     .def("add_view", &csfm::DepthmapPrunerWrapper::AddView)
     .def("prune", &csfm::DepthmapPrunerWrapper::Prune)
@@ -200,6 +210,7 @@ PYBIND11_MODULE(csfm, m) {
   // Reconstruction Aligment
   //
   py::class_<ReconstructionAlignment>(m, "ReconstructionAlignment")
+    .def(py::init())
     .def("run", &ReconstructionAlignment::Run)
     .def("get_shot", &ReconstructionAlignment::GetShot)
     .def("get_reconstruction", &ReconstructionAlignment::GetReconstruction)
@@ -215,6 +226,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<RAShot>(m, "RAShot")
+    .def(py::init())
     .def_property("rx", &RAShot::GetRX, &RAShot::SetRX)
     .def_property("ry", &RAShot::GetRY, &RAShot::SetRY)
     .def_property("rz", &RAShot::GetRZ, &RAShot::SetRZ)
@@ -225,6 +237,7 @@ PYBIND11_MODULE(csfm, m) {
   ;
 
   py::class_<RAReconstruction>(m, "RAReconstruction")
+    .def(py::init())
     .def_property("rx", &RAReconstruction::GetRX, &RAReconstruction::SetRX)
     .def_property("ry", &RAReconstruction::GetRY, &RAReconstruction::SetRY)
     .def_property("rz", &RAReconstruction::GetRZ, &RAReconstruction::SetRZ)

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -1,6 +1,6 @@
-#include <boost/python.hpp>
 #include <iostream>
 #include <vector>
+#include <pybind11/pybind11.h>
 
 #include "types.h"
 #include "hahog.cc"
@@ -11,29 +11,14 @@
 #include "depthmap_wrapper.cc"
 #include "reconstruction_alignment.h"
 
-#if (PY_VERSION_HEX < 0x03000000)
-static void numpy_import_array_wrapper()
-#else
-static int* numpy_import_array_wrapper()
-#endif
-{
-  /* Initialise numpy API and use 2/3 compatible return */
-  import_array();
-}
 
-BOOST_PYTHON_MODULE(csfm) {
-  using namespace boost::python;
+namespace py = pybind11;
 
+
+PYBIND11_MODULE(csfm, m) {
   google::InitGoogleLogging("csfm");
-#ifdef USE_BOOST_PYTHON_NUMPY
-  boost::python::numpy::initialize();
-#else
-  boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
-#endif
-  numpy_import_array_wrapper();
 
-
-  enum_<DESCRIPTOR_TYPE>("AkazeDescriptorType")
+  py::enum_<DESCRIPTOR_TYPE>(m, "AkazeDescriptorType")
     .value("SURF_UPRIGHT", SURF_UPRIGHT)
     .value("SURF", SURF)
     .value("MSURF_UPRIGHT", MSURF_UPRIGHT)
@@ -42,7 +27,7 @@ BOOST_PYTHON_MODULE(csfm) {
     .value("MLDB", MLDB)
   ;
 
-  class_<AKAZEOptions>("AKAZEOptions")
+  py::class_<AKAZEOptions>(m, "AKAZEOptions")
     .def_readwrite("omin", &AKAZEOptions::omin)
     .def_readwrite("omax", &AKAZEOptions::omax)
     .def_readwrite("nsublevels", &AKAZEOptions::nsublevels)
@@ -69,20 +54,20 @@ BOOST_PYTHON_MODULE(csfm) {
     .def_readwrite("verbosity", &AKAZEOptions::verbosity)
   ;
 
-  def("akaze", csfm::akaze);
+  m.def("akaze", csfm::akaze);
 
-  def("hahog", csfm::hahog,
-      (boost::python::arg("peak_threshold") = 0.003,
-       boost::python::arg("edge_threshold") = 10,
-       boost::python::arg("target_num_features") = 0,
-       boost::python::arg("use_adaptive_suppression") = false
-      )
+  m.def("hahog", csfm::hahog,
+        py::arg("image"),
+        py::arg("peak_threshold") = 0.003,
+        py::arg("edge_threshold") = 10,
+        py::arg("target_num_features") = 0,
+        py::arg("use_adaptive_suppression") = false
   );
 
-  def("triangulate_bearings_dlt", csfm::TriangulateBearingsDLT);
-  def("triangulate_bearings_midpoint", csfm::TriangulateBearingsMidpoint);
+  m.def("triangulate_bearings_dlt", csfm::TriangulateBearingsDLT);
+  m.def("triangulate_bearings_midpoint", csfm::TriangulateBearingsMidpoint);
 
-  class_<BundleAdjuster, boost::noncopyable>("BundleAdjuster")
+  py::class_<BundleAdjuster>(m, "BundleAdjuster")
     .def("run", &BundleAdjuster::Run)
     .def("get_perspective_camera", &BundleAdjuster::GetPerspectiveCamera)
     .def("get_brown_perspective_camera", &BundleAdjuster::GetBrownPerspectiveCamera)
@@ -117,25 +102,25 @@ BOOST_PYTHON_MODULE(csfm) {
     .def("full_report", &BundleAdjuster::FullReport)
   ;
 
-  class_<BAPerspectiveCamera>("BAPerspectiveCamera")
-    .add_property("focal", &BAPerspectiveCamera::GetFocal, &BAPerspectiveCamera::SetFocal)
-    .add_property("k1", &BAPerspectiveCamera::GetK1, &BAPerspectiveCamera::SetK1)
-    .add_property("k2", &BAPerspectiveCamera::GetK2, &BAPerspectiveCamera::SetK2)
+  py::class_<BAPerspectiveCamera>(m, "BAPerspectiveCamera")
+    .def_property("focal", &BAPerspectiveCamera::GetFocal, &BAPerspectiveCamera::SetFocal)
+    .def_property("k1", &BAPerspectiveCamera::GetK1, &BAPerspectiveCamera::SetK1)
+    .def_property("k2", &BAPerspectiveCamera::GetK2, &BAPerspectiveCamera::SetK2)
     .def_readwrite("constant", &BAPerspectiveCamera::constant)
     .def_readwrite("focal_prior", &BAPerspectiveCamera::focal_prior)
     .def_readwrite("id", &BAPerspectiveCamera::id)
   ;
 
-  class_<BABrownPerspectiveCamera>("BABrownPerspectiveCamera")
-    .add_property("focal_x", &BABrownPerspectiveCamera::GetFocalX, &BABrownPerspectiveCamera::SetFocalX)
-    .add_property("focal_y", &BABrownPerspectiveCamera::GetFocalY, &BABrownPerspectiveCamera::SetFocalY)
-    .add_property("c_x", &BABrownPerspectiveCamera::GetCX, &BABrownPerspectiveCamera::SetCX)
-    .add_property("c_y", &BABrownPerspectiveCamera::GetCY, &BABrownPerspectiveCamera::SetCY)
-    .add_property("k1", &BABrownPerspectiveCamera::GetK1, &BABrownPerspectiveCamera::SetK1)
-    .add_property("k2", &BABrownPerspectiveCamera::GetK2, &BABrownPerspectiveCamera::SetK2)
-    .add_property("p1", &BABrownPerspectiveCamera::GetP1, &BABrownPerspectiveCamera::SetP1)
-    .add_property("p2", &BABrownPerspectiveCamera::GetP2, &BABrownPerspectiveCamera::SetP2)
-    .add_property("k3", &BABrownPerspectiveCamera::GetK3, &BABrownPerspectiveCamera::SetK3)
+  py::class_<BABrownPerspectiveCamera>(m, "BABrownPerspectiveCamera")
+    .def_property("focal_x", &BABrownPerspectiveCamera::GetFocalX, &BABrownPerspectiveCamera::SetFocalX)
+    .def_property("focal_y", &BABrownPerspectiveCamera::GetFocalY, &BABrownPerspectiveCamera::SetFocalY)
+    .def_property("c_x", &BABrownPerspectiveCamera::GetCX, &BABrownPerspectiveCamera::SetCX)
+    .def_property("c_y", &BABrownPerspectiveCamera::GetCY, &BABrownPerspectiveCamera::SetCY)
+    .def_property("k1", &BABrownPerspectiveCamera::GetK1, &BABrownPerspectiveCamera::SetK1)
+    .def_property("k2", &BABrownPerspectiveCamera::GetK2, &BABrownPerspectiveCamera::SetK2)
+    .def_property("p1", &BABrownPerspectiveCamera::GetP1, &BABrownPerspectiveCamera::SetP1)
+    .def_property("p2", &BABrownPerspectiveCamera::GetP2, &BABrownPerspectiveCamera::SetP2)
+    .def_property("k3", &BABrownPerspectiveCamera::GetK3, &BABrownPerspectiveCamera::SetK3)
     .def_readwrite("focal_x_prior", &BABrownPerspectiveCamera::focal_x_prior)
     .def_readwrite("focal_y_prior", &BABrownPerspectiveCamera::focal_y_prior)
     .def_readwrite("c_x_prior", &BABrownPerspectiveCamera::c_x_prior)
@@ -149,45 +134,45 @@ BOOST_PYTHON_MODULE(csfm) {
     .def_readwrite("id", &BABrownPerspectiveCamera::id)
   ;
 
-  class_<BAFisheyeCamera>("BAFisheyeCamera")
-    .add_property("focal", &BAFisheyeCamera::GetFocal, &BAFisheyeCamera::SetFocal)
-    .add_property("k1", &BAFisheyeCamera::GetK1, &BAFisheyeCamera::SetK1)
-    .add_property("k2", &BAFisheyeCamera::GetK2, &BAFisheyeCamera::SetK2)
+  py::class_<BAFisheyeCamera>(m, "BAFisheyeCamera")
+    .def_property("focal", &BAFisheyeCamera::GetFocal, &BAFisheyeCamera::SetFocal)
+    .def_property("k1", &BAFisheyeCamera::GetK1, &BAFisheyeCamera::SetK1)
+    .def_property("k2", &BAFisheyeCamera::GetK2, &BAFisheyeCamera::SetK2)
     .def_readwrite("constant", &BAFisheyeCamera::constant)
     .def_readwrite("focal_prior", &BAFisheyeCamera::focal_prior)
     .def_readwrite("id", &BAFisheyeCamera::id)
   ;
 
-  class_<BAShot>("BAShot")
-    .add_property("rx", &BAShot::GetRX, &BAShot::SetRX)
-    .add_property("ry", &BAShot::GetRY, &BAShot::SetRY)
-    .add_property("rz", &BAShot::GetRZ, &BAShot::SetRZ)
-    .add_property("tx", &BAShot::GetTX, &BAShot::SetTX)
-    .add_property("ty", &BAShot::GetTY, &BAShot::SetTY)
-    .add_property("tz", &BAShot::GetTZ, &BAShot::SetTZ)
+  py::class_<BAShot>(m, "BAShot")
+    .def_property("rx", &BAShot::GetRX, &BAShot::SetRX)
+    .def_property("ry", &BAShot::GetRY, &BAShot::SetRY)
+    .def_property("rz", &BAShot::GetRZ, &BAShot::SetRZ)
+    .def_property("tx", &BAShot::GetTX, &BAShot::SetTX)
+    .def_property("ty", &BAShot::GetTY, &BAShot::SetTY)
+    .def_property("tz", &BAShot::GetTZ, &BAShot::SetTZ)
     .def("get_covariance", &BAShot::GetCovariance)
     .def_readwrite("constant", &BAShot::constant)
     .def_readwrite("camera", &BAShot::camera)
     .def_readwrite("id", &BAShot::id)
   ;
 
-  class_<BAPoint>("BAPoint")
-    .add_property("x", &BAPoint::GetX, &BAPoint::SetX)
-    .add_property("y", &BAPoint::GetY, &BAPoint::SetY)
-    .add_property("z", &BAPoint::GetZ, &BAPoint::SetZ)
+  py::class_<BAPoint>(m, "BAPoint")
+    .def_property("x", &BAPoint::GetX, &BAPoint::SetX)
+    .def_property("y", &BAPoint::GetY, &BAPoint::SetY)
+    .def_property("z", &BAPoint::GetZ, &BAPoint::SetZ)
     .def_readwrite("constant", &BAPoint::constant)
     .def_readwrite("reprojection_error", &BAPoint::reprojection_error)
     .def_readwrite("id", &BAPoint::id)
   ;
 
-  class_<csfm::OpenMVSExporter>("OpenMVSExporter")
+  py::class_<csfm::OpenMVSExporter>(m, "OpenMVSExporter")
     .def("add_camera", &csfm::OpenMVSExporter::AddCamera)
     .def("add_shot", &csfm::OpenMVSExporter::AddShot)
     .def("add_point", &csfm::OpenMVSExporter::AddPoint)
     .def("export", &csfm::OpenMVSExporter::Export)
   ;
 
-  class_<csfm::DepthmapEstimatorWrapper>("DepthmapEstimator")
+  py::class_<csfm::DepthmapEstimatorWrapper>(m, "DepthmapEstimator")
     .def("set_depth_range", &csfm::DepthmapEstimatorWrapper::SetDepthRange)
     .def("set_patchmatch_iterations", &csfm::DepthmapEstimatorWrapper::SetPatchMatchIterations)
     .def("set_min_patch_sd", &csfm::DepthmapEstimatorWrapper::SetMinPatchSD)
@@ -197,14 +182,14 @@ BOOST_PYTHON_MODULE(csfm) {
     .def("compute_brute_force", &csfm::DepthmapEstimatorWrapper::ComputeBruteForce)
   ;
 
-  class_<csfm::DepthmapCleanerWrapper>("DepthmapCleaner")
+  py::class_<csfm::DepthmapCleanerWrapper>(m, "DepthmapCleaner")
     .def("set_same_depth_threshold", &csfm::DepthmapCleanerWrapper::SetSameDepthThreshold)
     .def("set_min_consistent_views", &csfm::DepthmapCleanerWrapper::SetMinConsistentViews)
     .def("add_view", &csfm::DepthmapCleanerWrapper::AddView)
     .def("clean", &csfm::DepthmapCleanerWrapper::Clean)
   ;
 
-  class_<csfm::DepthmapPrunerWrapper>("DepthmapPruner")
+  py::class_<csfm::DepthmapPrunerWrapper>(m, "DepthmapPruner")
     .def("set_same_depth_threshold", &csfm::DepthmapPrunerWrapper::SetSameDepthThreshold)
     .def("add_view", &csfm::DepthmapPrunerWrapper::AddView)
     .def("prune", &csfm::DepthmapPrunerWrapper::Prune)
@@ -213,7 +198,7 @@ BOOST_PYTHON_MODULE(csfm) {
   ///////////////////////////////////
   // Reconstruction Aligment
   //
-  class_<ReconstructionAlignment>("ReconstructionAlignment")
+  py::class_<ReconstructionAlignment>(m, "ReconstructionAlignment")
     .def("run", &ReconstructionAlignment::Run)
     .def("get_shot", &ReconstructionAlignment::GetShot)
     .def("get_reconstruction", &ReconstructionAlignment::GetReconstruction)
@@ -228,36 +213,37 @@ BOOST_PYTHON_MODULE(csfm) {
     .def("full_report", &ReconstructionAlignment::FullReport)
   ;
 
-  class_<RAShot>("RAShot")
-    .add_property("rx", &RAShot::GetRX, &RAShot::SetRX)
-    .add_property("ry", &RAShot::GetRY, &RAShot::SetRY)
-    .add_property("rz", &RAShot::GetRZ, &RAShot::SetRZ)
-    .add_property("tx", &RAShot::GetTX, &RAShot::SetTX)
-    .add_property("ty", &RAShot::GetTY, &RAShot::SetTY)
-    .add_property("tz", &RAShot::GetTZ, &RAShot::SetTZ)
+  py::class_<RAShot>(m, "RAShot")
+    .def_property("rx", &RAShot::GetRX, &RAShot::SetRX)
+    .def_property("ry", &RAShot::GetRY, &RAShot::SetRY)
+    .def_property("rz", &RAShot::GetRZ, &RAShot::SetRZ)
+    .def_property("tx", &RAShot::GetTX, &RAShot::SetTX)
+    .def_property("ty", &RAShot::GetTY, &RAShot::SetTY)
+    .def_property("tz", &RAShot::GetTZ, &RAShot::SetTZ)
     .def_readwrite("id", &RAShot::id)
   ;
 
-  class_<RAReconstruction>("RAReconstruction")
-    .add_property("rx", &RAReconstruction::GetRX, &RAReconstruction::SetRX)
-    .add_property("ry", &RAReconstruction::GetRY, &RAReconstruction::SetRY)
-    .add_property("rz", &RAReconstruction::GetRZ, &RAReconstruction::SetRZ)
-    .add_property("tx", &RAReconstruction::GetTX, &RAReconstruction::SetTX)
-    .add_property("ty", &RAReconstruction::GetTY, &RAReconstruction::SetTY)
-    .add_property("tz", &RAReconstruction::GetTZ, &RAReconstruction::SetTZ)
-    .add_property("scale", &RAReconstruction::GetScale, &RAReconstruction::SetScale)
+  py::class_<RAReconstruction>(m, "RAReconstruction")
+    .def_property("rx", &RAReconstruction::GetRX, &RAReconstruction::SetRX)
+    .def_property("ry", &RAReconstruction::GetRY, &RAReconstruction::SetRY)
+    .def_property("rz", &RAReconstruction::GetRZ, &RAReconstruction::SetRZ)
+    .def_property("tx", &RAReconstruction::GetTX, &RAReconstruction::SetTX)
+    .def_property("ty", &RAReconstruction::GetTY, &RAReconstruction::SetTY)
+    .def_property("tz", &RAReconstruction::GetTZ, &RAReconstruction::SetTZ)
+    .def_property("scale", &RAReconstruction::GetScale, &RAReconstruction::SetScale)
     .def_readwrite("id", &RAReconstruction::id)
   ;
 
-  class_<RARelativeMotionConstraint>("RARelativeMotionConstraint", init<const std::string &, const std::string &, double, double, double, double, double, double>())
+  py::class_<RARelativeMotionConstraint>(m, "RARelativeMotionConstraint")
+    .def(py::init<const std::string &, const std::string &, double, double, double, double, double, double>())
     .def_readwrite("reconstruction", &RARelativeMotionConstraint::reconstruction_id)
     .def_readwrite("shot", &RARelativeMotionConstraint::shot_id)
-    .add_property("rx", &RARelativeMotionConstraint::GetRX, &RARelativeMotionConstraint::SetRX)
-    .add_property("ry", &RARelativeMotionConstraint::GetRY, &RARelativeMotionConstraint::SetRY)
-    .add_property("rz", &RARelativeMotionConstraint::GetRZ, &RARelativeMotionConstraint::SetRZ)
-    .add_property("tx", &RARelativeMotionConstraint::GetTX, &RARelativeMotionConstraint::SetTX)
-    .add_property("ty", &RARelativeMotionConstraint::GetTY, &RARelativeMotionConstraint::SetTY)
-    .add_property("tz", &RARelativeMotionConstraint::GetTZ, &RARelativeMotionConstraint::SetTZ)
+    .def_property("rx", &RARelativeMotionConstraint::GetRX, &RARelativeMotionConstraint::SetRX)
+    .def_property("ry", &RARelativeMotionConstraint::GetRY, &RARelativeMotionConstraint::SetRY)
+    .def_property("rz", &RARelativeMotionConstraint::GetRZ, &RARelativeMotionConstraint::SetRZ)
+    .def_property("tx", &RARelativeMotionConstraint::GetTX, &RARelativeMotionConstraint::SetTX)
+    .def_property("ty", &RARelativeMotionConstraint::GetTY, &RARelativeMotionConstraint::SetTY)
+    .def_property("tz", &RARelativeMotionConstraint::GetTZ, &RARelativeMotionConstraint::SetTZ)
     .def("set_scale_matrix", &RARelativeMotionConstraint::SetScaleMatrix)
   ;
 

--- a/opensfm/src/depthmap_wrapper.cc
+++ b/opensfm/src/depthmap_wrapper.cc
@@ -7,19 +7,13 @@ namespace csfm {
 
 class DepthmapEstimatorWrapper {
  public:
-  void AddView(PyObject *K,
-               PyObject *R,
-               PyObject *t,
-               PyObject *image,
-               PyObject *mask) {
-    PyArrayContiguousView<double> K_view((PyArrayObject *)K);
-    PyArrayContiguousView<double> R_view((PyArrayObject *)R);
-    PyArrayContiguousView<double> t_view((PyArrayObject *)t);
-    PyArrayContiguousView<unsigned char> image_view((PyArrayObject *)image);
-    PyArrayContiguousView<unsigned char> mask_view((PyArrayObject *)mask);
-    de_.AddView(K_view.data(), R_view.data(), t_view.data(),
-                image_view.data(), mask_view.data(),
-                image_view.shape(1), image_view.shape(0));
+  void AddView(ndarray_d K,
+               ndarray_d R,
+               ndarray_d t,
+               ndarray_uint8 image,
+               ndarray_uint8 mask) {
+    de_.AddView(K.data(), R.data(), t.data(),
+                image.data(), mask.data(), image.shape(1), image.shape(0));
   }
 
   void SetDepthRange(double min_depth, double max_depth, int num_depth_planes) {
@@ -34,30 +28,30 @@ class DepthmapEstimatorWrapper {
     de_.SetMinPatchSD(sd);
   }
 
-  bp::object ComputePatchMatch() {
+  py::object ComputePatchMatch() {
     DepthmapEstimatorResult result;
     de_.ComputePatchMatch(&result);
     return ComputeReturnValues(result);
   }
 
-  bp::object ComputePatchMatchSample() {
+  py::object ComputePatchMatchSample() {
     DepthmapEstimatorResult result;
     de_.ComputePatchMatchSample(&result);
     return ComputeReturnValues(result);
   }
 
-  bp::object ComputeBruteForce() {
+  py::object ComputeBruteForce() {
     DepthmapEstimatorResult result;
     de_.ComputeBruteForce(&result);
     return ComputeReturnValues(result);
   }
 
-  bp::object ComputeReturnValues(const DepthmapEstimatorResult &result) {
-    bp::list retn;
-    retn.append(bpn_array_from_data(result.depth.ptr<float>(0), result.depth.rows, result.depth.cols));
-    retn.append(bpn_array_from_data(result.plane.ptr<float>(0), result.plane.rows, result.plane.cols, 3));
-    retn.append(bpn_array_from_data(result.score.ptr<float>(0), result.score.rows, result.score.cols));
-    retn.append(bpn_array_from_data(result.nghbr.ptr<int>(0), result.nghbr.rows, result.nghbr.cols));
+  py::object ComputeReturnValues(const DepthmapEstimatorResult &result) {
+    py::list retn;
+    retn.append(py_array_from_data(result.depth.ptr<float>(0), result.depth.rows, result.depth.cols));
+    retn.append(py_array_from_data(result.plane.ptr<float>(0), result.plane.rows, result.plane.cols, 3));
+    retn.append(py_array_from_data(result.score.ptr<float>(0), result.score.rows, result.score.cols));
+    retn.append(py_array_from_data(result.nghbr.ptr<int>(0), result.nghbr.rows, result.nghbr.cols));
     return retn;
   }
 
@@ -76,22 +70,18 @@ class DepthmapCleanerWrapper {
     dc_.SetMinConsistentViews(n);
   }
 
-  void AddView(PyObject *K,
-               PyObject *R,
-               PyObject *t,
-               PyObject *depth) {
-    PyArrayContiguousView<double> K_view((PyArrayObject *)K);
-    PyArrayContiguousView<double> R_view((PyArrayObject *)R);
-    PyArrayContiguousView<double> t_view((PyArrayObject *)t);
-    PyArrayContiguousView<float> depth_view((PyArrayObject *)depth);
-    dc_.AddView(K_view.data(), R_view.data(), t_view.data(),
-                depth_view.data(), depth_view.shape(1), depth_view.shape(0));
+  void AddView(ndarray_d K,
+               ndarray_d R,
+               ndarray_d t,
+               ndarray_f depth) {
+    dc_.AddView(K.data(), R.data(), t.data(),
+                depth.data(), depth.shape(1), depth.shape(0));
   }
 
-  bp::object Clean() {
+  py::object Clean() {
     cv::Mat depth;
     dc_.Clean(&depth);
-    return bpn_array_from_data(depth.ptr<float>(0), depth.rows, depth.cols);
+    return py_array_from_data(depth.ptr<float>(0), depth.rows, depth.cols);
   }
 
  private:
@@ -105,27 +95,20 @@ class DepthmapPrunerWrapper {
     dp_.SetSameDepthThreshold(t);
   }
 
-  void AddView(PyObject *K,
-               PyObject *R,
-               PyObject *t,
-               PyObject *depth,
-               PyObject *normal,
-               PyObject *color,
-               PyObject *label) {
-    PyArrayContiguousView<double> K_view((PyArrayObject *)K);
-    PyArrayContiguousView<double> R_view((PyArrayObject *)R);
-    PyArrayContiguousView<double> t_view((PyArrayObject *)t);
-    PyArrayContiguousView<float> depth_view((PyArrayObject *)depth);
-    PyArrayContiguousView<float> plane_view((PyArrayObject *)normal);
-    PyArrayContiguousView<unsigned char> color_view((PyArrayObject *)color);
-    PyArrayContiguousView<unsigned char> label_view((PyArrayObject *)label);
-    dp_.AddView(K_view.data(), R_view.data(), t_view.data(),
-                depth_view.data(), plane_view.data(),
-                color_view.data(), label_view.data(),
-                depth_view.shape(1), depth_view.shape(0));
+  void AddView(ndarray_d K,
+               ndarray_d R,
+               ndarray_d t,
+               ndarray_f depth,
+               ndarray_f plane,
+               ndarray_uint8 color,
+               ndarray_uint8 label) {
+    dp_.AddView(K.data(), R.data(), t.data(),
+                depth.data(), plane.data(),
+                color.data(), label.data(),
+                depth.shape(1), depth.shape(0));
   }
 
-  bp::object Prune() {
+  py::object Prune() {
     std::vector<float> points;
     std::vector<float> normals;
     std::vector<unsigned char> colors;
@@ -133,12 +116,12 @@ class DepthmapPrunerWrapper {
 
     dp_.Prune(&points, &normals, &colors, &labels);
 
-    bp::list retn;
+    py::list retn;
     int n = int(points.size()) / 3;
-    retn.append(bpn_array_from_data(&points[0], n, 3));
-    retn.append(bpn_array_from_data(&normals[0], n, 3));
-    retn.append(bpn_array_from_data(&colors[0], n, 3));
-    retn.append(bpn_array_from_data(&labels[0], n));
+    retn.append(py_array_from_data(&points[0], n, 3));
+    retn.append(py_array_from_data(&normals[0], n, 3));
+    retn.append(py_array_from_data(&colors[0], n, 3));
+    retn.append(py_array_from_data(&labels[0], n));
     return retn;
   }
 

--- a/opensfm/src/depthmap_wrapper.cc
+++ b/opensfm/src/depthmap_wrapper.cc
@@ -7,11 +7,11 @@ namespace csfm {
 
 class DepthmapEstimatorWrapper {
  public:
-  void AddView(ndarray_d K,
-               ndarray_d R,
-               ndarray_d t,
-               ndarray_uint8 image,
-               ndarray_uint8 mask) {
+  void AddView(pyarray_d K,
+               pyarray_d R,
+               pyarray_d t,
+               pyarray_uint8 image,
+               pyarray_uint8 mask) {
     de_.AddView(K.data(), R.data(), t.data(),
                 image.data(), mask.data(), image.shape(1), image.shape(0));
   }
@@ -70,10 +70,10 @@ class DepthmapCleanerWrapper {
     dc_.SetMinConsistentViews(n);
   }
 
-  void AddView(ndarray_d K,
-               ndarray_d R,
-               ndarray_d t,
-               ndarray_f depth) {
+  void AddView(pyarray_d K,
+               pyarray_d R,
+               pyarray_d t,
+               pyarray_f depth) {
     dc_.AddView(K.data(), R.data(), t.data(),
                 depth.data(), depth.shape(1), depth.shape(0));
   }
@@ -95,13 +95,13 @@ class DepthmapPrunerWrapper {
     dp_.SetSameDepthThreshold(t);
   }
 
-  void AddView(ndarray_d K,
-               ndarray_d R,
-               ndarray_d t,
-               ndarray_f depth,
-               ndarray_f plane,
-               ndarray_uint8 color,
-               ndarray_uint8 label) {
+  void AddView(pyarray_d K,
+               pyarray_d R,
+               pyarray_d t,
+               pyarray_f depth,
+               pyarray_f plane,
+               pyarray_uint8 color,
+               pyarray_uint8 label) {
     dp_.AddView(K.data(), R.data(), t.data(),
                 depth.data(), plane.data(),
                 color.data(), label.data(),

--- a/opensfm/src/hahog.cc
+++ b/opensfm/src/hahog.cc
@@ -13,14 +13,13 @@ extern "C" {
 
 namespace csfm {
 
-bp::object hahog(PyObject *image,
+py::object hahog(ndarray_f image,
                  float peak_threshold,
                  float edge_threshold,
                  int target_num_features,
                  bool use_adaptive_suppression) {
-  PyArrayContiguousView<float> im((PyArrayObject *)image);
 
-  if (im.valid()) {
+  if (image.size()) {
     //clock_t t_start = clock();
     // create a detector object
     VlCovDet * covdet = vl_covdet_new(VL_COVDET_METHOD_HESSIAN);
@@ -33,7 +32,7 @@ bp::object hahog(PyObject *image,
     vl_covdet_set_use_adaptive_suppression(covdet, use_adaptive_suppression);
 
     // process the image and run the detector
-    vl_covdet_put_image(covdet, im.data(), im.shape(1), im.shape(0));
+    vl_covdet_put_image(covdet, image.data(), image.shape(1), image.shape(0));
 
     //clock_t t_scalespace = clock();
 
@@ -107,12 +106,12 @@ bp::object hahog(PyObject *image,
     // std::cout << "t_orient " << float(t_orient - t_affine)/CLOCKS_PER_SEC << "\n";
     // std::cout << "description " << float(t_description - t_orient)/CLOCKS_PER_SEC << "\n";
 
-    bp::list retn;
-    retn.append(bpn_array_from_data(&points[0], numFeatures, 4));
-    retn.append(bpn_array_from_data(&desc[0], numFeatures, dimension));
+    py::list retn;
+    retn.append(py_array_from_data(&points[0], numFeatures, 4));
+    retn.append(py_array_from_data(&desc[0], numFeatures, dimension));
     return retn;
   }
-  return bp::object();
+  return py::object();
 }
 
 }

--- a/opensfm/src/hahog.cc
+++ b/opensfm/src/hahog.cc
@@ -13,7 +13,7 @@ extern "C" {
 
 namespace csfm {
 
-py::object hahog(ndarray_f image,
+py::object hahog(pyarray_f image,
                  float peak_threshold,
                  float edge_threshold,
                  int target_num_features,

--- a/opensfm/src/hahog.cc
+++ b/opensfm/src/hahog.cc
@@ -111,7 +111,7 @@ py::object hahog(ndarray_f image,
     retn.append(py_array_from_data(&desc[0], numFeatures, dimension));
     return retn;
   }
-  return py::object();
+  return py::none();
 }
 
 }

--- a/opensfm/src/hahog.h
+++ b/opensfm/src/hahog.h
@@ -5,7 +5,7 @@
 
 namespace csfm {
 
-bp::object hahog(PyObject *image,
+py::object hahog(ndarray_f image,
                  float peak_threshold,
                  float edge_threshold,
                  int target_num_features,

--- a/opensfm/src/hahog.h
+++ b/opensfm/src/hahog.h
@@ -5,7 +5,7 @@
 
 namespace csfm {
 
-py::object hahog(ndarray_f image,
+py::object hahog(pyarray_f image,
                  float peak_threshold,
                  float edge_threshold,
                  int target_num_features,

--- a/opensfm/src/multiview.cc
+++ b/opensfm/src/multiview.cc
@@ -76,8 +76,8 @@ py::object TriangulateBearingsDLT(const py::list &Rts_list,
     py::object oRt = Rts_list[i];
     py::object ob = bs_list[i];
 
-    ndarray_d Rt_array(oRt);
-    ndarray_d b_array(ob);
+    pyarray_d Rt_array(oRt);
+    pyarray_d b_array(ob);
 
     Eigen::Map<const Eigen::MatrixXd> Rt(Rt_array.data(), 4, 3);
     Eigen::Map<const Eigen::MatrixXd> b(b_array.data(), 3, 1);
@@ -165,8 +165,8 @@ py::object TriangulateBearingsMidpoint(const py::list &os_list,
   Eigen::Matrix<double, 3, Eigen::Dynamic> os(3, n);
   Eigen::Matrix<double, 3, Eigen::Dynamic> bs(3, n);
   for (int i = 0; i < n; ++i) {
-    ndarray_d o_array = os_list[i].cast<ndarray_d>();
-    ndarray_d b_array = bs_list[i].cast<ndarray_d>();
+    pyarray_d o_array = os_list[i].cast<pyarray_d>();
+    pyarray_d b_array = bs_list[i].cast<pyarray_d>();
     const double *o = o_array.data();
     const double *b = b_array.data();
     os.col(i) <<  o[0], o[1], o[2];

--- a/opensfm/src/multiview.cc
+++ b/opensfm/src/multiview.cc
@@ -31,9 +31,9 @@ double AngleBetweenVectors(const Eigen::Vector3d &u,
 }
 
 
-py::object TriangulateReturn(int error, py::object value) {
+py::list TriangulateReturn(int error, py::object value) {
     py::list retn;
-    retn.append(int(error));
+    retn.append(error);
     retn.append(value);
     return retn;
 }
@@ -105,7 +105,7 @@ py::object TriangulateBearingsDLT(const py::list &Rts_list,
   }
 
   if (!angle_ok) {
-    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::object());
+    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::none());
   }
 
   Eigen::Vector4d X = TriangulateBearingsDLTSolve(bs, Rts);
@@ -118,7 +118,7 @@ py::object TriangulateBearingsDLT(const py::list &Rts_list,
 
     double error = AngleBetweenVectors(x_reproj, b);
     if (error > threshold) {
-     return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::object());
+     return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::none());
     }
   }
 
@@ -165,8 +165,8 @@ py::object TriangulateBearingsMidpoint(const py::list &os_list,
   Eigen::Matrix<double, 3, Eigen::Dynamic> os(3, n);
   Eigen::Matrix<double, 3, Eigen::Dynamic> bs(3, n);
   for (int i = 0; i < n; ++i) {
-    ndarray_d o_array(os_list[i]);
-    ndarray_d b_array(bs_list[i]);
+    ndarray_d o_array = os_list[i].cast<ndarray_d>();
+    ndarray_d b_array = bs_list[i].cast<ndarray_d>();
     const double *o = o_array.data();
     const double *b = b_array.data();
     os.col(i) <<  o[0], o[1], o[2];
@@ -189,7 +189,7 @@ py::object TriangulateBearingsMidpoint(const py::list &os_list,
     }
   }
   if (!angle_ok) {
-    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::object());
+    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::none());
   }
 
   // Triangulate
@@ -202,7 +202,7 @@ py::object TriangulateBearingsMidpoint(const py::list &os_list,
 
     double error = AngleBetweenVectors(x_reproj, b);
     if (error > threshold_list[i].cast<float>()) {
-      return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::object());
+      return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::none());
     }
   }
 

--- a/opensfm/src/multiview.cc
+++ b/opensfm/src/multiview.cc
@@ -31,8 +31,8 @@ double AngleBetweenVectors(const Eigen::Vector3d &u,
 }
 
 
-bp::object TriangulateReturn(int error, bp::object value) {
-    bp::list retn;
+py::object TriangulateReturn(int error, py::object value) {
+    py::list retn;
     retn.append(int(error));
     retn.append(value);
     return retn;
@@ -62,22 +62,22 @@ Eigen::Vector4d TriangulateBearingsDLTSolve(
 }
 
 
-bp::object TriangulateBearingsDLT(const bp::list &Rts_list,
-                                  const bp::list &bs_list,
+py::object TriangulateBearingsDLT(const py::list &Rts_list,
+                                  const py::list &bs_list,
                                   double threshold,
                                   double min_angle) {
 
-  int n = bp::len(Rts_list);
+  int n = py::len(Rts_list);
   vector_mat34 Rts;
   Eigen::Matrix<double, 3, Eigen::Dynamic> bs(3, n);
   Eigen::MatrixXd vs(3, n);
   bool angle_ok = false;
   for (int i = 0; i < n; ++i) {
-    bp::object oRt = Rts_list[i];
-    bp::object ob = bs_list[i];
+    py::object oRt = Rts_list[i];
+    py::object ob = bs_list[i];
 
-    PyArrayContiguousView<double> Rt_array(oRt);
-    PyArrayContiguousView<double> b_array(ob);
+    ndarray_d Rt_array(oRt);
+    ndarray_d b_array(ob);
 
     Eigen::Map<const Eigen::MatrixXd> Rt(Rt_array.data(), 4, 3);
     Eigen::Map<const Eigen::MatrixXd> b(b_array.data(), 3, 1);
@@ -105,7 +105,7 @@ bp::object TriangulateBearingsDLT(const bp::list &Rts_list,
   }
 
   if (!angle_ok) {
-    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, bp::object());
+    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::object());
   }
 
   Eigen::Vector4d X = TriangulateBearingsDLTSolve(bs, Rts);
@@ -118,12 +118,12 @@ bp::object TriangulateBearingsDLT(const bp::list &Rts_list,
 
     double error = AngleBetweenVectors(x_reproj, b);
     if (error > threshold) {
-     return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, bp::object());
+     return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::object());
     }
   }
 
   return TriangulateReturn(TRIANGULATION_OK,
-                           bpn_array_from_data(X.data(), 3));
+                           py_array_from_data(X.data(), 3));
 }
 
 
@@ -155,18 +155,18 @@ Eigen::Vector3d TriangulateBearingsMidpointSolve(
 }
 
 
-bp::object TriangulateBearingsMidpoint(const bp::list &os_list,
-                                       const bp::list &bs_list,
-                                       const bp::list &threshold_list,
+py::object TriangulateBearingsMidpoint(const py::list &os_list,
+                                       const py::list &bs_list,
+                                       const py::list &threshold_list,
                                        double min_angle) {
-  int n = bp::len(os_list);
+  int n = py::len(os_list);
 
   // Build Eigen matrices
   Eigen::Matrix<double, 3, Eigen::Dynamic> os(3, n);
   Eigen::Matrix<double, 3, Eigen::Dynamic> bs(3, n);
   for (int i = 0; i < n; ++i) {
-    PyArrayContiguousView<double> o_array(os_list[i]);
-    PyArrayContiguousView<double> b_array(bs_list[i]);
+    ndarray_d o_array(os_list[i]);
+    ndarray_d b_array(bs_list[i]);
     const double *o = o_array.data();
     const double *b = b_array.data();
     os.col(i) <<  o[0], o[1], o[2];
@@ -189,7 +189,7 @@ bp::object TriangulateBearingsMidpoint(const bp::list &os_list,
     }
   }
   if (!angle_ok) {
-    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, bp::object());
+    return TriangulateReturn(TRIANGULATION_SMALL_ANGLE, py::object());
   }
 
   // Triangulate
@@ -201,13 +201,13 @@ bp::object TriangulateBearingsMidpoint(const bp::list &os_list,
     Eigen::Vector3d b = bs.col(i);
 
     double error = AngleBetweenVectors(x_reproj, b);
-    if (error > threshold_list[i]) {
-      return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, bp::object());
+    if (error > threshold_list[i].cast<float>()) {
+      return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::object());
     }
   }
 
   return TriangulateReturn(TRIANGULATION_OK,
-                           bpn_array_from_data(X.data(), 3));
+                           py_array_from_data(X.data(), 3));
 }
 
 

--- a/opensfm/src/openmvs_exporter.h
+++ b/opensfm/src/openmvs_exporter.h
@@ -9,7 +9,7 @@ class OpenMVSExporter {
  public:
   void AddCamera(
       const std::string &camera_id,
-      ndarray_d K) {
+      pyarray_d K) {
     MVS::Interface::Platform platform;
     platform.name = camera_id;
     MVS::Interface::Platform::Camera camera;
@@ -26,8 +26,8 @@ class OpenMVSExporter {
       const std::string &path,
       const std::string &shot_id,
       const std::string &camera_id,
-      ndarray_d R,
-      ndarray_d C) {
+      pyarray_d R,
+      pyarray_d C) {
     const double *C_data = C.data();
 
     int platform_id = platform_ids_[camera_id];
@@ -50,7 +50,7 @@ class OpenMVSExporter {
   }
 
   void AddPoint(
-      ndarray_d coordinates,
+      pyarray_d coordinates,
       py::list shot_ids) {
     const double *x = coordinates.data();
 

--- a/opensfm/src/openmvs_exporter.h
+++ b/opensfm/src/openmvs_exporter.h
@@ -9,14 +9,11 @@ class OpenMVSExporter {
  public:
   void AddCamera(
       const std::string &camera_id,
-      PyObject *K) {
-
-    PyArrayContiguousView<double> K_view((PyArrayObject *)K);
-
+      ndarray_d K) {
     MVS::Interface::Platform platform;
     platform.name = camera_id;
     MVS::Interface::Platform::Camera camera;
-    camera.K = cv::Matx33d(K_view.data());
+    camera.K = cv::Matx33d(K.data());
     camera.R = cv::Matx33d::eye();
     camera.C = cv::Point3_<double>(0, 0, 0);
     platform.cameras.push_back(camera);
@@ -29,17 +26,15 @@ class OpenMVSExporter {
       const std::string &path,
       const std::string &shot_id,
       const std::string &camera_id,
-      PyObject *R,
-      PyObject *C) {
-    PyArrayContiguousView<double> R_view((PyArrayObject *)R);
-    PyArrayContiguousView<double> C_view((PyArrayObject *)C);
-    const double *C_data = C_view.data();
+      ndarray_d R,
+      ndarray_d C) {
+    const double *C_data = C.data();
 
     int platform_id = platform_ids_[camera_id];
     MVS::Interface::Platform &platform = scene_.platforms[platform_id];
 
     MVS::Interface::Platform::Pose pose;
-    pose.R = cv::Matx33d(R_view.data());
+    pose.R = cv::Matx33d(R.data());
     pose.C = cv::Point3_<double>(C_data[0], C_data[1], C_data[2]);
     int pose_id = platform.poses.size();
     platform.poses.push_back(pose);
@@ -55,15 +50,14 @@ class OpenMVSExporter {
   }
 
   void AddPoint(
-      PyObject *coordinates,
-      bp::list shot_ids) {
-    PyArrayContiguousView<double> coordinates_view((PyArrayObject *)coordinates);
-    const double *x = coordinates_view.data();
+      ndarray_d coordinates,
+      py::list shot_ids) {
+    const double *x = coordinates.data();
 
     MVS::Interface::Vertex vertex;
     vertex.X = cv::Point3_<double>(x[0], x[1], x[2]);
     for (int i = 0; i < len(shot_ids); ++i) {
-      std::string shot_id = bp::extract<std::string>(shot_ids[i]);
+      std::string shot_id = shot_ids[i].cast<std::string>();
       MVS::Interface::Vertex::View view;
       view.imageID = image_ids_[shot_id];
       view.confidence = 0;

--- a/opensfm/src/types.h
+++ b/opensfm/src/types.h
@@ -13,9 +13,9 @@ namespace csfm {
 namespace py = pybind11;
 
 
-typedef py::array_t<float, py::array::c_style | py::array::forcecast> ndarray_f;
-typedef py::array_t<double, py::array::c_style | py::array::forcecast> ndarray_d;
-typedef py::array_t<unsigned char, py::array::c_style | py::array::forcecast> ndarray_uint8;
+typedef py::array_t<float, py::array::c_style | py::array::forcecast> pyarray_f;
+typedef py::array_t<double, py::array::c_style | py::array::forcecast> pyarray_d;
+typedef py::array_t<unsigned char, py::array::c_style | py::array::forcecast> pyarray_uint8;
 
 template <typename T>
 py::array_t<T> py_array_from_data(const T *data, size_t shape0) {

--- a/opensfm/src/types.h
+++ b/opensfm/src/types.h
@@ -1,170 +1,48 @@
 #ifndef __TYPES_H__
 #define __TYPES_H__
 
-#include <boost/python.hpp>
-#ifdef USE_BOOST_PYTHON_NUMPY
-#include <boost/python/numpy.hpp>
-#endif
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 
 #include <vector>
 #include <iostream>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/ndarrayobject.h>
-
 
 namespace csfm {
 
-namespace bp = boost::python;
-
-template <typename T> inline int numpy_typenum() {}
-template <> inline int numpy_typenum<bool>() { return NPY_BOOL; }
-template <> inline int numpy_typenum<char>() { return NPY_INT8; }
-template <> inline int numpy_typenum<short>() { return NPY_INT16; }
-template <> inline int numpy_typenum<int>() { return NPY_INT32; }
-template <> inline int numpy_typenum<long long>() { return NPY_INT64; }
-template <> inline int numpy_typenum<unsigned char>() { return NPY_UINT8; }
-template <> inline int numpy_typenum<unsigned short>() { return NPY_UINT16; }
-template <> inline int numpy_typenum<unsigned int>() { return NPY_UINT32; }
-template <> inline int numpy_typenum<unsigned long long>() { return NPY_UINT64; }
-template <> inline int numpy_typenum<float>() { return NPY_FLOAT32; }
-template <> inline int numpy_typenum<double>() { return NPY_FLOAT64; }
-
-template <typename T> inline const char *type_string() {}
-template <> inline const char *type_string<bool>() { return "bool"; }
-template <> inline const char *type_string<char>() { return "int8"; }
-template <> inline const char *type_string<short>() { return "int16"; }
-template <> inline const char *type_string<int>() { return "int32"; }
-template <> inline const char *type_string<long long>() { return "int64"; }
-template <> inline const char *type_string<unsigned char>() { return "uint8"; }
-template <> inline const char *type_string<unsigned short>() { return "uint16"; }
-template <> inline const char *type_string<unsigned int>() { return "uint32"; }
-template <> inline const char *type_string<unsigned long long>() { return "uint64"; }
-template <> inline const char *type_string<float>() { return "float32"; }
-template <> inline const char *type_string<double>() { return "float64"; }
+namespace py = pybind11;
 
 
-#ifdef USE_BOOST_PYTHON_NUMPY
-
-namespace bpn = boost::python::numpy;
-typedef bpn::ndarray ndarray;
+typedef py::array_t<float, py::array::c_style | py::array::forcecast> ndarray_f;
+typedef py::array_t<double, py::array::c_style | py::array::forcecast> ndarray_d;
+typedef py::array_t<unsigned char, py::array::c_style | py::array::forcecast> ndarray_uint8;
 
 template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0) {
-  bp::tuple shape = bp::make_tuple(shape0);
-  bpn::dtype dtype =  bpn::dtype::get_builtin<T>();
-  bpn::ndarray res = bpn::empty(shape, dtype);
-  std::copy(data, data + shape0, reinterpret_cast<T*>(res.get_data()));
+py::array_t<T> py_array_from_data(const T *data, size_t shape0) {
+  py::array_t<T> res({shape0});
+  std::copy(data, data + shape0, res.mutable_data());
   return res;
 }
 
 template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0, int shape1) {
-  bp::tuple shape = bp::make_tuple(shape0, shape1);
-  bpn::dtype dtype =  bpn::dtype::get_builtin<T>();
-  bpn::ndarray res = bpn::empty(shape, dtype);
-  std::copy(data, data + shape0 * shape1, reinterpret_cast<T*>(res.get_data()));
+py::array_t<T> py_array_from_data(const T *data, size_t shape0, size_t shape1) {
+  py::array_t<T> res({shape0, shape1});
+  std::copy(data, data + shape0 * shape1, res.mutable_data());
   return res;
 }
 
 template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0, int shape1, int shape2) {
-  bp::tuple shape = bp::make_tuple(shape0, shape1, shape2);
-  bpn::dtype dtype =  bpn::dtype::get_builtin<T>();
-  bpn::ndarray res = bpn::empty(shape, dtype);
-  std::copy(data, data + shape0 * shape1 * shape2, reinterpret_cast<T*>(res.get_data()));
+py::array_t<T> py_array_from_data(const T *data, size_t shape0, size_t shape1, size_t shape2) {
+  py::array_t<T> res({shape0, shape1, shape2});
+  std::copy(data, data + shape0 * shape1 * shape2, res.mutable_data());
   return res;
 }
 
-#else
-
-namespace bpn = boost::python::numeric;
-typedef bpn::array ndarray;
-
 template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0) {
-  npy_intp shape[1] = {shape0};
-  PyObject *pyarray = PyArray_SimpleNewFromData(
-      1, shape, numpy_typenum<T>(), (void *)data);
-  bp::handle<> handle(pyarray);
-  return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
-}
-
-template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0, int shape1) {
-  npy_intp shape[2] = {shape0, shape1};
-  PyObject *pyarray = PyArray_SimpleNewFromData(
-      2, shape, numpy_typenum<T>(), (void *)data);
-  bp::handle<> handle(pyarray);
-  return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
-}
-
-template <typename T>
-bp::object bpn_array_from_data(const T *data, int shape0, int shape1, int shape2) {
-  npy_intp shape[3] = {shape0, shape1, shape2};
-  PyObject *pyarray = PyArray_SimpleNewFromData(
-      3, shape, numpy_typenum<T>(), (void *)data);
-  bp::handle<> handle(pyarray);
-  return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
-}
-
-#endif
-
-
-template <typename T>
-bp::object bpn_array_from_vector(const std::vector<T> &v) {
+py::array_t<T> py_array_from_vector(const std::vector<T> &v) {
   const T *data = v.size() ? &v[0] : NULL;
-  return bpn_array_from_data(data, v.size());
+  return py_array_from_data(data, v.size());
 }
-
-template<typename T>
-class PyArrayContiguousView {
- public:
-  PyArrayContiguousView(ndarray array) {
-    init((PyArrayObject *)array.ptr());
-  }
-
-  PyArrayContiguousView(bp::object object) {
-    init((PyArrayObject *)object.ptr());
-  }
-
-  PyArrayContiguousView(PyArrayObject *object) {
-    init(object);
-  }
-
-  ~PyArrayContiguousView() {
-    if (contiguous_) Py_DECREF(contiguous_);
-  }
-
-  const T *data() const {
-    return (T *)PyArray_DATA(contiguous_);
-  }
-
-  int ndim() const {
-    return PyArray_NDIM(contiguous_);
-  }
-
-  int shape(int dim) const {
-    return PyArray_DIMS(contiguous_)[dim];
-  }
-
-  bool valid() {
-    return contiguous_ != NULL;
-  }
-
- private:
-  void init(PyArrayObject *object) {
-    int type = PyArray_DESCR(object)->type_num;
-    if (type != numpy_typenum<T>()) {
-      std::cerr << "Error in PyArrayContiguousView: expected array of type " << type_string<T>() << std::endl;
-      contiguous_ = NULL;
-    } else {
-      contiguous_ = (PyArrayObject *)PyArray_ContiguousFromAny((PyObject *)object, numpy_typenum<T>(), 0, 0);
-    }
-  };
-
-  PyArrayObject *contiguous_;
-};
 
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 testpaths = opensfm
+norecursedirs = opensfm/src
 addopts = --doctest-modules

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,7 @@ cmake_command = ['cmake', '../opensfm/src']
 if sys.version_info >= (3, 0):
     cmake_command.extend([
         '-DBUILD_FOR_PYTHON3=ON',
-        '-DBOOST_PYTHON3_COMPONENT=python-py{}{}'.format(
-            sys.version_info.major,
-            sys.version_info.minor)])
+    ])
 subprocess.Popen(cmake_command, cwd='cmake_build').wait()
 
 print("Compiling extension...")


### PR DESCRIPTION
This PR replace the boost python based binding code with pybind11.
Main motivations:
- simpler to build for python 2 and 3
- simpler to maintain since pybind11 is included as a submodule. Support for different versions of boost python was difficult.

The only impact that this should have is that, in order to build opensfm, we now need first update git submodules with
```
git submodule update --init --recursive
```
To make sure we have `pybind11` code update. 