### PR TITLE
feature: bag-of-words matching

### DIFF
--- a/opensfm/bow.py
+++ b/opensfm/bow.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+import numpy as np
+import cv2
+from opensfm import context
+
+
+class BagOfWords:
+    def __init__(self, words, frequencies):
+        self.words = words
+        self.frequencies = frequencies
+        self.weights = np.log(frequencies.sum() / frequencies)
+        FLANN_INDEX_KDTREE = 1
+        flann_params = dict(algorithm=FLANN_INDEX_KDTREE,
+                            trees=8,
+                            checks=300)
+        self.index = context.flann_Index(words, flann_params)
+
+    def map_to_words(self, descriptors, k, matcher_type='FLANN'):
+        if matcher_type == 'FLANN':
+            params = {str('checks'): 200}
+            idx, dist = self.index.knnSearch(descriptors, k, params=params)
+        else:
+            matcher = cv2.DescriptorMatcher_create(matcher_type)
+            matches = matcher.knnMatch(descriptors, self.words, k=k)
+            idx = [[int(n.trainIdx) for n in m] for m in matches]
+            idx = np.array(idx).astype(np.int32)
+        return idx
+
+    def histogram(self, words):
+        h = np.bincount(words, minlength=len(self.words)) * self.weights
+        return h / h.sum()
+
+    def bow_distance(self, w1, w2, h1=None, h2=None):
+        if h1 is None:
+            h1 = self.histogram(w1)
+        if h2 is None:
+            h2 = self.histogram(w2)
+        return np.fabs(h1 - h2).sum()
+
+
+def load_bow_words_and_frequencies(config):
+    bow_file = os.path.join(context.BOW_PATH, config['bow_file'])
+    bow = np.load(bow_file)
+    return bow['words'], bow['frequencies']
+
+
+def load_bows(config):
+    words, frequencies = load_bow_words_and_frequencies(config)
+    return BagOfWords(words, frequencies)

--- a/opensfm/bow.py
+++ b/opensfm/bow.py
@@ -44,6 +44,11 @@ class BagOfWords:
 
 
 def load_bow_words_and_frequencies(config):
+    if config['bow_file'] == 'bow_hahog_root_uchar.npz':
+        assert config['feature_type'] == 'HAHOG'
+        assert config['feature_root']
+        assert config['hahog_normalize_to_uchar']
+
     bow_file = os.path.join(context.BOW_PATH, config['bow_file'])
     bow = np.load(bow_file)
     return bow['words'], bow['frequencies']

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -90,6 +90,7 @@ def detect(args):
         n_closest = data.config['bow_words_to_match']
         closest_words = bows.map_to_words(
             f_sorted, n_closest, data.config['bow_matcher_type'])
+        closest_words = closest_words[order, :]
         data.save_words(image, closest_words)
 
     end = timer()

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -85,7 +85,7 @@ def detect(args):
     if data.config['matcher_type'] == 'FLANN':
         index = features.build_flann_index(f_sorted, data.config)
         data.save_feature_index(image, index)
