### PR TITLE
Resolve export_openmvs.py Python 3 compat issue.

### DIFF
--- a/opensfm/commands/export_openmvs.py
+++ b/opensfm/commands/export_openmvs.py
@@ -49,6 +49,11 @@ class Command:
 
         for point in reconstruction.points.values():
             shots = graph[point.id].keys()
+
+            # Python 3: keys() returns a dict_keys, OpenMVSExporter::add_point() requires a list
+            if not isinstance(shots, list):
+                shots = list(shots)
+
             coordinates = np.array(point.coordinates, dtype=np.float64)
             exporter.add_point(coordinates, shots)
 

--- a/opensfm/commands/export_openmvs.py
+++ b/opensfm/commands/export_openmvs.py
@@ -50,10 +50,6 @@ class Command:
         for point in reconstruction.points.values():
             shots = list(graph[point.id])
 
-            # Python 3: keys() returns a dict_keys, OpenMVSExporter::add_point() requires a list
-            if not isinstance(shots, list):
-                shots = list(shots)
-
             coordinates = np.array(point.coordinates, dtype=np.float64)
             exporter.add_point(coordinates, shots)
 

--- a/opensfm/commands/export_openmvs.py
+++ b/opensfm/commands/export_openmvs.py
@@ -48,7 +48,7 @@ class Command:
                     shot.pose.get_origin())
 
         for point in reconstruction.points.values():
-            shots = graph[point.id].keys()
+            shots = list(graph[point.id])
 
             # Python 3: keys() returns a dict_keys, OpenMVSExporter::add_point() requires a list
             if not isinstance(shots, list):


### PR DESCRIPTION
It looks like other uses of .keys() are just wrapped in list(), let me know if you would prefer that for this line also.

Test with:
```sh
bin/opensfm_run_all data/berlin
bin/opensfm export_openmvs data/berlin
```

Error:
```
Traceback (most recent call last):
  File "bin/opensfm", line 34, in <module>
    command.run(args)
  File "/home/user/OpenSfM_python3/opensfm/commands/export_openmvs.py", line 26, in run
    self.export(reconstructions[0], graph, data)
  File "/home/user/OpenSfM_python3/opensfm/commands/export_openmvs.py", line 57, in export
    exporter.add_point(coordinates, shots)
TypeError: add_point(): incompatible function arguments. The following argument types are supported:
    1. (self: opensfm.csfm.OpenMVSExporter, arg0: numpy.ndarray[float64], arg1: list) -> None

```