### PR TITLE
Faster export to VisualSFM

### DIFF
--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -63,7 +63,8 @@ class Command:
         try:
             file_path = data._undistorted_image_file(image)
             with Image.open(file_path) as img:
-                return img.size
+                width, height = img.size
+                return height, width
         except:
             # Slower fallback
             image = data.load_undistorted_image(image)

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import struct
 
 from opensfm import dataset
 from opensfm import transformations as tf
@@ -57,6 +58,167 @@ class Command:
         return os.path.relpath(path, data.data_path)
 
     def image_size(self, image, data):
-        """Height and width of the undistorted image."""
-        image = data.load_undistorted_image(image)
-        return image.shape[:2]
+        """
+        Height and width of the undistorted image.
+
+        :Author:      Paulo Scardine (based on code from Emmanuel VAISSE)
+        :Created:     26/09/2013
+        :Copyright:   (c) Paulo Scardine 2013
+        :Licence:     MIT
+        Return (width, height) for a given img file content - no external
+        dependencies except the os and struct builtin modules
+        """
+        try:
+            file_path = data._undistorted_image_file(image)
+
+            with open(file_path, "rb") as input:
+                size = os.path.getsize(file_path)
+                height = -1
+                width = -1
+                data = input.read(26)
+                msg = " raised while trying to decode as JPEG."
+
+                if (size >= 10) and data[:6] in (b'GIF87a', b'GIF89a'):
+                    # GIFs
+                    w, h = struct.unpack("<HH", data[6:10])
+                    width = int(w)
+                    height = int(h)
+                elif ((size >= 24) and data.startswith(b'\211PNG\r\n\032\n')
+                        and (data[12:16] == b'IHDR')):
+                    # PNGs
+                    w, h = struct.unpack(">LL", data[16:24])
+                    width = int(w)
+                    height = int(h)
+                elif (size >= 16) and data.startswith(b'\211PNG\r\n\032\n'):
+                    # older PNGs
+                    w, h = struct.unpack(">LL", data[8:16])
+                    width = int(w)
+                    height = int(h)
+                elif (size >= 2) and data.startswith(b'\377\330'):
+                    # JPEG
+                    input.seek(0)
+                    input.read(2)
+                    b = input.read(1)
+                    try:
+                        while (b and ord(b) != 0xDA):
+                            while (ord(b) != 0xFF):
+                                b = input.read(1)
+                            while (ord(b) == 0xFF):
+                                b = input.read(1)
+                            if (ord(b) >= 0xC0 and ord(b) <= 0xC3):
+                                input.read(3)
+                                h, w = struct.unpack(">HH", input.read(4))
+                                break
+                            else:
+                                input.read(
+                                    int(struct.unpack(">H", input.read(2))[0]) - 2)
+                            b = input.read(1)
+                        width = int(w)
+                        height = int(h)
+                    except struct.error:
+                        raise RuntimeError("StructError" + msg)
+                    except ValueError:
+                        raise RuntimeError("ValueError" + msg)
+                    except Exception as e:
+                        raise RuntimeError(e.__class__.__name__ + msg)
+                elif (size >= 26) and data.startswith(b'BM'):
+                    # BMP
+                    headersize = struct.unpack("<I", data[14:18])[0]
+                    if headersize == 12:
+                        w, h = struct.unpack("<HH", data[18:22])
+                        width = int(w)
+                        height = int(h)
+                    elif headersize >= 40:
+                        w, h = struct.unpack("<ii", data[18:26])
+                        width = int(w)
+                        # as h is negative when stored upside down
+                        height = abs(int(h))
+                    else:
+                        raise RuntimeError(
+                            "Unkown DIB header size:" +
+                            str(headersize))
+                elif (size >= 8) and data[:4] in (b"II\052\000", b"MM\000\052"):
+                    # Standard TIFF, big- or little-endian
+                    # BigTIFF and other different but TIFF-like formats are not
+                    # supported currently
+                    byteOrder = data[:2]
+                    boChar = ">" if byteOrder == "MM" else "<"
+                    # maps TIFF type id to size (in bytes)
+                    # and python format char for struct
+                    tiffTypes = {
+                        1: (1, boChar + "B"),  # BYTE
+                        2: (1, boChar + "c"),  # ASCII
+                        3: (2, boChar + "H"),  # SHORT
+                        4: (4, boChar + "L"),  # LONG
+                        5: (8, boChar + "LL"),  # RATIONAL
+                        6: (1, boChar + "b"),  # SBYTE
+                        7: (1, boChar + "c"),  # UNDEFINED
+                        8: (2, boChar + "h"),  # SSHORT
+                        9: (4, boChar + "l"),  # SLONG
+                        10: (8, boChar + "ll"),  # SRATIONAL
+                        11: (4, boChar + "f"),  # FLOAT
+                        12: (8, boChar + "d")   # DOUBLE
+                    }
+                    ifdOffset = struct.unpack(boChar + "L", data[4:8])[0]
+                    try:
+                        countSize = 2
+                        input.seek(ifdOffset)
+                        ec = input.read(countSize)
+                        ifdEntryCount = struct.unpack(boChar + "H", ec)[0]
+                        # 2 bytes: TagId + 2 bytes: type + 4 bytes: count of values + 4
+                        # bytes: value offset
+                        ifdEntrySize = 12
+                        for i in range(ifdEntryCount):
+                            entryOffset = ifdOffset + countSize + i * ifdEntrySize
+                            input.seek(entryOffset)
+                            tag = input.read(2)
+                            tag = struct.unpack(boChar + "H", tag)[0]
+                            if(tag == 256 or tag == 257):
+                                # if type indicates that value fits into 4 bytes, value
+                                # offset is not an offset but value itself
+                                type = input.read(2)
+                                type = struct.unpack(boChar + "H", type)[0]
+                                if type not in tiffTypes:
+                                    raise RuntimeError(
+                                        "Unkown TIFF field type:" +
+                                        str(type))
+                                typeSize = tiffTypes[type][0]
+                                typeChar = tiffTypes[type][1]
+                                input.seek(entryOffset + 8)
+                                value = input.read(typeSize)
+                                value = int(struct.unpack(typeChar, value)[0])
+                                if tag == 256:
+                                    width = value
+                                else:
+                                    height = value
+                            if width > -1 and height > -1:
+                                break
+                    except Exception as e:
+                        raise RuntimeError(str(e))
+                elif size >= 2:
+                        # see http://en.wikipedia.org/wiki/ICO_(file_format)
+                    input.seek(0)
+                    reserved = input.read(2)
+                    if 0 != struct.unpack("<H", reserved)[0]:
+                        raise RuntimeError("Sorry, don't know how to get size for this file.")
+                    format = input.read(2)
+                    assert 1 == struct.unpack("<H", format)[0]
+                    num = input.read(2)
+                    num = struct.unpack("<H", num)[0]
+                    if num > 1:
+                        import warnings
+                        warnings.warn("ICO File contains more than one image")
+                    # http://msdn.microsoft.com/en-us/library/ms997538.aspx
+                    w = input.read(1)
+                    h = input.read(1)
+                    width = ord(w)
+                    height = ord(h)
+                else:
+                    raise RuntimeError("Sorry, don't know how to get size for this file.")
+
+                return (width, height)
+        except:
+            # Slower fallback
+            image = data.load_undistorted_image(image)
+            return image.shape[:2]
+

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals
 import logging
 import os
 import struct
