### PR TITLE
Update Installation Instructions

### DIFF
--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -52,7 +52,7 @@ Install OpenCV and the Ceres solver using::
 And install OpenGV using::
 
     brew install eigen
-    git clone https://github.com/paulinus/opengv.git
+    git clone --recurse-submodules -j8 https://github.com/paulinus/opengv.git
     cd opengv/build
     cd opengv/build
     cmake .. -DBUILD_TESTS=OFF -DBUILD_PYTHON=ON


### PR DESCRIPTION
Changed: `git clone https://github.com/paulinus/opengv.git` to `git clone --recurse-submodules -j8 https://github.com/paulinus/opengv.git`

Notes:
opengv contains sub modules, we need recursive git cloning, otherwise not all the modules will be loaded.