### PR TITLE
feature: scale 2D projection errors by their detected scale

### DIFF
--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -330,6 +330,7 @@ def add_subshot_tracks(graph, ugraph, shot, subshot):
             ugraph.add_edge(
                 subshot.id, track_id,
                 feature=edge['feature'],
+                feature_scale=edge['feature_scale'],
                 feature_id=edge['feature_id'],
                 feature_color=edge['feature_color'])
 

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -735,12 +735,13 @@ class DataSet(object):
 def load_tracks_graph(fileobj):
     g = nx.Graph()
     for line in fileobj:
-        image, track, observation, x, y, R, G, B = line.split('\t')
+        image, track, observation, x, y, scale, R, G, B = line.split('\t')
         g.add_node(image, bipartite=0)
         g.add_node(track, bipartite=1)
         g.add_edge(
             image, track,
             feature=(float(x), float(y)),
+            feature_scale=float(scale),
             feature_id=int(observation),
             feature_color=(float(R), float(G), float(B)))
     return g
@@ -752,7 +753,8 @@ def save_tracks_graph(fileobj, graph):
             image = node
             for track, data in graph[image].items():
                 x, y = data['feature']
+                s = data['feature_scale']
                 fid = data['feature_id']
                 r, g, b = data['feature_color']
-                fileobj.write(u'%s\t%s\t%d\t%g\t%g\t%g\t%g\t%g\n' % (
-                    str(image), str(track), fid, x, y, r, g, b))
+                fileobj.write(u'%s\t%s\t%d\t%g\t%g\t%g\t%g\t%g\t%g\n' % (
+                    str(image), str(track), fid, x, y, s, r, g, b))

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -135,8 +135,10 @@ def bundle(graph, reconstruction, gcp, config):
         if shot_id in graph:
             for track in graph[shot_id]:
                 if track in reconstruction.points:
+                    point = graph[shot_id][track]['feature']
+                    scale = graph[shot_id][track]['feature_scale']
                     ba.add_observation(shot_id, track,
-                                       *graph[shot_id][track]['feature'])
+                                       point[0], point[1], scale)
 
     if config['bundle_use_gps']:
         for shot in reconstruction.shots.values():
@@ -211,8 +213,10 @@ def bundle_single_view(graph, reconstruction, shot_id, config):
             track = reconstruction.points[track_id]
             x = track.coordinates
             ba.add_point(track_id, x[0], x[1], x[2], True)
+            point = graph[shot_id][track_id]['feature']
+            scale = graph[shot_id][track_id]['feature_scale']
             ba.add_observation(shot_id, track_id,
-                               *graph[shot_id][track_id]['feature'])
+                                point[0], point[1], scale)
 
     if config['bundle_use_gps']:
         g = shot.metadata.gps_position
@@ -290,8 +294,10 @@ def bundle_local(graph, reconstruction, gcp, central_shot_id, config):
         if shot_id in graph:
             for track in graph[shot_id]:
                 if track in point_ids:
+                    point = graph[shot_id][track]['feature']
+                    scale = graph[shot_id][track]['feature_scale']
                     ba.add_observation(shot_id, track,
-                                       *graph[shot_id][track]['feature'])
+                                       point[0], point[1], scale)
 
     if config['bundle_use_gps']:
         for shot_id in interior:

