### PR TITLE
Add options to set undistorted image format and max size

### DIFF
--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -19,6 +19,7 @@ class Command:
         parser.add_argument('--undistorted',
                             action='store_true',
                             help='export the undistorted reconstruction')
+        parser.add_argument('--image_extension', choices=["jpg", "png"], default="jpg", type=str, help='Extension of images. Default: %(default)s')
         parser.add_argument('--scale_focal', default=1.0, type=float, help='Scale the focal length by this value. Default: %(default)s (no scale)')
 
     def run(self, args):
@@ -31,15 +32,15 @@ class Command:
             graph = data.load_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.scale_focal)
+            self.export(reconstructions[0], graph, data, args.image_extension, args.scale_focal)
 
-    def export(self, reconstruction, graph, data, scale_focal = 1.0):
+    def export(self, reconstruction, graph, data, image_extension = 'jpg', scale_focal = 1.0):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
             words = [
-                self.image_path(shot.id, data),
+                self.image_path(shot.id, data, image_extension),
                 shot.camera.focal * max(shot.camera.width, shot.camera.height) * scale_focal,
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
@@ -51,13 +52,7 @@ class Command:
         with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data):
+    def image_path(self, image, data, extension):
         """Path to the undistorted image relative to the dataset path."""
-        extensions = ['png', 'jpg']
-        for extension in extensions:
-            path = data._undistorted_image_file(image, extension)
-            if os.path.exists(path) or extension == extensions[-1]:
-                return os.path.relpath(path, data.data_path)
-                
-
-         
+        path = data._undistorted_image_file(image, extension)
+        return os.path.relpath(path, data.data_path)

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -19,8 +19,6 @@ class Command:
         parser.add_argument('--undistorted',
                             action='store_true',
                             help='export the undistorted reconstruction')
-        parser.add_argument('--image_extension', choices=["jpg", "png"], default="jpg", type=str, help='Extension of images. Default: %(default)s')
-        parser.add_argument('--scale_focal', default=1.0, type=float, help='Scale the focal length by this value. Default: %(default)s (no scale)')
 
     def run(self, args):
         data = dataset.DataSet(args.dataset)
@@ -32,16 +30,17 @@ class Command:
             graph = data.load_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.image_extension, args.scale_focal)
+            self.export(reconstructions[0], graph, data)
 
-    def export(self, reconstruction, graph, data, image_extension = 'jpg', scale_focal = 1.0):
+    def export(self, reconstruction, graph, data):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
+            size = max(self.image_size(shot.id, data))
             words = [
-                self.image_path(shot.id, data, image_extension),
-                shot.camera.focal * max(shot.camera.width, shot.camera.height) * scale_focal,
+                self.image_path(shot.id, data),
+                shot.camera.focal * size,
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
                 '0', '0',
@@ -52,7 +51,12 @@ class Command:
         with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data, extension):
+    def image_path(self, image, data):
         """Path to the undistorted image relative to the dataset path."""
-        path = data._undistorted_image_file(image, extension)
+        path = data._undistorted_image_file(image)
         return os.path.relpath(path, data.data_path)
+
+    def image_size(self, image, data):
+        """Height and width of the undistorted image."""
+        image = data.load_undistorted_image(image)
+        return image.shape[:2]

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -19,7 +19,6 @@ class Command:
         parser.add_argument('--undistorted',
                             action='store_true',
                             help='export the undistorted reconstruction')
-        parser.add_argument('--image_extension', choices=["jpg", "png"], default="jpg", type=str, help='Extension of images. Default: %(default)s')
         parser.add_argument('--scale_focal', default=1.0, type=float, help='Scale the focal length by this value. Default: %(default)s (no scale)')
 
     def run(self, args):
@@ -32,15 +31,15 @@ class Command:
             graph = data.load_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.image_extension, args.scale_focal)
+            self.export(reconstructions[0], graph, data, args.scale_focal)
 
-    def export(self, reconstruction, graph, data, image_extension = 'jpg', scale_focal = 1.0):
+    def export(self, reconstruction, graph, data, scale_focal = 1.0):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
             words = [
-                self.image_path(shot.id, data, image_extension),
+                self.image_path(shot.id, data),
                 shot.camera.focal * max(shot.camera.width, shot.camera.height) * scale_focal,
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
@@ -52,7 +51,13 @@ class Command:
         with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data, extension):
+    def image_path(self, image, data):
         """Path to the undistorted image relative to the dataset path."""
-        path = data._undistorted_image_file(image, extension)
-        return os.path.relpath(path, data.data_path)
+        extensions = ['png', 'jpg']
+        for extension in extensions:
+            path = data._undistorted_image_file(image, extension)
+            if os.path.exists(path) or extension == extensions[-1]:
+                return os.path.relpath(path, data.data_path)
+                
+
+         

--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -116,7 +116,7 @@ def undistort_image(arguments):
         new_camera = undistorted_shots[0].camera
         uf = undistort_function[projection_type]
         undistorted = uf(image, shot.camera, new_camera, interpolation)
-        undistorted = scale_image(undistorted, interpolation, image_scale)
+        undistorted = scale_image(undistorted, image_scale)
         getattr(data, save_image)(shot.id, undistorted, image_format)
     elif projection_type in ['equirectangular', 'spherical']:
         original = getattr(data, load_image)(shot.id)
@@ -130,7 +130,7 @@ def undistort_image(arguments):
             undistorted = render_perspective_view_of_a_panorama(
                 image, shot, subshot,
                 cv2.INTER_LINEAR if interpolation == cv2.INTER_AREA else interpolation)
