### PR TITLE
Add time zone support to time stamp extraction

### DIFF
--- a/bin/focal_from_exif
+++ b/bin/focal_from_exif
@@ -59,4 +59,4 @@ data.save_camera_models(camera_models)
 
 end = time.time()
 with open(data.profile_log(), 'a') as fout:
-    fout.write('focal_from_exif: {0}\n'.format(end - start))
+    fout.write('extract_metadata: {0}\n'.format(end - start))

--- a/opensfm/commands/extract_metadata.py
+++ b/opensfm/commands/extract_metadata.py
@@ -57,7 +57,7 @@ class Command:
 
         end = time.time()
         with open(data.profile_log(), 'a') as fout:
-            fout.write('focal_from_exif: {0}\n'.format(end - start))
+            fout.write('extract_metadata: {0}\n'.format(end - start))
 
     def _extract_exif(self, image, data):
          # EXIF data in Image


### PR DESCRIPTION
`DateTime*` time stamps are adjusted by time zone offsets `OffsetTimeOriginal`, `OffsetTimeDigitized`, and `OffsetTime` respectively, if available. Otherwise, UTC is naively assumed on any `DateTime*`.

The time stamp is extracted in the following order of decreasing precedence:
 * `GPSDateStamp` and `GPSTimeStamp`
 * `DateTimeOriginal` + `SubSecTimeOriginal` + `OffsetTimeOriginal`
 * `DateTimeDigitized` + `SubSecTimeDigitized` + `OffsetTimeDigitized`
 * `DateTime` + `SubSecTime` + `OffsetTime`
 * `DateTimeOriginal` + `SubSecTimeOriginal` (*UTC*)
 * `DateTimeDigitized` + `SubSecTimeDigitized` (*UTC*)
 * `DateTime` + `SubSecTime` (*UTC*)