### PR TITLE
FIX: cast to float in undistort.py

### DIFF
--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -156,7 +156,7 @@ def undistort_image(shot, undistorted_shots, original, interpolation,
 def scale_image(image, max_size):
     """Scale an image not to exceed max_size."""
     height, width = image.shape[:2]
-    factor = max_size / max(height, width)
+    factor = max_size / float(max(height, width))
     if factor >= 1:
         return image
     width = int(round(width * factor))


### PR DESCRIPTION
Problem: when setting `undistorted_image_max_size` to a value lower than the images (eg. 100) the value of:

`factor = max_size / max(height, width)`

Always evaluates to 0 during undistortion.

Proposed solution: type cast to float the denominator.