### PR TITLE
feat(docs): use brand colors in docs

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,3 +1,41 @@
 {% extends "!layout.html" %}
+{% block footer %}
+{{ super() }}
+<style>
+  @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700&display=swap');
+  * {
+    font-family: 'Source Sans Pro', sans-serif!important;
+  }
+  .wy-side-nav-search {
+    background: #05cb63;
+  }
+  .wy-side-nav-search input[type=text] {
+    border-color: #05cb63;
+  }
+  .wy-nav-side {
+    background: #212b36;
+  }
+  .wy-menu-vertical a:hover {
+    color: #d9d9d9;
+    background: rgba(255, 255, 255, 0.1);
+  }
+  a, a:hover {
+    color: #05cb63;
+  }
+  body {
+    color: #212b36;
+  }
+  .wy-side-nav-search>a:hover {
+    color: #fff!important;
+  }
+  .highlight {
+    background: #dee5ed;
+  }
+  .rst-content pre.literal-block, .rst-content div[class^='highlight'] {
+    border-radius: 4px;
+    border-color: #dee5ed!important;  
+  }
+</style>
+{% endblock %}
 
 {% set script_files = script_files + ["_static/mathjax_conf.js"] %}

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -3,14 +3,18 @@
 {{ super() }}
 <style>
   @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700&display=swap');
-  * {
-    font-family: 'Source Sans Pro', sans-serif!important;
+  html {
+    font-family: 'Source Sans Pro', sans-serif;
+  }
+  .highlight {
+    font-family: "Lucida Console", Monaco, monospace!important;
   }
   .wy-side-nav-search {
-    background: #05cb63;
+    background: #212b36;
   }
   .wy-side-nav-search input[type=text] {
-    border-color: #05cb63;
+    border-color: transparent;
+    
   }
   .wy-nav-side {
     background: #212b36;
@@ -25,11 +29,21 @@
   body {
     color: #212b36;
   }
+  .wy-nav-content-wrap {
+    background: #fcfcfc!important;
+  }
   .wy-side-nav-search>a:hover {
     color: #fff!important;
   }
   .highlight {
     background: #dee5ed;
+  }
+  .wy-menu-vertical li.on a, .wy-menu-vertical li.current>a {
+
+  }
+  .wy-menu-vertical li.toctree-l1.current>a {
+    border-top: 0;
+    border-bottom: 0;
   }
   .rst-content pre.literal-block, .rst-content div[class^='highlight'] {
     border-radius: 4px;


### PR DESCRIPTION
Some style overrides using brand colors. Doesn't touch `sphinx_rtd_theme`.

WIP.