### PR TITLE
Enable overriding of default OpenMP number of threads limit in libAKAZE

### DIFF
--- a/opensfm/src/third_party/akaze/lib/AKAZEConfig.h
+++ b/opensfm/src/third_party/akaze/lib/AKAZEConfig.h
@@ -14,7 +14,9 @@
 // OpenMP
 #ifdef _OPENMP
 #include <omp.h>
+#ifndef OMP_MAX_THREADS
 #define OMP_MAX_THREADS 16
+#endif
 #endif
 
 // System


### PR DESCRIPTION
`OMP_MAX_THREADS` can now be specified without having to modify `AKAZEConfig.h`. This also serves as a safeguard against accidental check-in of a modified `AKAZEConfig.h`, which prevents messing up the default configuration.