-    elif data.config['matcher_type'] == 'WORDS':
+    if data.config['matcher_type'] == 'WORDS' or data.config['matching_bow_neighbors'] > 0:
         bows = bow.load_bows(data.config)
         n_closest = data.config['bow_words_to_match']
         closest_words = bows.map_to_words(

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -56,7 +56,11 @@ def detect(args):
 
     log.setup()
 
-    if data.feature_index_exists(image):
+    need_words = data.config['matcher_type'] == 'WORDS' or data.config['matching_bow_neighbors'] > 0
+    has_words = not need_words or data.words_exist(image)
+    has_features = data.feature_index_exists(image)
+
+    if has_features and has_words:
         logger.info('Skip recomputing {} features for image {}'.format(
             data.feature_type().upper(), image))
         return
@@ -85,7 +89,7 @@ def detect(args):
     if data.config['matcher_type'] == 'FLANN':
         index = features.build_flann_index(f_sorted, data.config)
         data.save_feature_index(image, index)
-    if data.config['matcher_type'] == 'WORDS' or data.config['matching_bow_neighbors'] > 0:
+    if need_words:
         bows = bow.load_bows(data.config)
         n_closest = data.config['bow_words_to_match']
         closest_words = bows.map_to_words(

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -3,6 +3,7 @@ from timeit import default_timer as timer
 
 import numpy as np
 
+from opensfm import bow
 from opensfm import dataset
 from opensfm import features
 from opensfm import io
@@ -88,6 +89,12 @@ def detect(args):
     if data.config['matcher_type'] == 'FLANN':
         index = features.build_flann_index(f_sorted, data.config)
         data.save_feature_index(image, index)
+    elif data.config['matcher_type'] == 'WORDS':
+        bows = bow.load_bows(data.config)
+        n_closest = data.config['bow_words_to_match']
+        closest_words = bows.map_to_words(
+            f_sorted, n_closest, data.config['bow_matcher_type'])
+        data.save_words(image, closest_words, n_closest)
 
     end = timer()
     report = {

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -90,7 +90,7 @@ def detect(args):
         n_closest = data.config['bow_words_to_match']
         closest_words = bows.map_to_words(
             f_sorted, n_closest, data.config['bow_matcher_type'])
-        data.save_words(image, closest_words, n_closest)
+        data.save_words(image, closest_words)
 
     end = timer()
     report = {

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -51,42 +51,48 @@ class Command:
 
 
 def detect(args):
+    image, data = args
+
     log.setup()
 
-    image, data = args
+    if data.feature_index_exists(image):
+        logger.info('Skip recomputing {} features for image {}'.format(
+            data.feature_type().upper(), image))
+        return
+
     logger.info('Extracting {} features for image {}'.format(
         data.feature_type().upper(), image))
 
-    if not data.feature_index_exists(image):
-        start = timer()
-        mask = data.load_combined_mask(image)
-        if mask is not None:
-            logger.info('Found mask to apply for image {}'.format(image))
-        preemptive_max = data.config['preemptive_max']
-        p_unsorted, f_unsorted, c_unsorted = features.extract_features(
-            data.load_image(image), data.config, mask)
-        if len(p_unsorted) == 0:
-            return
+    start = timer()
+    mask = data.load_combined_mask(image)
+    if mask is not None:
+        logger.info('Found mask to apply for image {}'.format(image))
+    preemptive_max = data.config['preemptive_max']
+    p_unsorted, f_unsorted, c_unsorted = features.extract_features(
+        data.load_image(image), data.config, mask)
 
-        size = p_unsorted[:, 2]
-        order = np.argsort(size)
-        p_sorted = p_unsorted[order, :]
-        f_sorted = f_unsorted[order, :]
-        c_sorted = c_unsorted[order, :]
-        p_pre = p_sorted[-preemptive_max:]
-        f_pre = f_sorted[-preemptive_max:]
-        data.save_features(image, p_sorted, f_sorted, c_sorted)
-        data.save_preemptive_features(image, p_pre, f_pre)
+    if len(p_unsorted) == 0:
+        logger.warning('No features found in image {}'.format(image))
+        return
 
-        if data.config['matcher_type'] == 'FLANN':
-            index = features.build_flann_index(f_sorted, data.config)
-            data.save_feature_index(image, index)
+    size = p_unsorted[:, 2]
+    order = np.argsort(size)
+    p_sorted = p_unsorted[order, :]
+    f_sorted = f_unsorted[order, :]
+    c_sorted = c_unsorted[order, :]
+    p_pre = p_sorted[-preemptive_max:]
+    f_pre = f_sorted[-preemptive_max:]
+    data.save_features(image, p_sorted, f_sorted, c_sorted)
+    data.save_preemptive_features(image, p_pre, f_pre)
 
-        end = timer()
-        report = {
-            "image": image,
-            "num_features": len(p_sorted),
-            "wall_time": end - start,
-        }
-        data.save_report(io.json_dumps(report),
-                         'features/{}.json'.format(image))
+    if data.config['matcher_type'] == 'FLANN':
+        index = features.build_flann_index(f_sorted, data.config)
+        data.save_feature_index(image, index)
+
+    end = timer()
+    report = {
+        "image": image,
+        "num_features": len(p_sorted),
+        "wall_time": end - start,
+    }
+    data.save_report(io.json_dumps(report), 'features/{}.json'.format(image))

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -68,7 +68,6 @@ def detect(args):
     mask = data.load_combined_mask(image)
     if mask is not None:
         logger.info('Found mask to apply for image {}'.format(image))
-    preemptive_max = data.config['preemptive_max']
     p_unsorted, f_unsorted, c_unsorted = features.extract_features(
         data.load_image(image), data.config, mask)
 
@@ -81,10 +80,7 @@ def detect(args):
     p_sorted = p_unsorted[order, :]
     f_sorted = f_unsorted[order, :]
     c_sorted = c_unsorted[order, :]
-    p_pre = p_sorted[-preemptive_max:]
-    f_pre = f_sorted[-preemptive_max:]
     data.save_features(image, p_sorted, f_sorted, c_sorted)
-    data.save_preemptive_features(image, p_pre, f_pre)
 
     if data.config['matcher_type'] == 'FLANN':
         index = features.build_flann_index(f_sorted, data.config)

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -1,14 +1,13 @@
 import logging
-from itertools import combinations
 from timeit import default_timer as timer
 
 import numpy as np
-import scipy.spatial as spatial
 
 from opensfm import dataset
 from opensfm import io
 from opensfm import log
 from opensfm import matching
+from opensfm import pairs_selection
 from opensfm.context import parallel_map
 
 
@@ -26,7 +25,7 @@ class Command:
         data = dataset.DataSet(args.dataset)
         images = data.images()
         exifs = {im: data.load_exif(im) for im in images}
-        pairs, preport = match_candidates_from_metadata(images, exifs, data)
+        pairs, preport = pairs_selection.match_candidates_from_metadata(images, exifs, data)
 
         num_pairs = sum(len(c) for c in pairs.values())
         logger.info('Matching {} image pairs'.format(num_pairs))
@@ -63,126 +62,6 @@ class Command:
 
 class Context:
     pass
-
-
-def has_gps_info(exif):
-    return (exif and
-            'gps' in exif and
-            'latitude' in exif['gps'] and
-            'longitude' in exif['gps'])
-
-
-def match_candidates_by_distance(images, exifs, reference, max_neighbors, max_distance):
-    """Find candidate matching pairs by GPS distance.
-
-    The GPS altitude is ignored because we want images of the same position
-    at different altitudes to be matched together.  Otherwise, for drone
-    datasets, flights at different altitudes do not get matched.
-    """
-    if max_neighbors <= 0 and max_distance <= 0:
-        return set()
-    max_neighbors = max_neighbors or 99999999
-    max_distance = max_distance or 99999999.
-    k = min(len(images), max_neighbors + 1)
-
-    points = np.zeros((len(images), 3))
-    for i, image in enumerate(images):
-        gps = exifs[image]['gps']
-        points[i] = reference.to_topocentric(
-            gps['latitude'], gps['longitude'], 0)
-
-    tree = spatial.cKDTree(points)
-
-    pairs = set()
-    for i, image in enumerate(images):
-        distances, neighbors = tree.query(
-            points[i], k=k, distance_upper_bound=max_distance)
-        for j in neighbors:
-            if i != j and j < len(images):
-                pairs.add(tuple(sorted((images[i], images[j]))))
-    return pairs
-
-
-def match_candidates_by_time(images, exifs, max_neighbors):
-    """Find candidate matching pairs by time difference."""
-    if max_neighbors <= 0:
-        return set()
-    k = min(len(images), max_neighbors + 1)
-
-    times = np.zeros((len(images), 1))
-    for i, image in enumerate(images):
-        times[i] = exifs[image]['capture_time']
-
-    tree = spatial.cKDTree(times)
-
-    pairs = set()
-    for i, image in enumerate(images):
-        distances, neighbors = tree.query(times[i], k=k)
-        for j in neighbors:
-            if i != j and j < len(images):
-                pairs.add(tuple(sorted((images[i], images[j]))))
-    return pairs
-
-
-def match_candidates_by_order(images, max_neighbors):
-    """Find candidate matching pairs by sequence order."""
-    if max_neighbors <= 0:
-        return set()
-    n = (max_neighbors + 1) // 2
-
-    pairs = set()
-    for i, image in enumerate(images):
-        a = max(0, i - n)
-        b = min(len(images), i + n)
-        for j in range(a, b):
-            if i != j:
-                pairs.add(tuple(sorted((images[i], images[j]))))
-    return pairs
-
-
-def match_candidates_from_metadata(images, exifs, data):
-    """Compute candidate matching pairs"""
-    max_distance = data.config['matching_gps_distance']
-    gps_neighbors = data.config['matching_gps_neighbors']
-    time_neighbors = data.config['matching_time_neighbors']
-    order_neighbors = data.config['matching_order_neighbors']
-
-    if not data.reference_lla_exists():
-        data.invent_reference_lla()
-    reference = data.load_reference()
-
-    if not all(map(has_gps_info, exifs.values())):
-        if gps_neighbors != 0:
-            logger.warn("Not all images have GPS info. "
-                        "Disabling matching_gps_neighbors.")
-        gps_neighbors = 0
-        max_distance = 0
-
-    images.sort()
-
-    if max_distance == gps_neighbors == time_neighbors == order_neighbors == 0:
-        # All pair selection strategies deactivated so we match all pairs
-        d = set()
-        t = set()
-        o = set()
-        pairs = combinations(images, 2)
-    else:
-        d = match_candidates_by_distance(images, exifs, reference,
-                                         gps_neighbors, max_distance)
-        t = match_candidates_by_time(images, exifs, time_neighbors)
-        o = match_candidates_by_order(images, order_neighbors)
-        pairs = d | t | o
-
-    res = {im: [] for im in images}
-    for im1, im2 in pairs:
-        res[im1].append(im2)
-
-    report = {
-        "num_pairs_distance": len(d),
-        "num_pairs_time": len(t),
-        "num_pairs_order": len(o)
-    }
-    return res, report
 
 
 def match_arguments(pairs, ctx):

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -209,7 +209,11 @@ def match(args):
         p1, f1, c1 = ctx.data.load_features(im1)
         p2, f2, c2 = ctx.data.load_features(im2)
 
-        if matcher_type == 'FLANN':
+        if matcher_type == 'WORDS':
+            w1 = ctx.data.load_words(im1)
+            w2 = ctx.data.load_words(im2)
+            matches = matching.match_words_symmetric(f1, w1, f2, w2, config)
+        elif matcher_type == 'FLANN':
             i1 = ctx.data.load_feature_index(im1, f1)
             i2 = ctx.data.load_feature_index(im2, f2)
             matches = matching.match_flann_symmetric(f1, i1, f2, i2, config)
@@ -217,7 +221,7 @@ def match(args):
             matches = matching.match_brute_force_symmetric(f1, f2, config)
         else:
             raise ValueError("Invalid matcher_type: {}".format(matcher_type))
-            
+
         logger.debug('{} - {} has {} candidate matches'.format(
             im1, im2, len(matches)))
         if len(matches) < robust_matching_min_match:

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -58,6 +58,7 @@ matching_gps_distance: 150            # Maximum gps distance between two images 
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit (or disable if matching_gps_distance is also 0)
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to disable
 matching_order_neighbors: 0           # Number of images to match selected by image name. Set to 0 to disable
+matching_bow_neighbors: 8             # Number of images to match selected by BoW distance. Set to 0 to disable
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -39,7 +39,6 @@ hahog_normalize_to_uchar: no
 
 # Params for general matching
 lowes_ratio: 0.8              # Ratio test for matches
-preemptive_lowes_ratio: 0.6   # Ratio test for preemptive matches
 matcher_type: FLANN           # FLANN or BRUTEFORCE or WORDS
 
 # Params for FLANN matching
@@ -59,8 +58,6 @@ matching_gps_distance: 150            # Maximum gps distance between two images 
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit (or disable if matching_gps_distance is also 0)
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to disable
 matching_order_neighbors: 0           # Number of images to match selected by image name. Set to 0 to disable
-preemptive_max: 200                   # Number of features to use for preemptive matching
-preemptive_threshold: 0               # If number of matches passes the threshold -> full feature matching
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -58,7 +58,7 @@ matching_gps_distance: 150            # Maximum gps distance between two images 
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit (or disable if matching_gps_distance is also 0)
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to disable
 matching_order_neighbors: 0           # Number of images to match selected by image name. Set to 0 to disable
-matching_bow_neighbors: 8             # Number of images to match selected by BoW distance. Set to 0 to disable
+matching_bow_neighbors: 0             # Number of images to match selected by BoW distance. Set to 0 to disable
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -40,12 +40,19 @@ hahog_normalize_to_uchar: no
 # Params for general matching
 lowes_ratio: 0.8              # Ratio test for matches
 preemptive_lowes_ratio: 0.6   # Ratio test for preemptive matches
-matcher_type: FLANN           # FLANN or BRUTEFORCE
+matcher_type: FLANN           # FLANN or BRUTEFORCE or WORDS
 
 # Params for FLANN matching
 flann_branching: 16           # See OpenCV doc
 flann_iterations: 10          # See OpenCV doc
 flann_checks: 200             # Smaller -> Faster (but might lose good matches)
+
+# Params for BoW matching
+bow_file: bow_hahog_root_uchar.npz
+bow_images_to_match: 15       # Number of images to do detailed matching.
+bow_words_to_match: 50        # Number of words to explore per feature.
+bow_num_checks: 20            # Number of matching features to check.
+bow_matcher_type: FLANN       # Matcher type to assign words to features
 
 # Params for preemptive matching
 matching_gps_distance: 150            # Maximum gps distance between two images for matching

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -35,7 +35,7 @@ akaze_use_isotropic_diffusion: no
 # Params for HAHOG
 hahog_peak_threshold: 0.00001
 hahog_edge_threshold: 10
-hahog_normalize_to_uchar: no
+hahog_normalize_to_uchar: yes
 
 # Params for general matching
 lowes_ratio: 0.8              # Ratio test for matches

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 abspath = os.path.abspath(os.path.dirname(__file__))
-SENSOR = os.path.join(abspath, 'data/sensor_data.json')
+SENSOR = os.path.join(abspath, 'data', 'sensor_data.json')
+BOW_PATH = os.path.join(abspath, 'data', 'bow')
 
 
 # Handle different OpenCV versions

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -478,6 +478,19 @@ class DataSet(object):
     def save_words(self, image, words):
         np.savez_compressed(self._words_file(image), words=words.astype(np.uint16))
 
+    def _words_file(self, image, n):
+        return os.path.join(self._feature_path(), image + '.words.npz')
+
+    def words_exist(self, image, n):
+        return os.path.isfile(self._words_file(image, n))
+
+    def load_words(self, image, n):
+        s = np.load(self._words_file(image, n))
+        return s['words'].astype(np.int32)
+
+    def save_words(self, image, words, n):
+        np.savez_compressed(self._words_file(image, n), words=words.astype(np.uint16))
+
     def _matches_path(self):
         """Return path of matches directory"""
         return os.path.join(self.data_path, 'matches')

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -478,19 +478,6 @@ class DataSet(object):
     def save_words(self, image, words):
         np.savez_compressed(self._words_file(image), words=words.astype(np.uint16))
 
-    def _words_file(self, image, n):
-        return os.path.join(self._feature_path(), image + '.words.npz')
-
-    def words_exist(self, image, n):
-        return os.path.isfile(self._words_file(image, n))
-
-    def load_words(self, image, n):
-        s = np.load(self._words_file(image, n))
-        return s['words'].astype(np.int32)
-
-    def save_words(self, image, words, n):
-        np.savez_compressed(self._words_file(image, n), words=words.astype(np.uint16))
-
     def _matches_path(self):
         """Return path of matches directory"""
         return os.path.join(self.data_path, 'matches')

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -432,7 +432,7 @@ class DataSet(object):
         Return path of feature file for specified image
         :param image: Image name, with extension (i.e. 123.jpg)
         """
-        return os.path.join(self._feature_path(), image + '.npz')
+        return os.path.join(self._feature_path(), image + '.features.npz')
 
     def _save_features(self, filepath, points, descriptors, colors=None):
         io.mkdir_p(self._feature_path())
@@ -479,6 +479,19 @@ class DataSet(object):
 
     def save_preemptive_features(self, image, points, descriptors):
         self._save_features(self._preemptive_features_file(image), points, descriptors)
+
+    def _words_file(self, image, n):
+        return os.path.join(self._feature_path(), image + '.words.npz')
+
+    def words_exist(self, image, n):
+        return os.path.isfile(self._words_file(image, n))
+
+    def load_words(self, image, n):
+        s = np.load(self._words_file(image, n))
+        return s['words'].astype(np.int32)
+
+    def save_words(self, image, words, n):
+        np.savez_compressed(self._words_file(image, n), words=words.astype(np.uint16))
 
     def _matches_path(self):
         """Return path of matches directory"""

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -465,33 +465,18 @@ class DataSet(object):
     def save_feature_index(self, image, index):
         index.save(self._feature_index_file(image))
 
-    def _preemptive_features_file(self, image):
-        """
-        Return path of preemptive feature file (a short list of the full feature file)
-        for specified image
-        :param image: Image name, with extension (i.e. 123.jpg)
-        """
-        return os.path.join(self._feature_path(), image + '_preemptive' + '.npz')
-
-    def load_preemtive_features(self, image):
-        s = np.load(self._preemptive_features_file(image))
-        return s['points'], s['descriptors']
-
-    def save_preemptive_features(self, image, points, descriptors):
-        self._save_features(self._preemptive_features_file(image), points, descriptors)
-
-    def _words_file(self, image, n):
+    def _words_file(self, image):
         return os.path.join(self._feature_path(), image + '.words.npz')
 
-    def words_exist(self, image, n):
-        return os.path.isfile(self._words_file(image, n))
+    def words_exist(self, image):
+        return os.path.isfile(self._words_file(image))
 
-    def load_words(self, image, n):
-        s = np.load(self._words_file(image, n))
+    def load_words(self, image):
+        s = np.load(self._words_file(image))
         return s['words'].astype(np.int32)
 
-    def save_words(self, image, words, n):
-        np.savez_compressed(self._words_file(image, n), words=words.astype(np.uint16))
+    def save_words(self, image, words):
+        np.savez_compressed(self._words_file(image), words=words.astype(np.uint16))
 
     def _matches_path(self):
         """Return path of matches directory"""

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -4,6 +4,8 @@ import numpy as np
 
 import scipy.spatial as spatial
 
+from opensfm import bow
+
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +15,60 @@ def has_gps_info(exif):
             'gps' in exif and
             'latitude' in exif['gps'] and
             'longitude' in exif['gps'])
+
+
+def bow_distances(image, other_images, words, masks, bows):
+    """ Compute BoW-based distance (L1 on histogram of words)
+        between an image and other images.
+
+        Can use optionaly masks for discarding some features
+    """
+    # params
+    min_num_feature = 8
+
+    if words[image] is None:
+        logger.error("Could not load words for image {}".format(image))
+        return []
+
+    filtered_words = words[image][masks[image]] if masks else words[image]
+    if len(filtered_words) <= min_num_feature:
+        logger.warning("Too few filtered features in image {}: {}".format(
+            image, len(filtered_words)))
+        return []
+
+    # Compute distance
+    distances = []
+    other = []
+    h = bows.histogram(filtered_words[:, 0])
+    for im2 in other_images:
+        if im2 != image and words[im2] is not None:
+            im2_words = words[im2][masks[im2]] if masks else words[im2]
+            if len(im2_words) > min_num_feature:
+                h2 = bows.histogram(im2_words[:, 0])
+                distances.append(np.fabs(h - h2).sum())
+                other.append(im2)
+            else:
+                logger.warning(
+                    "Too few features in matching image {}: {}".format(
+                        im2, len(words[im2])))
+    return np.argsort(distances), other
+
+
+def match_candidates_with_bow(data, images, max_neighbors):
+    """Find candidate matching pairs using BoW-based distance."""
+    if max_neighbors <= 0:
+        return set()
+
+    words = {im: data.load_words(im) for im in images}
+    bows = bow.load_bows(data.config)
+
+    pairs = set()
+    for im in images:
+        order, other = bow_distances(im, images, words, None, bows)
+        for i in order[:max_neighbors]:
+            pairs.add(tuple(sorted((im, other[i]))))
+        logger.info("Candidates for %s are %s" % (im, str(pairs).translate(None, "'")))
+    return pairs
 
 
 def match_candidates_by_distance(images, exifs, reference, max_neighbors, max_distance):
@@ -89,6 +145,7 @@ def match_candidates_from_metadata(images, exifs, data):
     gps_neighbors = data.config['matching_gps_neighbors']
     time_neighbors = data.config['matching_time_neighbors']
     order_neighbors = data.config['matching_order_neighbors']
+    bow_neighbors = data.config['matching_bow_neighbors']
 
     if not data.reference_lla_exists():
         data.invent_reference_lla()
@@ -103,7 +160,7 @@ def match_candidates_from_metadata(images, exifs, data):
 
     images.sort()
 
-    if max_distance == gps_neighbors == time_neighbors == order_neighbors == 0:
+    if max_distance == gps_neighbors == time_neighbors == order_neighbors == bow_neighbors == 0:
         # All pair selection strategies deactivated so we match all pairs
         d = set()
         t = set()
@@ -114,7 +171,8 @@ def match_candidates_from_metadata(images, exifs, data):
                                          gps_neighbors, max_distance)
         t = match_candidates_by_time(images, exifs, time_neighbors)
         o = match_candidates_by_order(images, order_neighbors)
-        pairs = d | t | o
+        b = match_candidates_with_bow(data, images, bow_neighbors)
+        pairs = d | t | o | b
 
     res = {im: [] for im in images}
     for im1, im2 in pairs:

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -1,0 +1,128 @@
+import logging
+from itertools import combinations
+import numpy as np
+
+import scipy.spatial as spatial
+
+
+logger = logging.getLogger(__name__)
+
+
+def has_gps_info(exif):
+    return (exif and
+            'gps' in exif and
+            'latitude' in exif['gps'] and
+            'longitude' in exif['gps'])
+
+
+def match_candidates_by_distance(images, exifs, reference, max_neighbors, max_distance):
+    """Find candidate matching pairs by GPS distance.
+
+    The GPS altitude is ignored because we want images of the same position
+    at different altitudes to be matched together.  Otherwise, for drone
+    datasets, flights at different altitudes do not get matched.
+    """
+    if max_neighbors <= 0 and max_distance <= 0:
+        return set()
+    max_neighbors = max_neighbors or 99999999
+    max_distance = max_distance or 99999999.
+    k = min(len(images), max_neighbors + 1)
+
+    points = np.zeros((len(images), 3))
+    for i, image in enumerate(images):
+        gps = exifs[image]['gps']
+        points[i] = reference.to_topocentric(
+            gps['latitude'], gps['longitude'], 0)
+
+    tree = spatial.cKDTree(points)
+
+    pairs = set()
+    for i, image in enumerate(images):
+        distances, neighbors = tree.query(
+            points[i], k=k, distance_upper_bound=max_distance)
+        for j in neighbors:
+            if i != j and j < len(images):
+                pairs.add(tuple(sorted((images[i], images[j]))))
+    return pairs
+
+
+def match_candidates_by_time(images, exifs, max_neighbors):
+    """Find candidate matching pairs by time difference."""
+    if max_neighbors <= 0:
+        return set()
+    k = min(len(images), max_neighbors + 1)
+
+    times = np.zeros((len(images), 1))
+    for i, image in enumerate(images):
+        times[i] = exifs[image]['capture_time']
+
+    tree = spatial.cKDTree(times)
+
+    pairs = set()
+    for i, image in enumerate(images):
+        distances, neighbors = tree.query(times[i], k=k)
+        for j in neighbors:
+            if i != j and j < len(images):
+                pairs.add(tuple(sorted((images[i], images[j]))))
+    return pairs
+
+
+def match_candidates_by_order(images, max_neighbors):
+    """Find candidate matching pairs by sequence order."""
+    if max_neighbors <= 0:
+        return set()
+    n = (max_neighbors + 1) // 2
+
+    pairs = set()
+    for i, image in enumerate(images):
+        a = max(0, i - n)
+        b = min(len(images), i + n)
+        for j in range(a, b):
+            if i != j:
+                pairs.add(tuple(sorted((images[i], images[j]))))
+    return pairs
+
+
+def match_candidates_from_metadata(images, exifs, data):
+    """Compute candidate matching pairs"""
+    max_distance = data.config['matching_gps_distance']
+    gps_neighbors = data.config['matching_gps_neighbors']
+    time_neighbors = data.config['matching_time_neighbors']
+    order_neighbors = data.config['matching_order_neighbors']
+
+    if not data.reference_lla_exists():
+        data.invent_reference_lla()
+    reference = data.load_reference()
+
+    if not all(map(has_gps_info, exifs.values())):
+        if gps_neighbors != 0:
+            logger.warn("Not all images have GPS info. "
+                        "Disabling matching_gps_neighbors.")
+        gps_neighbors = 0
+        max_distance = 0
+
+    images.sort()
+
+    if max_distance == gps_neighbors == time_neighbors == order_neighbors == 0:
+        # All pair selection strategies deactivated so we match all pairs
+        d = set()
+        t = set()
+        o = set()
+        pairs = combinations(images, 2)
+    else:
+        d = match_candidates_by_distance(images, exifs, reference,
+                                         gps_neighbors, max_distance)
+        t = match_candidates_by_time(images, exifs, time_neighbors)
+        o = match_candidates_by_order(images, order_neighbors)
+        pairs = d | t | o
+
+    res = {im: [] for im in images}
+    for im1, im2 in pairs:
+        res[im1].append(im2)
+
+    report = {
+        "num_pairs_distance": len(d),
+        "num_pairs_time": len(t),
+        "num_pairs_order": len(o)
+    }
+    return res, report

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -67,7 +67,6 @@ def match_candidates_with_bow(data, images, max_neighbors):
         order, other = bow_distances(im, images, words, None, bows)
         for i in order[:max_neighbors]:
             pairs.add(tuple(sorted((im, other[i]))))
-        logger.info("Candidates for %s are %s" % (im, str(pairs).translate(None, "'")))
     return pairs
 
 

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -103,7 +103,13 @@ target_link_libraries(bundle PRIVATE
 
 
 # Python wrapper
-pybind11_add_module(csfm csfm.cc akaze_bind.cc depthmap.cc)
+pybind11_add_module(csfm
+    csfm.cc
+    types.cc
+    akaze_bind.cc
+    matching.cc
+    depthmap.cc
+)
 target_link_libraries(csfm PRIVATE
     ${OpenCV_LIBS}
     ${GFLAGS_LIBRARY}

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -9,6 +9,7 @@
 #include "matching.h"
 #include "multiview.cc"
 #include "akaze_bind.h"
+#include "matching.h"
 #include "bundle/bundle_adjuster.h"
 #include "openmvs_exporter.h"
 #include "depthmap_bind.h"

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -6,6 +6,7 @@
 
 #include "types.h"
 #include "hahog.cc"
+#include "matching.h"
 #include "multiview.cc"
 #include "akaze_bind.h"
 #include "bundle/bundle_adjuster.h"
@@ -72,6 +73,8 @@ PYBIND11_MODULE(csfm, m) {
         py::arg("target_num_features") = 0,
         py::arg("use_adaptive_suppression") = false
   );
+
+  m.def("match_using_words", csfm::match_using_words);
 
   m.def("triangulate_bearings_dlt", csfm::TriangulateBearingsDLT);
   m.def("triangulate_bearings_midpoint", csfm::TriangulateBearingsMidpoint);

--- a/opensfm/src/matching.cc
+++ b/opensfm/src/matching.cc
@@ -1,0 +1,97 @@
+#include <opencv2/core/core.hpp>
+#include <pybind11/pybind11.h>
+
+#include "types.h"
+
+
+namespace csfm {
+
+float DistanceL1(const float *pa, const float *pb, int n) {
+  float distance = 0;
+  for (int i = 0; i < n; ++i) {
+    distance += fabs(pa[i] - pb[i]);
+  }
+  return distance;
+}
+
+float DistanceL2(const float *pa, const float *pb, int n) {
+  float distance = 0;
+  for (int i = 0; i < n; ++i) {
+    distance += (pa[i] - pb[i]) * (pa[i] - pb[i]);
+  }
+  return sqrt(distance);
+}
+
+void MatchUsingWords(const cv::Mat &f1,
+                     const cv::Mat &w1,
+                     const cv::Mat &f2,
+                     const cv::Mat &w2,
+                     float lowes_ratio,
+                     int max_checks,
+                     cv::Mat *matches) {
+  // Index features on the second image.
+  std::multimap<int, int> index2;
+  const int *pw2 = &w2.at<int>(0, 0);
+  for (unsigned int i = 0; i < w2.rows * w2.cols; ++i) {
+    index2.insert(std::pair<int, int>(pw2[i], i));
+  }
+
+  std::vector<int> best_match(f1.rows, -1),
+                   second_best_match(f1.rows, -1);
+  std::vector<float> best_distance(f1.rows, 99999999),
+                     second_best_distance(f1.rows, 99999999);
+  *matches = cv::Mat(0, 2, CV_32S);
+  cv::Mat tmp_match(1, 2, CV_32S);
+  for (unsigned int i = 0; i < w1.rows; ++i) {
+    int checks = 0;
+    for (unsigned int j = 0; j < w1.cols; ++j) {
+      int word = w1.at<int>(i, j);
+      auto range = index2.equal_range(word);
+      for (auto it = range.first; it != range.second; ++it) {
+        int match = it->second;
+        const float *pa = f1.ptr<float>(i);
+        const float *pb = f2.ptr<float>(match);
+        float distance = DistanceL1(pa, pb, f1.cols);
+        if (distance < best_distance[i]) {
+          second_best_distance[i] = best_distance[i];
+          second_best_match[i] = best_match[i];
+          best_distance[i] = distance;
+          best_match[i] = match;
+        } else if (distance < second_best_distance[i]) {
+          second_best_distance[i] = distance;
+          second_best_match[i] = match;
+        }
+        checks++;
+      }
+      if (checks >= max_checks) break;
+    }
+    if (best_distance[i] < lowes_ratio * second_best_distance[i]) {
+      tmp_match.at<int>(0, 0) = i;
+      tmp_match.at<int>(0, 1) = best_match[i];
+      matches->push_back(tmp_match);
+    }
+  }
+}
+
+py::object match_using_words(pyarray_f features1,
+                             pyarray_int words1,
+                             pyarray_f features2,
+                             pyarray_int words2,
+                             float lowes_ratio,
+                             int max_checks) {
+  cv::Mat cv_f1 = pyarray_cv_mat_view(features1);
+  cv::Mat cv_w1 = pyarray_cv_mat_view(words1);
+  cv::Mat cv_f2 = pyarray_cv_mat_view(features2);
+  cv::Mat cv_w2 = pyarray_cv_mat_view(words2);
+  cv::Mat matches;
+
+  MatchUsingWords(cv_f1, cv_w1,
+                  cv_f2, cv_w2,
+                  lowes_ratio,
+                  max_checks,
+                  &matches);
+
+  return py_array_from_cvmat<int>(matches);
+}
+
+}

--- a/opensfm/src/matching.cc
+++ b/opensfm/src/matching.cc
@@ -53,7 +53,7 @@ void MatchUsingWords(const cv::Mat &f1,
         int match = it->second;
         const float *pa = f1.ptr<float>(i);
         const float *pb = f2.ptr<float>(match);
-        float distance = DistanceL1(pa, pb, f1.cols);
+        float distance = DistanceL2(pa, pb, f1.cols);
         if (distance < best_distance[i]) {
           second_best_distance[i] = best_distance[i];
           second_best_match[i] = best_match[i];

--- a/opensfm/src/matching.cc
+++ b/opensfm/src/matching.cc
@@ -1,3 +1,5 @@
+#include <map>
+#include <vector>
 #include <opencv2/core/core.hpp>
 #include <pybind11/pybind11.h>
 

--- a/opensfm/src/matching.h
+++ b/opensfm/src/matching.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "types.h"
+
+namespace csfm {
+
+py::object match_using_words(pyarray_f features1,
+                             pyarray_int words1,
+                             pyarray_f features2,
+                             pyarray_int words2,
+                             float lowes_ratio,
+                             int max_checks);
+
+}

--- a/opensfm/src/types.cc
+++ b/opensfm/src/types.cc
@@ -1,0 +1,26 @@
+#include "types.h"
+
+
+namespace csfm {
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_f &array) {
+  return pyarray_cv_mat_view_typed(array, CV_32F);
+}
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_d &array) {
+  return pyarray_cv_mat_view_typed(array, CV_64F);
+}
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_int &array) {
+  return pyarray_cv_mat_view_typed(array, CV_32S);
+}
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_uint8 &array) {
+  return pyarray_cv_mat_view_typed(array, CV_8U);
+}
+
+}

--- a/opensfm/src/types.h
+++ b/opensfm/src/types.h
@@ -1,11 +1,11 @@
-#ifndef __TYPES_H__
-#define __TYPES_H__
+#pragma once
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
 #include <vector>
 #include <iostream>
+#include "opencv2/core/core.hpp"
 
 
 namespace csfm {
@@ -15,6 +15,7 @@ namespace py = pybind11;
 
 typedef py::array_t<float, py::array::c_style | py::array::forcecast> pyarray_f;
 typedef py::array_t<double, py::array::c_style | py::array::forcecast> pyarray_d;
+typedef py::array_t<int, py::array::c_style | py::array::forcecast> pyarray_int;
 typedef py::array_t<unsigned char, py::array::c_style | py::array::forcecast> pyarray_uint8;
 
 template <typename T>
@@ -44,6 +45,40 @@ py::array_t<T> py_array_from_vector(const std::vector<T> &v) {
   return py_array_from_data(data, v.size());
 }
 
+template <typename T>
+py::array_t<T> py_array_from_cvmat(const cv::Mat &m) {
+  const T *data = m.rows ? m.ptr<T>(0) : NULL;
+  return py_array_from_data(data, m.rows, m.cols);
 }
 
-#endif // __TYPES_H__
+template<typename T>
+cv::Mat pyarray_cv_mat_view_typed(T &array, int type) {
+  int height = 1;
+  int width = 1;
+
+  if (array.ndim() == 1) {
+    width = array.shape(0);
+  } else if (array.ndim() == 2) {
+    height = array.shape(0);
+    width = array.shape(1);
+  }
+
+  return cv::Mat(height, width, type, array.mutable_data());
+}
+
+template<typename T>
+cv::Mat pyarray_cv_mat_view(T &array) {}
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_f &array);
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_d &array);
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_int &array);
+
+template<>
+cv::Mat pyarray_cv_mat_view(pyarray_uint8 &array);
+
+}

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setuptools.setup(
         'opensfm': [
             'csfm.*',
             'data/sensor_data.json',
+            'data/bow/frequencies_hahog_root_uchar.npy',
+            'data/bow/words_hahog_root_uchar.npy',
         ]
     },
     # install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,7 @@ setuptools.setup(
         'opensfm': [
             'csfm.*',
             'data/sensor_data.json',
-            'data/bow/frequencies_hahog_root_uchar.npy',
-            'data/bow/words_hahog_root_uchar.npy',
+            'data/bow/bow_hahog_root_uchar.npz',
         ]
     },
     # install_requires=[


### PR DESCRIPTION
This PR add bags-of-words (BoW) matching to OpenSfM. This branch is the combination of https://github.com/mapillary/OpenSfM/tree/feat-match-words, which adds BoW matching, and other commits that add pairs generation from BoW. More specifically, we did the following :

 - Compute words assignemnts at feature extraction stage, when either matching or pairs generation is BoW-based.
 - Add image-to-image BoW matching. 2x to 5x faster than FLANN-based matching with reduction in accuracy.
 - Removed unused preemptive matching
 - Moved pair generation code to a new module
 - Added pairs generation using BoW distances, further controlled by `matching_bow_neighbors` in `config`