### PR TITLE
Faster extract_metadata when using use_exif_size: no

### DIFF
--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-from PIL import Image
 
 from opensfm import dataset
 from opensfm import transformations as tf
@@ -37,7 +36,7 @@ class Command:
         for shot in reconstruction.shots.values():
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
-            size = max(self.image_size(shot.id, data))
+            size = max(data.undistorted_image_size(shot.id))
             words = [
                 self.image_path(shot.id, data),
                 shot.camera.focal * size,
@@ -55,17 +54,3 @@ class Command:
         """Path to the undistorted image relative to the dataset path."""
         path = data._undistorted_image_file(image)
         return os.path.relpath(path, data.data_path)
-
-    def image_size(self, image, data):
-        """
-        Height and width of the undistorted image.
-        """
-        try:
-            file_path = data._undistorted_image_file(image)
-            with Image.open(file_path) as img:
-                width, height = img.size
-                return height, width
-        except:
-            # Slower fallback
-            image = data.load_undistorted_image(image)
-            return image.shape[:2]

--- a/opensfm/commands/extract_metadata.py
+++ b/opensfm/commands/extract_metadata.py
@@ -38,12 +38,7 @@ class Command:
 
                 data.save_exif(image, d)
 
-        processes = min(data.config['processes'], 2) # Don't use all CPUs as we're I/O bound
-        if processes > 1:
-            parallel_map(extract_exif, data.images(), processes)
-        else:
-            for image in data.images():
-                extract_exif(image)
+        parallel_map(extract_exif, data.images(), data.config['processes'])
 
         camera_models = {}
         for image in data.images():
@@ -76,7 +71,7 @@ class Command:
 
         # Image Height and Image Width
         if d['width'] <= 0 or not data.config['use_exif_size']:
-            d['height'], d['width'] = data.load_image(image).shape[:2]
+            d['height'], d['width'] = data.image_size(image)
 
         d['camera'] = exif.camera_id(d)
 

--- a/opensfm/commands/extract_metadata.py
+++ b/opensfm/commands/extract_metadata.py
@@ -4,6 +4,8 @@ import time
 
 from opensfm import dataset
 from opensfm import exif
+from opensfm.context import parallel_map
+from opensfm import log
 
 
 logger = logging.getLogger(__name__)
@@ -25,19 +27,28 @@ class Command:
         if data.exif_overrides_exists():
             exif_overrides = data.load_exif_overrides()
 
-        camera_models = {}
-        for image in data.images():
-            if data.exif_exists(image):
-                logging.info('Loading existing EXIF for {}'.format(image))
-                d = data.load_exif(image)
-            else:
-                logging.info('Extracting EXIF for {}'.format(image))
+        def extract_exif(image):
+            if not data.exif_exists(image):
+                log.setup()
+                logger.info('Extracting EXIF for {}'.format(image))
                 d = self._extract_exif(image, data)
 
                 if image in exif_overrides:
                     d.update(exif_overrides[image])
 
                 data.save_exif(image, d)
+
+        processes = min(data.config['processes'], 2) # Don't use all CPUs as we're I/O bound
+        if processes > 1:
+            parallel_map(extract_exif, data.images(), processes)
+        else:
+            for image in data.images():
+                extract_exif(image)
+
+        camera_models = {}
+        for image in data.images():
+            logging.info('Loading EXIF for {}'.format(image))
+            d = data.load_exif(image)
 
             if d['camera'] not in camera_models:
                 camera = exif.camera_from_exif_metadata(d, data)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -10,6 +10,7 @@ import sys
 import numpy as np
 import networkx as nx
 import six
+from PIL import Image
 
 from opensfm import io
 from opensfm import config
@@ -76,6 +77,19 @@ class DataSet(object):
         """
         return io.imread(self._image_file(image))
 
+    def image_size(self, image):
+        """
+        Height and width of the image.
+        """
+        try:
+            with Image.open(self._image_file(image)) as img:
+                width, height = img.size
+                return height, width
+        except:
+            # Slower fallback
+            image = self.load_image(image)
+            return image.shape[:2]
+
     def _undistorted_image_path(self):
         return os.path.join(self.data_path, 'undistorted')
 
@@ -93,6 +107,19 @@ class DataSet(object):
         """Save undistorted image pixels."""
         io.mkdir_p(self._undistorted_image_path())
         io.imwrite(self._undistorted_image_file(image), array)
+
+    def undistorted_image_size(self, image):
+        """
+        Height and width of the undistorted image.
+        """
+        try:
+            with Image.open(self._undistorted_image_file(image)) as img:
+                width, height = img.size
+                return height, width
+        except:
+            # Slower fallback
+            image = self.load_undistorted_image(image)
+            return image.shape[:2]
 
     def _load_mask_list(self):
         """Load mask list from mask_list.txt or list masks/ folder."""


### PR DESCRIPTION
While `extract_metadata` seems I/O bound, I've noticed that processing with two processes yields almost 30% speed-up in performance.

With 78 images:

```
real	0m19.920s
user	0m16.316s
sys	0m3.808s
```

vs. proposed

```
real	0m14.724s
user	0m22.400s
sys	0m6.029s
```

Not sure if the added complexity is worth it, but thought I'd open a PR to see if there's interest.