--- a/opensfm/src/bundle.h
+++ b/opensfm/src/bundle.h
@@ -170,6 +170,7 @@ struct BAObservation {
   BACamera *camera;
   BAShot *shot;
   BAPoint *point;
+  double std_deviation;
 };
 
 struct BARotationPrior {
@@ -996,13 +997,15 @@ class BundleAdjuster {
       const std::string &shot,
       const std::string &point,
       double x,
-      double y) {
+      double y,
+      double std_deviation) {
     BAObservation o;
     o.shot = &shots_[shot];
     o.camera = cameras_[o.shot->camera].get();
     o.point = &points_[point];
     o.coordinates[0] = x;
     o.coordinates[1] = y;
+    o.std_deviation = std_deviation;
     observations_.push_back(o);
   }
 
@@ -1391,7 +1394,7 @@ class BundleAdjuster {
             new ceres::AutoDiffCostFunction<PerspectiveReprojectionError, 2, 3, 6, 3>(
                 new PerspectiveReprojectionError(observation.coordinates[0],
                                                   observation.coordinates[1],
-                                                  reprojection_error_sd_));
+                                                  observation.std_deviation));
 
         problem->AddResidualBlock(cost_function,
                                   loss,
@@ -1407,7 +1410,7 @@ class BundleAdjuster {
             new ceres::AutoDiffCostFunction<BrownPerspectiveReprojectionError, 2, 9, 6, 3>(
                 new BrownPerspectiveReprojectionError(observation.coordinates[0],
                                                       observation.coordinates[1],
-                                                      reprojection_error_sd_));
+                                                      observation.std_deviation));
 
         problem->AddResidualBlock(cost_function,
                                   loss,
@@ -1423,7 +1426,7 @@ class BundleAdjuster {
             new ceres::AutoDiffCostFunction<FisheyeReprojectionError, 2, 3, 6, 3>(
                 new FisheyeReprojectionError(observation.coordinates[0],
                                               observation.coordinates[1],
-                                              reprojection_error_sd_));
+                                              observation.std_deviation));
 
         problem->AddResidualBlock(cost_function,
                                   loss,
@@ -1439,7 +1442,7 @@ class BundleAdjuster {
             new ceres::AutoDiffCostFunction<EquirectangularReprojectionError, 3, 6, 3>(
                 new EquirectangularReprojectionError(observation.coordinates[0],
                                                       observation.coordinates[1],
-                                                      reprojection_error_sd_));
+                                                      observation.std_deviation));
 
         problem->AddResidualBlock(cost_function,
                                   loss,

--- a/opensfm/synthetic_data/synthetic_generator.py
+++ b/opensfm/synthetic_data/synthetic_generator.py
@@ -264,6 +264,7 @@ def generate_track_data(reconstruction, maximum_depth, noise):
                                   str(original_key),
                                   feature=projection,
                                   feature_id=len(projections_inside)-1,
+                                  feature_scale=0.004,
                                   feature_color=(float(original_point.color[0]),
                                                  float(original_point.color[1]),
                                                  float(original_point.color[2])))

--- a/opensfm/test/data_generation.py
+++ b/opensfm/test/data_generation.py
@@ -80,10 +80,12 @@ class CubeDataset:
             for point_id, point in iteritems(self.points):
                 feature = shot.project(point)
                 feature += np.random.rand(*feature.shape)*noise
+                point_integer = int(point_id.split('point')[1])
                 g.add_node(shot_id, bipartite=0)
                 g.add_node(point_id, bipartite=1)
                 g.add_edge(shot_id, point_id, feature=feature,
-                           feature_id=point_id, feature_color=(0, 0, 0))
+                           feature_id=point_integer, feature_color=(0, 0, 0),
+                           feature_scale=0.004)
         self.tracks = g
 
 

--- a/opensfm/test/test_tracks.py
+++ b/opensfm/test/test_tracks.py
@@ -1,0 +1,18 @@
+import StringIO
+
+import opensfm.tracking
+import data_generation
+
+
+def test_tracks_io():
+    d = data_generation.CubeDataset(2, 100, 0.0, 0.3)
+
+    output = StringIO.StringIO()
+
+    tracks_before = d.tracks
+    opensfm.tracking.save_tracks_graph(output, tracks_before)
+    output.seek(0)
+    tracks_after = opensfm.tracking.load_tracks_graph(output)
+
+    assert tracks_before.nodes() == tracks_after.nodes()
+    assert tracks_before.edges() == tracks_after.edges()

--- a/opensfm/test/test_tracks.py
+++ b/opensfm/test/test_tracks.py
@@ -1,4 +1,4 @@
-import StringIO
+from io import StringIO
 
 import opensfm.tracking
 import data_generation
@@ -7,7 +7,7 @@ import data_generation
 def test_tracks_io():
     d = data_generation.CubeDataset(2, 100, 0.0, 0.3)
 
-    output = StringIO.StringIO()
+    output = StringIO()
 
     tracks_before = d.tracks
     opensfm.tracking.save_tracks_graph(output, tracks_before)

--- a/opensfm/tracking.py
+++ b/opensfm/tracking.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import numpy as np
 import networkx as nx


### PR DESCRIPTION
This PR makes 2D projection errors being scaled by their respective detected scale. Improves results on Strecha's bencmark by 25-50%.

A minor issue is that the feature were always exported by their actual pixel scale instead of a normalized one : hence a normalization hack.

Found a general issue in the bundle code, where errors should by scaled by `sqrt(1/std_deviation)` instead of just `1/std_deviation`