### PR TITLE
Merge OpenSfM and production matching 2/2

### DIFF
--- a/doc/source/geometry.rst
+++ b/doc/source/geometry.rst
@@ -61,6 +61,17 @@ and its inverse
 
 where :math:`w` and :math:`h` being the width and height of the image.
 
+Upright Coordinates
+~~~~~~~~~~~~~~~~~~~
+
+When taking pictures, a camera might be rotated in either portrait or in landscape orientation. But the corresponding image file will always store the pixels in the same order, the one when the camera is supposed to be upright.
+
+To overcome this issue, most camera store this orientation (i.e. camera orientation at shoot time) in the EXIFs in the `orientation` tag. Most editing software will also use this information to display image correctly.
+
+That's why, when editing a mask with your favorite software, you don't need to bother about image orientation as OpenSfM will automatically apply the right rotation correction so your mask will be aligned with the original image.
+
+Please note that `Normalized Image Coordinates` and `Pixel Coordinates` are *NOT* corrected for upright, and are really *original* image coordinates.
+
 World Coordinates
 ~~~~~~~~~~~~~~~~~
 The position of the reconstructed 3D points is stored in *world coordinates*.  In general, this is an arbitrary euclidean reference frame.

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -28,7 +28,7 @@ class Command:
 
         start = timer()
         processes = data.config['processes']
-        parallel_map(detect, arguments, processes)
+        parallel_map(detect, arguments, processes, 1)
         end = timer()
         with open(data.profile_log(), 'a') as fout:
             fout.write('detect_features: {0}\n'.format(end - start))

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -97,7 +97,6 @@ def detect(args):
         n_closest = data.config['bow_words_to_match']
         closest_words = bows.map_to_words(
             f_sorted, n_closest, data.config['bow_matcher_type'])
-        closest_words = closest_words[order, :]
         data.save_words(image, closest_words)
 
     end = timer()

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -76,52 +76,16 @@ def match(args):
     im1, candidates, i, n, ctx = args
     logger.info('Matching {}  -  {} / {}'.format(im1, i + 1, n))
 
-    config = ctx.data.config
-    matcher_type = config['matcher_type']
-    robust_matching_min_match = config['robust_matching_min_match']
-
+    t = timer()
     im1_matches = {}
-
     for im2 in candidates:
-        # symmetric matching
-        t = timer()
-        p1, f1, c1 = ctx.data.load_features(im1)
-        p2, f2, c2 = ctx.data.load_features(im2)
-
-        if matcher_type == 'WORDS':
-            w1 = ctx.data.load_words(im1)
-            w2 = ctx.data.load_words(im2)
-            matches = matching.match_words_symmetric(f1, w1, f2, w2, config)
-        elif matcher_type == 'FLANN':
-            i1 = ctx.data.load_feature_index(im1, f1)
-            i2 = ctx.data.load_feature_index(im2, f2)
-            matches = matching.match_flann_symmetric(f1, i1, f2, i2, config)
-        elif matcher_type == 'BRUTEFORCE':
-            matches = matching.match_brute_force_symmetric(f1, f2, config)
-        else:
-            raise ValueError("Invalid matcher_type: {}".format(matcher_type))
-
-        logger.debug('{} - {} has {} candidate matches'.format(
-            im1, im2, len(matches)))
-        if len(matches) < robust_matching_min_match:
-            im1_matches[im2] = []
-            continue
-
-        # robust matching
-        t_robust_matching = timer()
+        p1, f1, _ = ctx.data.load_features(im1)
+        p2, f2, _ = ctx.data.load_features(im2)
+        w1 = ctx.data.load_words(im1)
+        w2 = ctx.data.load_words(im2)
         camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]
-
-        rmatches = matching.robust_match(p1, p2, camera1, camera2, matches,
-                                         config)
-
-        if len(rmatches) < robust_matching_min_match:
-            im1_matches[im2] = []
-            continue
-        im1_matches[im2] = rmatches
-        logger.debug('Robust matching time : {0}s'.format(
-            timer() - t_robust_matching))
-
-        logger.debug("Full matching {0} / {1}, time: {2}s".format(
-            len(rmatches), len(matches), timer() - t))
+        im1_matches[im2] = matching.match(im1, im2, camera1, camera2,
+                                          p1, p2, f1, f2, w1, w2,
+                                          None, None, ctx.data)
     ctx.data.save_matches(im1, im1_matches)

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -31,7 +31,7 @@ class Command:
 
         with open(data.profile_log(), 'a') as fout:
             fout.write('match_features: {0}\n'.format(end - start))
