### PR TITLE
Add self parameter in  get_mm_per_unit function

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -202,7 +202,7 @@ class EXIF:
         width_in_pixels = self.extract_image_size()[0]
         return width_in_pixels * units_per_pixel * mm_per_unit
 
-    def get_mm_per_unit(resolution_unit):
+    def get_mm_per_unit(self,resolution_unit):
         """Length of a resolution unit in millimeters.
 
         Uses the values from the EXIF specs in


### PR DESCRIPTION
When Focal Plane Resolution Unit is present in exif,  function extract_sensor_width calls self.get_mm_per_unit(resolution_unit) with only one argument.  Added self as first argument. 

File "/home/test/OpenSfM/opensfm/exif.py", line 197, in extract_sensor_width
    mm_per_unit = self.get_mm_per_unit(resolution_unit)
TypeError: get_mm_per_unit() takes exactly 1 argument (2 given)