-            undistorted = scale_image(undistorted, interpolation, image_scale)
+            undistorted = scale_image(undistorted, image_scale)
             getattr(data, save_image)(subshot.id, undistorted, image_format)
     else:
         raise NotImplementedError(
@@ -138,7 +138,7 @@ def undistort_image(arguments):
                 shot.camera.projection_type))
 
 
-def scale_image(image, interpolation, scale_factor):
+def scale_image(image, scale_factor):
     """Scale an image by a factor."""
     if scale_factor == 1.0:
         return image
@@ -146,7 +146,7 @@ def scale_image(image, interpolation, scale_factor):
     height, width, _ = image.shape
     width = int(width * scale_factor)
     height = int(height * scale_factor)
-    return cv2.resize(image, (width, height), interpolation=interpolation)
+    return cv2.resize(image, (width, height), interpolation=cv2.INTER_NEAREST)
 
 
 def undistort_perspective_image(image, camera, new_camera, interpolation):

--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -125,7 +125,6 @@ def undistort_image(arguments):
         subshot_width = int(data.config['depthmap_resolution'])
         width = 4 * subshot_width
         height = width // 2
-
         image = cv2.resize(original, (width, height), interpolation=interpolation)
         for subshot in undistorted_shots:
             undistorted = render_perspective_view_of_a_panorama(

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -112,6 +112,10 @@ nav_turn_view_threshold: 40           # Maximum difference of angles in degrees 
 nav_vertical_threshold: 20            # Maximum vertical angle difference in motion and viewing direction in degrees
 nav_rotation_threshold: 30            # Maximum general rotation in degrees between cameras for steps
 
+# Params for image undistortion
+undistorted_image_format: jpg         # Format in which to save the undistorted images
+undistorted_image_max_size: 100000    # Max width and height of the undistorted image
+
 # Params for depth estimation
 depthmap_method: PATCH_MATCH_SAMPLE   # Raw depthmap computation algorithm (PATCH_MATCH, BRUTE_FORCE, PATCH_MATCH_SAMPLE)
 depthmap_resolution: 640              # Resolution of the depth maps

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -83,7 +83,11 @@ class DataSet(object):
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
-        return io.imread(self._undistorted_image_file(image))
+        for extension in ['jpg', 'png']:
+            if os.path.exists(self._undistorted_image_file(image, extension)):
+                return io.imread(self._undistorted_image_file(image, extension))
+        
+        raise OSError("Cannot read image {}. File does not exist.".format(image))
 
     def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -77,17 +77,20 @@ class DataSet(object):
     def _undistorted_image_path(self):
         return os.path.join(self.data_path, 'undistorted')
 
-    def _undistorted_image_file(self, image, extension = 'jpg'):
+    def _undistorted_image_file(self, image):
         """Path of undistorted version of an image."""
-        return os.path.join(self._undistorted_image_path(), image + '.' + extension)
+        image_format = self.config['undistorted_image_format']
+        filename = image + '.' + image_format
+        return os.path.join(self._undistorted_image_path(), filename)
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
         return io.imread(self._undistorted_image_file(image))
 
-    def save_undistorted_image(self, image, array, image_format = 'jpg'):
+    def save_undistorted_image(self, image, array):
+        """Save undistorted image pixels."""
         io.mkdir_p(self._undistorted_image_path())
-        cv2.imwrite(self._undistorted_image_file(image, image_format), array[:, :, ::-1])
+        cv2.imwrite(self._undistorted_image_file(image), array[:, :, ::-1])
 
     def _load_mask_list(self):
         """Load mask list from mask_list.txt or list masks/ folder."""

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -83,11 +83,7 @@ class DataSet(object):
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
-        for extension in ['jpg', 'png']:
-            if os.path.exists(self._undistorted_image_file(image, extension)):
-                return io.imread(self._undistorted_image_file(image, extension))
-        
-        raise OSError("Cannot read image {}. File does not exist.".format(image))
+        return io.imread(self._undistorted_image_file(image))
 
     def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -77,17 +77,17 @@ class DataSet(object):
     def _undistorted_image_path(self):
         return os.path.join(self.data_path, 'undistorted')
 
-    def _undistorted_image_file(self, image):
+    def _undistorted_image_file(self, image, extension = 'jpg'):
         """Path of undistorted version of an image."""
-        return os.path.join(self._undistorted_image_path(), image + '.jpg')
+        return os.path.join(self._undistorted_image_path(), image + '.' + extension)
 
     def load_undistorted_image(self, image):
         """Load undistorted image pixels as a numpy array."""
         return io.imread(self._undistorted_image_file(image))
 
-    def save_undistorted_image(self, image, array):
+    def save_undistorted_image(self, image, array, image_format = 'jpg'):
         io.mkdir_p(self._undistorted_image_path())
-        cv2.imwrite(self._undistorted_image_file(image), array[:, :, ::-1])
+        cv2.imwrite(self._undistorted_image_file(image, image_format), array[:, :, ::-1])
 
     def _load_mask_list(self):
         """Load mask list from mask_list.txt or list masks/ folder."""


### PR DESCRIPTION
This PR adds two config options for image undistortion
```
undistorted_image_format: jpg         # Format in which to save the undistorted images
undistorted_image_max_size: 100000    # Max width and height of the undistorted image
```

It is a continuation of #352 with the following differences:
- undistorting the different layers (image, mask, segmentation) is now done sequentially so that each can be configured easierly.
- the command line options are moved to config options so that they are accessible for all commands. Otherwise, one could undistort in png format while the `compute_depthmaps` command would keep trying to load jpg files.