-        self.write_report(data, preport, pairs_matches.keys(), end - start)
+        self.write_report(data, preport, list(pairs_matches.keys()), end - start)
 
     def write_report(self, data, preport, pairs, wall_time):
         report = {

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -24,68 +24,20 @@ class Command:
     def run(self, args):
         data = dataset.DataSet(args.dataset)
         images = data.images()
-        exifs = {im: data.load_exif(im) for im in images}
-        pairs, preport = pairs_selection.match_candidates_from_metadata(images, images, exifs, data)
-
-        num_pairs = sum(len(c) for c in pairs.values())
-        logger.info('Matching {} image pairs'.format(num_pairs))
-
-        ctx = Context()
-        ctx.data = data
-        ctx.cameras = ctx.data.load_camera_models()
-        ctx.exifs = exifs
-        args = list(match_arguments(pairs, ctx))
 
         start = timer()
-        processes = ctx.data.config['processes']
-        parallel_map(match, args, processes)
+        pairs, preport = matching.match_images(data, images, images)
         end = timer()
 
-        with open(ctx.data.profile_log(), 'a') as fout:
+        with open(data.profile_log(), 'a') as fout:
             fout.write('match_features: {0}\n'.format(end - start))
         self.write_report(data, preport, pairs, end - start)
 
     def write_report(self, data, preport, pairs, wall_time):
-        pair_list = []
-        for im1, others in pairs.items():
-            for im2 in others:
-                pair_list.append((im1, im2))
-
         report = {
             "wall_time": wall_time,
-            "num_pairs": len(pair_list),
-            "pairs": pair_list,
+            "num_pairs": len(pairs),
+            "pairs": pairs,
         }
         report.update(preport)
         data.save_report(io.json_dumps(report), 'matches.json')
-
-
-class Context:
-    pass
-
-
-def match_arguments(pairs, ctx):
-    for i, (im, candidates) in enumerate(pairs.items()):
-        yield im, candidates, i, len(pairs), ctx
-
-
-def match(args):
-    """Compute all matches for a single image"""
-    log.setup()
-
-    im1, candidates, i, n, ctx = args
-    logger.info('Matching {}  -  {} / {}'.format(im1, i + 1, n))
-
-    t = timer()
-    im1_matches = {}
-    for im2 in candidates:
-        p1, f1, _ = ctx.data.load_features(im1)
-        p2, f2, _ = ctx.data.load_features(im2)
-        w1 = ctx.data.load_words(im1)
-        w2 = ctx.data.load_words(im2)
-        camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
-        camera2 = ctx.cameras[ctx.exifs[im2]['camera']]
-        im1_matches[im2] = matching.match(im1, im2, camera1, camera2,
-                                          p1, p2, f1, f2, w1, w2,
-                                          None, None, ctx.data)
-    ctx.data.save_matches(im1, im1_matches)

--- a/opensfm/commands/match_features.py
+++ b/opensfm/commands/match_features.py
@@ -26,12 +26,12 @@ class Command:
         images = data.images()
 
         start = timer()
-        pairs, preport = matching.match_images(data, images, images)
+        pairs_matches, preport = matching.match_images(data, images, images)
         end = timer()
 
         with open(data.profile_log(), 'a') as fout:
             fout.write('match_features: {0}\n'.format(end - start))
-        self.write_report(data, preport, pairs, end - start)
+        self.write_report(data, preport, pairs_matches.keys(), end - start)
 
     def write_report(self, data, preport, pairs, wall_time):
         report = {

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -39,7 +39,7 @@ hahog_normalize_to_uchar: yes
 
 # Params for general matching
 lowes_ratio: 0.8              # Ratio test for matches
-matcher_type: FLANN           # FLANN or BRUTEFORCE or WORDS
+matcher_type: FLANN           # FLANN(symmetric) or BRUTEFORCE(symmetric), WORDS(one-way) or WORDS_SYMMETRIC(symmetric)
 
 # Params for FLANN matching
 flann_branching: 16           # See OpenCV doc
@@ -62,7 +62,7 @@ matching_bow_neighbors: 0             # Number of images to match selected by Bo
 matching_bow_gps_distance: 0          # Maximum GPS distance for preempting images before using selection by BoW distance. Set to 0 to disable
 matching_bow_gps_neighbors: 0         # Number of images (selected by GPS distance) to preempt before using selection by BoW distance. Set to 0 to use no limit (or disable if matching_bow_gps_distance is also 0)
 matching_bow_other_cameras: False     # If True, BoW image selection will use N neighbors from the same camera + N neighbors from any different camera.
-matching_use_filters: False           # If True, removes matches using ad-hoc heuristics
+matching_use_filters: False           # If True, removes static matches using ad-hoc heuristics
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -62,6 +62,7 @@ matching_bow_neighbors: 0             # Number of images to match selected by Bo
 matching_bow_gps_distance: 0          # Maximum GPS distance for preempting images before using selection by BoW distance. Set to 0 to disable
 matching_bow_gps_neighbors: 0         # Number of images (selected by GPS distance) to preempt before using selection by BoW distance. Set to 0 to use no limit (or disable if matching_bow_gps_distance is also 0)
 matching_bow_other_cameras: False     # If True, BoW image selection will use N neighbors from the same camera + N neighbors from any different camera.
+matching_use_filters: False           # If True, removes matches using ad-hoc heuristics
 
 # Params for geometric estimation
 robust_matching_threshold: 0.004        # Outlier threshold for fundamental matrix estimation as portion of image width

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -48,12 +48,11 @@ flann_checks: 200             # Smaller -> Faster (but might lose good matches)
 
 # Params for BoW matching
 bow_file: bow_hahog_root_uchar.npz
-bow_images_to_match: 15       # Number of images to do detailed matching.
 bow_words_to_match: 50        # Number of words to explore per feature.
 bow_num_checks: 20            # Number of matching features to check.
 bow_matcher_type: FLANN       # Matcher type to assign words to features
 
-# Params for preemptive matching
+# Params for matching
 matching_gps_distance: 150            # Maximum gps distance between two images for matching
 matching_gps_neighbors: 0             # Number of images to match selected by GPS distance. Set to 0 to use no limit (or disable if matching_gps_distance is also 0)
 matching_time_neighbors: 0            # Number of images to match selected by time taken. Set to 0 to disable

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -29,7 +29,7 @@ else:
 
 
 # Parallel processes
-def parallel_map(func, args, num_proc):
+def parallel_map(func, args, num_proc, max_batch_size=None):
     """Run function for all arguments using multiple processes."""
     num_proc = min(num_proc, len(args))
     if num_proc <= 1:
@@ -37,6 +37,7 @@ def parallel_map(func, args, num_proc):
     else:
         with parallel_backend('loky', n_jobs=num_proc):
             batch_size = max(1, len(args)/(num_proc*2))
+            batch_size = min(batch_size, max_batch_size) if max_batch_size else batch_size
             return Parallel(batch_size=batch_size)(delayed(func)(arg) for arg in args)
 
 

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -29,7 +29,7 @@ else:
 
 
 # Parallel processes
-def parallel_map(func, args, num_proc, max_batch_size=None):
+def parallel_map(func, args, num_proc, max_batch_size=1):
     """Run function for all arguments using multiple processes."""
     num_proc = min(num_proc, len(args))
     if num_proc <= 1:

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -59,5 +59,17 @@ def memory_available():
     return available_mem
 
 
+def memory_available():
+    """Available memory in MB.
+
+    Only works on linux and returns None otherwise.
+    """
+    lines = os.popen('free -t -m').readlines()
+    if not lines:
+        return None
+    available_mem = int(lines[1].split()[6])
+    return available_mem
+
+
 def current_memory_usage():
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -36,7 +36,7 @@ def parallel_map(func, args, num_proc):
         return list(map(func, args))
     else:
         with parallel_backend('loky', n_jobs=num_proc):
-            batch_size = max(1, len(args)/num_proc)
+            batch_size = max(1, len(args)/(num_proc*2))
             return Parallel(batch_size=batch_size)(delayed(func)(arg) for arg in args)
 
 

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -59,16 +59,14 @@ def memory_available():
     return available_mem
 
 
-def memory_available():
-    """Available memory in MB.
-
-    Only works on linux and returns None otherwise.
-    """
-    lines = os.popen('free -t -m').readlines()
-    if not lines:
-        return None
-    available_mem = int(lines[1].split()[6])
-    return available_mem
+def processes_that_fit_in_memory(desired, per_process):
+    """Amount of parallel BoW process that fit in memory."""
+    available_mem = memory_available()
+    if available_mem is not None:
+        fittable = max(1, int(available_mem / per_process))
+        return min(desired, fittable)
+    else:
+        return desired
 
 
 def current_memory_usage():

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -122,6 +122,13 @@ class DataSet(object):
             mask = None
         return mask
 
+    def load_features_mask(self, image, features):
+        """Load a feature-wise mask if it exists, otherwise return None.
+
+        This mask is used when performing features matching.
+        """
+        return np.ones((features.shape[0],), dtype=bool)
+
     def _undistorted_mask_path(self):
         return os.path.join(self.data_path, 'undistorted_masks')
 

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -141,7 +141,9 @@ class DataSet(object):
         height = exif["height"]
         orientation = exif["orientation"]
 
-        ps = upright.opensfm_to_upright(feat, width, height, orientation).astype(int)
+        new_height, new_width = mask_image.shape
+        ps = upright.opensfm_to_upright(feat, width, height, orientation,
+                                        new_width=new_width, new_height=new_height).astype(int)
         mask = mask_image[ps[:, 1], ps[:, 0]]
 
         n_removed = len(mask) - np.sum(mask)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -15,6 +15,7 @@ from opensfm import context
 from opensfm import geo
 from opensfm import tracking
 from opensfm import features
+from opensfm import upright
 
 
 logger = logging.getLogger(__name__)
@@ -135,9 +136,12 @@ class DataSet(object):
             logger.debug('No segmentation for {}, no features masked.'.format(image))
             return np.ones((feat.shape[0],), dtype=bool)
 
-        w = mask_image.shape[1]
-        h = mask_image.shape[0]
-        ps = features.denormalized_image_coordinates(feat, w, h).astype(int)
+        exif = self.load_exif(image)
+        width = exif["width"]
+        height = exif["height"]
+        orientation = exif["orientation"]
+
+        ps = upright.opensfm_to_upright(feat, width, height, orientation).astype(int)
         mask = mask_image[ps[:, 1], ps[:, 0]]
 
         n_removed = len(mask) - np.sum(mask)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -481,6 +481,8 @@ class DataSet(object):
         return os.path.join(self._feature_path(), image + '.flann')
 
     def load_feature_index(self, image, features):
+        if not self.feature_index_exists(image):
+            raise IOError("FLANN index file for {} doesn't exists.".format(image))
         index = context.flann_Index()
         index.load(features, self._feature_index_file(image))
         return index

--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import numpy as np
+from repoze.lru import LRUCache
+
+
+logger = logging.getLogger(__name__)
+
+
+class FeatureLoader(object):
+    def __init__(self):
+        self.points_cache = LRUCache(1000)
+        self.colors_cache = LRUCache(1000)
+        self.features_cache = LRUCache(200)
+        self.words_cache = LRUCache(200)
+        self.masks_cache = LRUCache(1000)
+        self.index_cache = LRUCache(200)
+
+    def clear_cache(self):
+        self.points_cache.clear()
+        self.colors_cache.clear()
+        self.features_cache.clear()
+        self.words_cache.clear()
+        self.masks_cache.clear()
+
+    def load_points_colors(self, data, image):
+        points = self.points_cache.get(image)
+        colors = self.colors_cache.get(image)
+        if points is None or colors is None:
+            points, _, colors = self._load_features_nocache(data, image)
+            self.points_cache.put(image, points)
+            self.colors_cache.put(image, colors)
+        return points, colors
+
+    def load_features_index(self, data, image, features):
+        index = self.index_cache.get(image)
+        if index is None:
+            index = data.load_feature_index(image, features)
+            self.index_cache.put(image, index)
+        return index
+
+    def load_points_features_colors(self, data, image):
+        points = self.points_cache.get(image)
+        features = self.features_cache.get(image)
+        colors = self.colors_cache.get(image)
+        if points is None or features is None or colors is None:
+            points, features, colors = self._load_features_nocache(data, image)
+            self.points_cache.put(image, points)
+            self.features_cache.put(image, features)
+            self.colors_cache.put(image, colors)
+        return points, features, colors
+
+    def load_words(self, data, image):
+        words = self.words_cache.get(image)
+        if words is None:
+            words = data.load_words(image)
+            self.words_cache.put(image, words)
+        return words
+
+    def _load_features_nocache(self, data, image):
+        points, features, colors = data.load_features(image)
+        if points is None:
+            logger.error('Could not load features for image {}'.format(image))
+        else:
+            points = np.array(points[:, :3], dtype=float)
+        return points, features, colors

--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -41,7 +41,7 @@ class FeatureLoader(object):
         points, _ = self.load_points_colors(data, image)
         masks = self.masks_cache.get(image)
         if masks is None:
-            masks = data.load_features_mask(image, points[:, :2], data)
+            masks = data.load_features_mask(image, points[:, :2])
             self.masks_cache.put(image, masks)
         return masks
 

--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -37,6 +37,14 @@ class FeatureLoader(object):
             self.colors_cache.put(image, colors)
         return points, colors
 
+    def load_masks(self, data, image):
+        points, _ = self.load_points_colors(data, image)
+        masks = self.masks_cache.get(image)
+        if masks is None:
+            masks = data.load_features_mask(image, points[:, :2], data)
+            self.masks_cache.put(image, masks)
+        return masks
+
     def load_features_index(self, data, image, features):
         index = self.index_cache.get(image)
         if index is None:

--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -8,6 +8,8 @@ import logging
 import numpy as np
 from repoze.lru import LRUCache
 
+from opensfm import features as ft
+
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +49,14 @@ class FeatureLoader(object):
 
     def load_features_index(self, data, image, features):
         index = self.index_cache.get(image)
-        if index is None:
+        current_features = self.load_points_features_colors(data, image)
+        use_load = len(current_features) == len(features) and index is None
+        use_rebuild = len(current_features) != len(features)
+        if use_load:
             index = data.load_feature_index(image, features)
+        if use_rebuild:
+            index = ft.build_flann_index(features, data.config)
+        if use_load or use_rebuild:
             self.index_cache.put(image, index)
         return index
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -157,9 +157,9 @@ def match(im1, im2, camera1, camera2,
             f1_filtered, w1_filtered,
             f2_filtered, w2_filtered, config)
     elif matcher_type == 'FLANN':
-        matches = match_flann_symmetric(f1, i1, f2, i2, config)
+        matches = match_flann_symmetric(f1_filtered, i1, f2_filtered, i2, config)
     elif matcher_type == 'BRUTEFORCE':
-        matches = match_brute_force_symmetric(f1, f2, config)
+        matches = match_brute_force_symmetric(f1_filtered, f2_filtered, config)
     else:
         raise ValueError("Invalid matcher_type: {}".format(matcher_type))
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -169,8 +169,8 @@ def match(im1, im2, camera1, camera2,
     # Adhoc filters
     if config['matching_use_filters']:
         matches = apply_adhoc_filters(data, matches,
-                                      p1, camera1,
-                                      p2, camera2)
+                                      im1, camera1, p1,
+                                      im2, camera2, p2)
 
     matches = np.array(matches, dtype=int)
     time_2d_matching = timer() - time_start
@@ -409,7 +409,7 @@ def unfilter_matches(matches, m1, m2):
     return np.array([(i1[match[0]], i2[match[1]]) for match in matches])
 
 
-def apply_adhoc_filters(data, matches, camera1, p1, camera2, p2):
+def apply_adhoc_filters(data, matches, im1, camera1, p1, im2, camera2, p2):
     """ Apply a set of filters functions defined further below
         for removing static data in images.
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -88,18 +88,20 @@ def match_unwrap_args(args):
     """
     log.setup()
     im1, candidates, ctx = args
+
     need_words = 'WORDS' in ctx.data.config['matcher_type']
+    need_index = 'FLANN' in ctx.data.config['matcher_type']
 
     im1_matches = {}
     p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
     w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
-    i1 = feature_loader.load_features_index(ctx.data, im1, f1)
+    i1 = feature_loader.load_features_index(ctx.data, im1, f1) if need_index else None
     m1 = feature_loader.load_masks(ctx.data, im1)
 
     for im2 in candidates:
         p2, f2, _ = feature_loader.load_points_features_colors(ctx.data, im2)
         w2 = feature_loader.load_words(ctx.data, im2) if need_words else None
-        i2 = feature_loader.load_features_index(ctx.data, im2, f2)
+        i2 = feature_loader.load_features_index(ctx.data, im2, f2) if need_index else None
         m2 = feature_loader.load_masks(ctx.data, im2)
         camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -77,12 +77,14 @@ def match_unwrap_args(args):
     """
     log.setup()
     im1, candidates, ctx = args
+    need_words = 'WORDS' in ctx.data.config['matcher_type']
+
     im1_matches = {}
     for im2 in candidates:
         p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
         p2, f2, _ = feature_loader.load_points_features_colors(ctx.data, im2)
-        w1 = feature_loader.load_words(ctx.data, im1)
-        w2 = feature_loader.load_words(ctx.data, im2)
+        w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
+        w2 = feature_loader.load_words(ctx.data, im2) if need_words else None
         i1 = feature_loader.load_features_index(ctx.data, im1, f1)
         i2 = feature_loader.load_features_index(ctx.data, im2, f2)
         m1 = ctx.data.load_masks(im1) if hasattr(ctx.data, 'load_masks') else None

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -54,10 +54,11 @@ def match_images(data, ref_images, cand_images):
 
     # Perform all pair matchings in parallel
     start = timer()
-    per_process = 512
-    processes = context.processes_that_fit_in_memory(data.config['processes'], per_process)
+    mem_per_process = 512
+    jobs_per_process = 100
+    processes = context.processes_that_fit_in_memory(data.config['processes'], mem_per_process)
     logger.info("Computing pair matching with %d processes" % processes)
-    matches = context.parallel_map(match_unwrap_args, args, processes)
+    matches = context.parallel_map(match_unwrap_args, args, processes, jobs_per_process)
     logger.debug('Matched {} pairs in {} seconds.'.format(
         len(pairs), timer()-start))
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -50,7 +50,7 @@ def match_images(data, ref_images, cand_images):
 
     # Perform all pair matchings in parallel
     start = timer()
-    per_process = 1.6 * 1024
+    per_process = 512
     processes = context.processes_that_fit_in_memory(data.config['processes'], per_process)
     logger.info("Computing pair matching with %d processes" % processes)
     context.parallel_map(match_unwrap_args, args, processes)

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -93,13 +93,13 @@ def match_unwrap_args(args):
     p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
     w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
     i1 = feature_loader.load_features_index(ctx.data, im1, f1)
-    m1 = ctx.data.load_masks(im1) if hasattr(ctx.data, 'load_masks') else None
+    m1 = feature_loader.load_masks(ctx.data, im1)
 
     for im2 in candidates:
         p2, f2, _ = feature_loader.load_points_features_colors(ctx.data, im2)
         w2 = feature_loader.load_words(ctx.data, im2) if need_words else None
         i2 = feature_loader.load_features_index(ctx.data, im2, f2)
-        m2 = ctx.data.load_masks(im2) if hasattr(ctx.data, 'load_masks') else None
+        m2 = feature_loader.load_masks(ctx.data, im2)
         camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]
         im1_matches[im2] = match(im1, im2, camera1, camera2,
@@ -160,7 +160,7 @@ def match(im1, im2, camera1, camera2,
         raise ValueError("Invalid matcher_type: {}".format(matcher_type))
 
     # From indexes in filtered sets, to indexes in original sets of features
-    if m1 and m2:
+    if m1 is not None and m2 is not None:
         matches = unfilter_matches(matches, m1, m2)
 
     # Adhoc filters

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -96,16 +96,21 @@ def match_unwrap_args(args):
     im1_matches = {}
     p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
     w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
-    i1 = feature_loader.load_features_index(ctx.data, im1, f1) if need_index else None
     m1 = feature_loader.load_masks(ctx.data, im1)
     camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
+
+    f1_filtered = f1 if m1 is None else f1[m1]
+    i1 = feature_loader.load_features_index(ctx.data, im1, f1_filtered) if need_index else None
 
     for im2 in candidates:
         p2, f2, _ = feature_loader.load_points_features_colors(ctx.data, im2)
         w2 = feature_loader.load_words(ctx.data, im2) if need_words else None
-        i2 = feature_loader.load_features_index(ctx.data, im2, f2) if need_index else None
         m2 = feature_loader.load_masks(ctx.data, im2)
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]
+
+        f2_filtered = f2 if m2 is None else f2[m2]
+        i2 = feature_loader.load_features_index(ctx.data, im2, f2_filtered) if need_index else None
+
         im1_matches[im2] = match(im1, im2, camera1, camera2,
                                  p1, p2, f1, f2, w1, w2,
                                  i1, i2, m1, m2, ctx.data)

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -80,14 +80,15 @@ def match_unwrap_args(args):
     need_words = 'WORDS' in ctx.data.config['matcher_type']
 
     im1_matches = {}
+    p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
+    w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
+    i1 = feature_loader.load_features_index(ctx.data, im1, f1)
+    m1 = ctx.data.load_masks(im1) if hasattr(ctx.data, 'load_masks') else None
+
     for im2 in candidates:
-        p1, f1, _ = feature_loader.load_points_features_colors(ctx.data, im1)
         p2, f2, _ = feature_loader.load_points_features_colors(ctx.data, im2)
-        w1 = feature_loader.load_words(ctx.data, im1) if need_words else None
         w2 = feature_loader.load_words(ctx.data, im2) if need_words else None
-        i1 = feature_loader.load_features_index(ctx.data, im1, f1)
         i2 = feature_loader.load_features_index(ctx.data, im2, f2)
-        m1 = ctx.data.load_masks(im1) if hasattr(ctx.data, 'load_masks') else None
         m2 = ctx.data.load_masks(im2) if hasattr(ctx.data, 'load_masks') else None
         camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -100,7 +100,7 @@ def match_candidates_with_bow(data, images_ref, images_cand,
     args = list(match_bow_arguments(preempted_cand, histograms))
 
     # parralel BoW neighbors computation
-    per_process = 1.6 * 1024
+    per_process = 512
     processes = context.processes_that_fit_in_memory(data.config['processes'], per_process)
     logger.info("Computing BoW candidates with %d processes" % processes)
     results = context.parallel_map(match_bow_unwrap_args, args, processes)

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -100,7 +100,8 @@ def match_candidates_with_bow(data, images_ref, images_cand,
     args = list(match_bow_arguments(preempted_cand, histograms))
 
     # parralel BoW neighbors computation
-    processes = processes_that_fit_in_memory(data.config['processes'])
+    per_process = 1.6 * 1024
+    processes = context.processes_that_fit_in_memory(data.config['processes'], per_process)
     logger.info("Computing BoW candidates with %d processes" % processes)
     results = context.parallel_map(match_bow_unwrap_args, args, processes)
 
@@ -290,14 +291,3 @@ def pairs_from_neighbors(image, exifs, order, other, max_neighbors):
     for im2 in same_camera+other_cameras:
         pairs.add(tuple(sorted((image, im2))))
     return pairs
-
-
-def processes_that_fit_in_memory(desired):
-    """Amount of parallel BoW process that fit in memory."""
-    per_process_mem = 1.6 * 1024
-    available_mem = context.memory_available()
-    if available_mem is not None:
-        fittable = max(1, int(available_mem / per_process_mem))
-        return min(desired, fittable)
-    else:
-        return desired

--- a/opensfm/synthetic_data/synthetic_scene.py
+++ b/opensfm/synthetic_data/synthetic_scene.py
@@ -116,22 +116,22 @@ class SyntheticScene(object):
         return sg.generate_track_data(self.get_reconstruction(),
                                       maximum_depth, noise)
 
-    def compare(self, reconstruction):
-        reference = self.get_reconstruction()
-        position = sm.position_errors(reference, reconstruction)
-        gps = sm.gps_errors(reconstruction)
-        rotation = sm.rotation_errors(reference, reconstruction)
-        points = sm.points_errors(reference, reconstruction)
-        completeness = sm.completeness_errors(reference, reconstruction)
-        return {
-            'position_average': np.linalg.norm(np.average(position, axis=0)),
-            'position_std': np.linalg.norm(np.std(position, axis=0)),
-            'gps_average': np.linalg.norm(np.average(gps, axis=0)),
-            'gps_std': np.linalg.norm(np.std(gps, axis=0)),
-            'rotation_average': np.average(rotation),
-            'rotation_std': np.std(rotation),
-            'points_average': np.linalg.norm(np.average(points, axis=0)),
-            'points_std': np.linalg.norm(np.std(points, axis=0)),
-            'ratio_cameras': completeness[0],
-            'ratio_points': completeness[1]
-        }
+
+def compare(reference, reconstruction):
+    position = sm.position_errors(reference, reconstruction)
+    gps = sm.gps_errors(reconstruction)
+    rotation = sm.rotation_errors(reference, reconstruction)
+    points = sm.points_errors(reference, reconstruction)
+    completeness = sm.completeness_errors(reference, reconstruction)
+    return {
+        'position_average': np.linalg.norm(np.average(position, axis=0)),
+        'position_std': np.linalg.norm(np.std(position, axis=0)),
+        'gps_average': np.linalg.norm(np.average(gps, axis=0)),
+        'gps_std': np.linalg.norm(np.std(gps, axis=0)),
+        'rotation_average': np.average(rotation),
+        'rotation_std': np.std(rotation),
+        'points_average': np.linalg.norm(np.average(points, axis=0)),
+        'points_std': np.linalg.norm(np.std(points, axis=0)),
+        'ratio_cameras': completeness[0],
+        'ratio_points': completeness[1]
+    }

--- a/opensfm/test/conftest.py
+++ b/opensfm/test/conftest.py
@@ -17,6 +17,15 @@ def use_legacy_numpy_printoptions():
 
 
 @pytest.fixture(scope='module')
-def scene():
+def scene_synthetic():
     np.random.seed(42)
-    return synthetic_examples.synthetic_ellipse_scene()
+    data = synthetic_examples.synthetic_ellipse_scene()
+
+    maximum_depth = 40
+    projection_noise = 1.0
+    gps_noise = 5.0
+
+    exifs = data.get_scene_exifs(gps_noise)
+    features, desc, colors, graph = data.get_tracks_data(maximum_depth,
+                                                         projection_noise)
+    return data, exifs, features, desc, colors, graph

--- a/opensfm/test/test_bundle.py
+++ b/opensfm/test/test_bundle.py
@@ -59,14 +59,14 @@ def _projection_errors_std(points):
     return np.std(all_errors)
 
 
-def test_bundle_projection_fixed_internals(scene):
-    reference = scene.get_reconstruction(0.01, [1.0] * 3, 0.1)
+def test_bundle_projection_fixed_internals(scene_synthetic):
+    reference = scene_synthetic[0].get_reconstruction()
+    graph = scene_synthetic[5]
     adjusted = copy.deepcopy(reference)
 
     custom_config = config.default_config()
     custom_config['bundle_use_gps'] = False
     custom_config['optimize_camera_parameters'] = False
-    _, _, _, graph = scene.get_tracks_data(40, 1.0)
     reconstruction.bundle(graph, adjusted, {}, custom_config)
 
     assert _projection_errors_std(adjusted.points) < 5e-3

--- a/opensfm/test/test_matching.py
+++ b/opensfm/test/test_matching.py
@@ -1,9 +1,122 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import numpy as np
 from six import iteritems
 
 from opensfm import config
 from opensfm import matching
+from opensfm import pairs_selection
+from opensfm import bow
+from opensfm import csfm
+from opensfm.synthetic_data import synthetic_dataset
 from opensfm.test import data_generation
+
+
+def compute_words(features, bag_of_words, num_words, bow_matcher_type):
+    closest_words = bag_of_words.map_to_words(
+        features, num_words, bow_matcher_type)
+    if closest_words is None:
+        return np.array([], dtype=np.int32)
+    else:
+        return closest_words.astype(np.int32)
+
+
+def example_features(nfeatures, config):
+    words, frequencies = bow.load_bow_words_and_frequencies(config)
+    bag_of_words = bow.BagOfWords(words, frequencies)
+
+    # features 1
+    f1 = np.random.normal(size=(nfeatures, 128)).astype(np.float32)
+    f1 /= np.linalg.norm(f1)
+    w1 = compute_words(f1, bag_of_words, config['bow_words_to_match'],
+                       'FLANN')
+
+    # features 2
+    f2 = f1 + np.random.normal(size=f1.shape).astype(np.float32) / 500.0
+    f2 /= np.linalg.norm(f2)
+    w2 = compute_words(f2, bag_of_words, config['bow_words_to_match'],
+                       'FLANN')
+
+    return [f1, f2], [w1, w2]
+
+
+def test_example_features():
+    nfeatures = 1000
+
+    features, words = example_features(nfeatures, config.default_config())
+    assert len(features[0]) == nfeatures
+    assert len(words[0]) == nfeatures
+
+
+def test_match_using_words():
+    configuration = config.default_config()
+    nfeatures = 1000
+
+    features, words = example_features(nfeatures, configuration)
+    matches = csfm.match_using_words(features[0], words[0],
+                                     features[1], words[1][:, 0],
+                                     configuration['lowes_ratio'],
+                                     configuration['bow_num_checks'])
+    assert len(matches) == nfeatures
+    for i, j in matches:
+        assert i == j
+
+
+def test_unfilter_matches():
+    matches = np.array([])
+    m1 = np.array([], dtype=bool)
+    m2 = np.array([], dtype=bool)
+    res = matching.unfilter_matches(matches, m1, m2)
+    assert len(res) == 0
+
+    matches = np.array([[0, 2], [2, 1]])
+    i1 = np.array([False, False, False, True, False, True, False, True, False])
+    i2 = np.array([False, False, False, False, True, False, True, False, True])
+    res = matching.unfilter_matches(matches, i1, i2)
+    assert len(res) == 2
+    assert res[0][0] == 3
+    assert res[0][1] == 8
+    assert res[1][0] == 7
+    assert res[1][1] == 6
+
+
+def test_compute_bow_gps_pairs(scene_synthetic):
+    reference = scene_synthetic[0].get_reconstruction()
+    synthetic = synthetic_dataset.SyntheticDataSet(reference,
+                                                   scene_synthetic[1],
+                                                   scene_synthetic[2],
+                                                   scene_synthetic[3],
+                                                   scene_synthetic[4],
+                                                   scene_synthetic[5])
+    synthetic.matches_exists = lambda im: False
+    synthetic.save_matches = lambda im, m: False
+
+    num_neighbors = 5
+    synthetic.config['matching_gps_neighbors'] = num_neighbors
+    synthetic.config['bow_words_to_match'] = 8
+
+    images = synthetic.images()
+    exifs = {im: synthetic.load_exif(im) for im in images}
+    pairs = pairs_selection.match_candidates_from_metadata(images, images,
+                                                           exifs, synthetic)
+
+    assert len(pairs) <= num_neighbors * len(images)
+
+
+def test_ordered_pairs():
+    neighbors = [
+        [1, 3],
+        [1, 2],
+        [2, 5],
+        [3, 2],
+        [4, 5],
+        ]
+    images = [1, 2, 3]
+    pairs = pairs_selection.ordered_pairs(neighbors, images)
+    assert set(pairs) == {(1, 2), (1, 3), (2, 5), (3, 2)}
 
 
 def test_robust_match():
@@ -19,7 +132,3 @@ def test_robust_match():
     rmatches = matching.robust_match(p1, p2, camera1, camera2, matches,
                                      config.default_config())
     assert num_points <= len(rmatches) <= len(matches)
-
-
-if __name__ == "__main__":
-    test_robust_match()

--- a/opensfm/test/test_matching.py
+++ b/opensfm/test/test_matching.py
@@ -64,7 +64,7 @@ def test_match_using_words():
     for i, j in matches:
         assert i == j
 
-
+        
 def test_unfilter_matches():
     matches = np.array([])
     m1 = np.array([], dtype=bool)
@@ -83,7 +83,7 @@ def test_unfilter_matches():
     assert res[1][1] == 6
 
 
-def test_compute_bow_gps_pairs(scene_synthetic):
+def test_match_images(scene_synthetic):
     reference = scene_synthetic[0].get_reconstruction()
     synthetic = synthetic_dataset.SyntheticDataSet(reference,
                                                    scene_synthetic[1],
@@ -91,19 +91,21 @@ def test_compute_bow_gps_pairs(scene_synthetic):
                                                    scene_synthetic[3],
                                                    scene_synthetic[4],
                                                    scene_synthetic[5])
+
     synthetic.matches_exists = lambda im: False
     synthetic.save_matches = lambda im, m: False
 
     num_neighbors = 5
     synthetic.config['matching_gps_neighbors'] = num_neighbors
     synthetic.config['bow_words_to_match'] = 8
+    synthetic.config['matcher_type'] = 'FLANN'
 
     images = synthetic.images()
-    exifs = {im: synthetic.load_exif(im) for im in images}
-    pairs = pairs_selection.match_candidates_from_metadata(images, images,
-                                                           exifs, synthetic)
+    pairs, _ = matching.match_images(synthetic, images, images)
 
-    assert len(pairs) <= num_neighbors * len(images)
+    assert len(pairs) == 62
+    value, margin = 11842, 0.01
+    assert value*(1-margin) < sum([len(m) for m in pairs.values()]) < value*(1+margin)
 
 
 def test_ordered_pairs():

--- a/opensfm/test/test_reconstruction_incremental.py
+++ b/opensfm/test/test_reconstruction_incremental.py
@@ -3,23 +3,21 @@ import numpy as np
 
 from opensfm import reconstruction
 from opensfm.synthetic_data import synthetic_dataset
+from opensfm.synthetic_data import synthetic_scene
 
 
-def test_reconstruction_incremental(scene):
-    reference = scene.get_reconstruction()
-    maximum_depth = 40
-    projection_noise = 1.0
-    gps_noise = 5.0
-
-    exifs = scene.get_scene_exifs(gps_noise)
-    features, desc, colors, graph = scene.get_tracks_data(maximum_depth,
-                                                          projection_noise)
-    dataset = synthetic_dataset.SyntheticDataSet(reference, exifs, features,
-                                                 desc, colors, graph)
+def test_reconstruction_incremental(scene_synthetic):
+    reference = scene_synthetic[0].get_reconstruction()
+    dataset = synthetic_dataset.SyntheticDataSet(reference,
+                                                 scene_synthetic[1],
+                                                 scene_synthetic[2],
+                                                 scene_synthetic[3],
+                                                 scene_synthetic[4],
+                                                 scene_synthetic[5])
 
     _, reconstructed_scene = reconstruction.\
-        incremental_reconstruction(dataset, graph)
-    errors = scene.compare(reconstructed_scene[0])
+        incremental_reconstruction(dataset, scene_synthetic[5])
+    errors = synthetic_scene.compare(reference, reconstructed_scene[0])
 
     assert errors['ratio_cameras'] >= 0.95          # Keeps jumping last resection between 9 and 14 inliers with Python3
     assert 0.920 < errors['ratio_points'] < 0.950

--- a/opensfm/upright.py
+++ b/opensfm/upright.py
@@ -6,7 +6,8 @@ from __future__ import unicode_literals
 import numpy as np
 
 
-def opensfm_to_upright(coords, width, height, orientation):
+def opensfm_to_upright(coords, width, height, orientation,
+                       new_width=None, new_height=None):
     """
     Transform opensfm coordinates to upright coordinates, correcting for EXIF orientation.
 
@@ -49,6 +50,10 @@ def opensfm_to_upright(coords, width, height, orientation):
 
     upright_width = width if orientation < 6 else height
     upright_height = height if orientation < 6 else width
+    if new_width is not None:
+        upright_width = new_width
+    if new_height is not None:
+        upright_height = new_height
     p[:, 0] = upright_width * p[:, 0]
     p[:, 1] = upright_height * p[:, 1]
 

--- a/opensfm/upright.py
+++ b/opensfm/upright.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+
+def opensfm_to_upright(coords, width, height, orientation):
+    """
+    Transform opensfm coordinates to upright coordinates, correcting for EXIF orientation.
+
+    :param coords: Points in opensfm coordinate system.
+    :param width: Width of original image in pixels unadjusted for orientation.
+    :param height: Height of original image in pixels unadjusted for orientation.
+    :param orientation: Orientation of original image.
+
+    :return: Points in upright coordinate system.
+
+    >>> sfm = np.array([[-0.5, -0.375],
+    ...                 [-0.5,  0.375],
+    ...                 [ 0.5, -0.375],
+    ...                 [ 0.5,  0.375]])
+    >>> opensfm_to_upright(sfm, 320, 240, 1)
+    array([[ 0.,  0.],
+           [ 0.,  320.],
+           [ 240.,  0.],
+           [ 240.,  320.]])
+    """
+
+    R_T = {
+        1: np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        3: np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]]),
+        6: np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]),
+        8: np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]]),
+    }
+
+    w = float(width)
+    h = float(height)
+    s = max(w, h)
+
+    H_inv = np.array([[s / w,     0, 0.5],
+                      [    0, s / h, 0.5],
+                      [    0,     0,   1]])
+
+    T_inv = np.dot(R_T[orientation], H_inv)
+
+    p = np.dot(coords, T_inv[:2, :2].T) + T_inv[:2, 2].reshape(1, 2)
+
+    upright_width = width if orientation < 6 else height
+    upright_height = height if orientation < 6 else width
+    p[:, 0] = upright_width * p[:, 0]
+    p[:, 1] = upright_height * p[:, 1]
+
+    return p


### PR DESCRIPTION
This PR is the first in a series of 2, which aims at unifiying OpenSfM matching with Mapillary's production matching. This PR focuses on the pair matching part, and does the following :

 - Move images matching main entry point, from `command` to `matching`
 - Unify production and OpenSfM matching
 - Add optional production-specific filters
 - Add production feature cache