### PR TITLE
fix: typo in inch_in_mm

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -13,7 +13,7 @@ from opensfm import types
 
 logger = logging.getLogger(__name__)
 
-inch_in_mm = 1609334.0 / 1760.0 / 3.0 / 12.0
+inch_in_mm = 25.4
 
 
 def eval_frac(value):


### PR DESCRIPTION
@paulinus I am sorry for this. My SI units print with US customary units equivalents has a typo in the length of a mile in mm. So, I have double-checked twice now. The US customary units system defines an inch as exactly 25.4 mm, instead of 804667 / 31680 = 25.39984217… mm. I could not wrap around my head why the exact length of an inch in mm (in my SI units print) was not exactly a multiple of a mile in mm. Fortunately, the error is so marginal that it is negligible but it is better to be correct than sorry later.