### PR TITLE
add xiaomi gimbal camera ccd width, fix extra space

### DIFF
--- a/opensfm/data/sensor_data.json
+++ b/opensfm/data/sensor_data.json
@@ -3641,6 +3641,7 @@
     "Yakumo Mega Image X": 7.11,
     "Yakumo Mega Image XL": 4.23,
     "Yakumo Mega Image XS": 6.4,
+    "YTXJ02FM": 6.17,
     "Google Nexus S": 3.9,
     "HUAWEI HUAWEI P6-U06": 4.8,
     "oneplu A000": 4.8,

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -57,7 +57,7 @@ def sensor_string(make, model):
     if make != 'unknown':
         # remove duplicate 'make' information in 'model'
         model = model.replace(make, '')
-    return (make.strip() + ' ' + model.strip()).lower()
+    return (make.strip() + ' ' + model.strip()).strip().lower()
 
 
 def camera_id(exif):


### PR DESCRIPTION
Xiaomi gimbal camera data is missing.
Fix extra space in the beginning of model string due to non valid utf8 bytes in exif data.