### PR TITLE
feat:scale properly the feature scale

### DIFF
--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -313,3 +313,27 @@ def build_flann_index(features, config):
                         iterations=config['flann_iterations'])
 
     return context.flann_Index(features, flann_params)
+
+
+def load_features(filepath, config):
+    feature_type = config['feature_type']
+    s = np.load(filepath)
+    if feature_type == 'HAHOG' and config['hahog_normalize_to_uchar']:
+        descriptors = s['descriptors'].astype(np.float32)
+    else:
+        descriptors = s['descriptors']
+    return s['points'], descriptors, s['colors'].astype(float)
+
+
+def save_features(filepath, points, desc, colors, config):
+    feature_type = config['feature_type']
+    if ((feature_type == 'AKAZE' and config['akaze_descriptor'] in ['MLDB_UPRIGHT', 'MLDB'])
+            or (feature_type == 'HAHOG' and config['hahog_normalize_to_uchar'])
+            or (feature_type == 'ORB')):
+        feature_data_type = np.uint8
+    else:
+        feature_data_type = np.float32
+    np.savez_compressed(filepath,
+                        points=points.astype(np.float32),
+                        descriptors=desc.astype(feature_data_type),
+                        colors=colors)

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -80,6 +80,7 @@ def mask_and_normalize_features(points, desc, colors, width, height, mask=None):
         colors = colors[ids]
 
     points[:, :2] = normalized_image_coordinates(points[:, :2], width, height)
+    points[:, 2:3] /= max(width, height)
     return points, desc, colors
 
 

--- a/opensfm/synthetic_data/synthetic_generator.py
+++ b/opensfm/synthetic_data/synthetic_generator.py
@@ -231,6 +231,7 @@ def generate_track_data(reconstruction, maximum_depth, noise):
     colors = {}
     features = {}
     descriptors = {}
+    default_scale = 0.004
     for shot_index, shot in reconstruction.shots.items():
         # need to have these as we lost track of keys
         all_keys = list(reconstruction.points.keys())
@@ -257,14 +258,14 @@ def generate_track_data(reconstruction, maximum_depth, noise):
                                                   shot.camera.height))
             perturb_points([projection], np.array([perturbation, perturbation]))
 
-            projections_inside.append(projection)
+            projections_inside.append(np.hstack((projection, [default_scale])))
             descriptors_inside.append(track_descriptors[original_key])
             colors_inside.append(original_point.color)
             tracks_graph.add_edge(str(shot_index),
                                   str(original_key),
                                   feature=projection,
                                   feature_id=len(projections_inside)-1,
-                                  feature_scale=0.004,
+                                  feature_scale=default_scale,
                                   feature_color=(float(original_point.color[0]),
                                                  float(original_point.color[1]),
                                                  float(original_point.color[2])))

--- a/opensfm/tracking.py
+++ b/opensfm/tracking.py
@@ -20,12 +20,6 @@ def load_features(dataset, images):
     for im in images:
         p, f, c = dataset.load_features(im)
         exif = dataset.load_exif(im)
-
-        # legacy : scale is not normalized
-        width = exif["width"]
-        height = exif["height"]
-        p[:, 2:3] /= max(width, height)
-
         features[im] = p[:, :3]
         colors[im] = c
     return features, colors


### PR DESCRIPTION
This PR aims at correcting some hack introduced here (https://github.com/mapillary/OpenSfM/pull/417) : we want the feature scale to be properly set, at extraction time, when pixel position are normalized wrt. the image size.

To do so, we  :
 - Moved features IO to the `features` module
 - Added basic versioning. In the 0 version, normalized scale is set to the default config value (`0.004`)
 - Removed the normalizing hack in `tracking`
 - Added proper normalization in `features`