+from PIL import Image
 
 from opensfm import dataset
 from opensfm import transformations as tf
 from opensfm import io
 
 logger = logging.getLogger(__name__)
-
 
 class Command:
     name = 'export_visualsfm'
@@ -60,163 +60,11 @@ class Command:
     def image_size(self, image, data):
         """
         Height and width of the undistorted image.
-
-        :Author:      Paulo Scardine (based on code from Emmanuel VAISSE)
-        :Created:     26/09/2013
-        :Copyright:   (c) Paulo Scardine 2013
-        :Licence:     MIT
-        Return (width, height) for a given img file content - no external
-        dependencies except the os and struct builtin modules
         """
         try:
             file_path = data._undistorted_image_file(image)
-
-            with open(file_path, "rb") as input:
-                size = os.path.getsize(file_path)
-                height = -1
-                width = -1
-                data = input.read(26)
-                msg = " raised while trying to decode as JPEG."
-
-                if (size >= 10) and data[:6] in (b'GIF87a', b'GIF89a'):
-                    # GIFs
-                    w, h = struct.unpack("<HH", data[6:10])
-                    width = int(w)
-                    height = int(h)
-                elif ((size >= 24) and data.startswith(b'\211PNG\r\n\032\n')
-                        and (data[12:16] == b'IHDR')):
-                    # PNGs
-                    w, h = struct.unpack(">LL", data[16:24])
-                    width = int(w)
-                    height = int(h)
-                elif (size >= 16) and data.startswith(b'\211PNG\r\n\032\n'):
-                    # older PNGs
-                    w, h = struct.unpack(">LL", data[8:16])
-                    width = int(w)
-                    height = int(h)
-                elif (size >= 2) and data.startswith(b'\377\330'):
-                    # JPEG
-                    input.seek(0)
-                    input.read(2)
-                    b = input.read(1)
-                    try:
-                        while (b and ord(b) != 0xDA):
-                            while (ord(b) != 0xFF):
-                                b = input.read(1)
-                            while (ord(b) == 0xFF):
-                                b = input.read(1)
-                            if (ord(b) >= 0xC0 and ord(b) <= 0xC3):
-                                input.read(3)
-                                h, w = struct.unpack(">HH", input.read(4))
-                                break
-                            else:
-                                input.read(
-                                    int(struct.unpack(">H", input.read(2))[0]) - 2)
-                            b = input.read(1)
-                        width = int(w)
-                        height = int(h)
-                    except struct.error:
-                        raise RuntimeError("StructError" + msg)
-                    except ValueError:
-                        raise RuntimeError("ValueError" + msg)
-                    except Exception as e:
-                        raise RuntimeError(e.__class__.__name__ + msg)
-                elif (size >= 26) and data.startswith(b'BM'):
-                    # BMP
-                    headersize = struct.unpack("<I", data[14:18])[0]
-                    if headersize == 12:
-                        w, h = struct.unpack("<HH", data[18:22])
-                        width = int(w)
-                        height = int(h)
-                    elif headersize >= 40:
-                        w, h = struct.unpack("<ii", data[18:26])
-                        width = int(w)
-                        # as h is negative when stored upside down
-                        height = abs(int(h))
-                    else:
-                        raise RuntimeError(
-                            "Unkown DIB header size:" +
-                            str(headersize))
-                elif (size >= 8) and data[:4] in (b"II\052\000", b"MM\000\052"):
-                    # Standard TIFF, big- or little-endian
-                    # BigTIFF and other different but TIFF-like formats are not
-                    # supported currently
-                    byteOrder = data[:2]
-                    boChar = ">" if byteOrder == "MM" else "<"
-                    # maps TIFF type id to size (in bytes)
-                    # and python format char for struct
-                    tiffTypes = {
-                        1: (1, boChar + "B"),  # BYTE
-                        2: (1, boChar + "c"),  # ASCII
-                        3: (2, boChar + "H"),  # SHORT
-                        4: (4, boChar + "L"),  # LONG
-                        5: (8, boChar + "LL"),  # RATIONAL
-                        6: (1, boChar + "b"),  # SBYTE
-                        7: (1, boChar + "c"),  # UNDEFINED
-                        8: (2, boChar + "h"),  # SSHORT
-                        9: (4, boChar + "l"),  # SLONG
-                        10: (8, boChar + "ll"),  # SRATIONAL
-                        11: (4, boChar + "f"),  # FLOAT
-                        12: (8, boChar + "d")   # DOUBLE
-                    }
-                    ifdOffset = struct.unpack(boChar + "L", data[4:8])[0]
-                    try:
-                        countSize = 2
-                        input.seek(ifdOffset)
-                        ec = input.read(countSize)
-                        ifdEntryCount = struct.unpack(boChar + "H", ec)[0]
-                        # 2 bytes: TagId + 2 bytes: type + 4 bytes: count of values + 4
-                        # bytes: value offset
-                        ifdEntrySize = 12
-                        for i in range(ifdEntryCount):
-                            entryOffset = ifdOffset + countSize + i * ifdEntrySize
-                            input.seek(entryOffset)
-                            tag = input.read(2)
-                            tag = struct.unpack(boChar + "H", tag)[0]
-                            if(tag == 256 or tag == 257):
-                                # if type indicates that value fits into 4 bytes, value
-                                # offset is not an offset but value itself
-                                type = input.read(2)
-                                type = struct.unpack(boChar + "H", type)[0]
-                                if type not in tiffTypes:
-                                    raise RuntimeError(
-                                        "Unkown TIFF field type:" +
-                                        str(type))
-                                typeSize = tiffTypes[type][0]
-                                typeChar = tiffTypes[type][1]
-                                input.seek(entryOffset + 8)
-                                value = input.read(typeSize)
-                                value = int(struct.unpack(typeChar, value)[0])
-                                if tag == 256:
-                                    width = value
-                                else:
-                                    height = value
-                            if width > -1 and height > -1:
-                                break
-                    except Exception as e:
-                        raise RuntimeError(str(e))
-                elif size >= 2:
-                        # see http://en.wikipedia.org/wiki/ICO_(file_format)
-                    input.seek(0)
-                    reserved = input.read(2)
-                    if 0 != struct.unpack("<H", reserved)[0]:
-                        raise RuntimeError("Sorry, don't know how to get size for this file.")
-                    format = input.read(2)
-                    assert 1 == struct.unpack("<H", format)[0]
-                    num = input.read(2)
-                    num = struct.unpack("<H", num)[0]
-                    if num > 1:
-                        import warnings
-                        warnings.warn("ICO File contains more than one image")
-                    # http://msdn.microsoft.com/en-us/library/ms997538.aspx
-                    w = input.read(1)
-                    h = input.read(1)
-                    width = ord(w)
-                    height = ord(h)
-                else:
-                    raise RuntimeError("Sorry, don't know how to get size for this file.")
-
-                return (width, height)
+            with Image.open(file_path) as img:
+                return img.size
         except:
             # Slower fallback
             image = data.load_undistorted_image(image)

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import struct
 from PIL import Image
 
 from opensfm import dataset
@@ -69,4 +68,3 @@ class Command:
             # Slower fallback
             image = data.load_undistorted_image(image)
             return image.shape[:2]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ repoze.lru==0.7
 scipy
 six
 xmltodict==0.10.2
+Pillow==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setuptools.setup(
     #     'scipy',
     #     'six',
     #     'xmltodict>=0.10.2',
+    #     'Pillow>=6.0.0',
     # ],
     cmdclass={'bdist_wheel': platform_bdist_wheel},
 )


### PR DESCRIPTION
Currently calling `export_visualsfm` will read the entire dataset of images from disk to compute width and height for each image.

This can be sped up a lot by simply reading the header values instead of loading the entire image in memory.

Even on a small dataset (a few dozen images):

```
time opensfm/bin/opensfm export_visualsfm /datasets/test

real	0m9.027s
user	0m8.164s
sys	0m1.302s
```

Vs. the proposed change:

```
time opensfm/bin/opensfm export_visualsfm /datasets/test

real	0m0.802s
user	0m0.694s
sys	0m0.500s
```

I'm not sure if the function to compute the width/height should move moved elsewhere? Anyway, let me know if anything needs to be changed :pray: Thank you!