### PR TITLE
feat: better gps and gcp align

### DIFF
--- a/bin/plot_gcp.py
+++ b/bin/plot_gcp.py
@@ -107,8 +107,9 @@ def main():
             apixel = pix_coords(annotated, image)
 
             n = (len(gcp.observations) + 3) / 4
-            plt.subplot(n, min(len(gcp.observations), 4), i + 1)
+            ax = plt.subplot(n, min(len(gcp.observations), 4), i + 1)
             plt.imshow(image)
+            ax.title.set_text("{}".format(observation.shot_id))
             plt.scatter(rpixel[0], rpixel[1])
             plt.scatter(apixel[0], apixel[1])
         plt.show()

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -88,7 +88,7 @@ def detect_alignment_constraints(config, reconstruction, gcp):
 
     X, Xp = alignment_constraints(config, reconstruction, gcp)
     if len(X) < 3:
-        return 'naive'
+        return 'orientation_prior'
 
     X = np.array(X)
     X = X - np.average(X, axis=0)

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -84,7 +84,7 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
 
     # For now, translation only, need to decide on a prior rotation
     if len(X) == 2:
-        s = np.linalg.norm(Xp[0] - Xp[1])/np.linalg.norm(X[0] - X[1])
+        s = np.linalg.norm(Xp[0] - Xp[1])/np.linalg.norm(np.array(X[0]) - np.array(X[1]))
         t = np.average(Xp, axis=0)-s*np.average(X, axis=0)
         return s, np.identity(3), t
 

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -176,6 +176,9 @@ def align_reconstruction_orientation_prior_similarity(reconstruction, config, gc
     X = np.array(X)
     Xp = np.array(Xp)
 
+    if len(X) < 1:
+        return 1.0, np.identity(3), np.zeros((3))
+
     # Estimate ground plane.
     p = multiview.fit_plane(X - X.mean(axis=0), onplane, verticals)
     Rplane = multiview.plane_horizontalling_rotation(p)

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -1,6 +1,7 @@
 """Tools to align a reconstruction to GPS and GCP data."""
 
 import logging
+import math
 
 import numpy as np
 
@@ -51,14 +52,17 @@ def align_reconstruction_similarity(reconstruction, gcp, config):
      - orientation_prior: assumes a particular camera orientation
     """
     align_method = config['align_method']
+    if align_method == 'auto':
+        align_method = detect_alignment_constraints(config, reconstruction, gcp)
     if align_method == 'orientation_prior':
-        return align_reconstruction_orientation_prior_similarity(
-            reconstruction, config)
+        return align_reconstruction_orientation_prior_similarity(reconstruction, config, gcp)
     elif align_method == 'naive':
         return align_reconstruction_naive_similarity(config, reconstruction, gcp)
 
 
 def alignment_constraints(config, reconstruction, gcp):
+    """ Gather alignment constraints to be used by checking bundle_use_gcp and bundle_use_gps. """
+
     X, Xp = [], []
 
     # Get Ground Control Point correspondences
@@ -76,6 +80,35 @@ def alignment_constraints(config, reconstruction, gcp):
     return X, Xp
 
 
+def detect_alignment_constraints(config, reconstruction, gcp):
+    """ Automatically pick the best alignment method, depending
+    if alignment data such as GPS/GCP is aligned on a single-line or not.
+
+    """
+
+    X, Xp = alignment_constraints(config, reconstruction, gcp)
+    if len(X) < 3:
+        return 'naive'
+
+    X = np.array(X)
+    X = X - np.average(X, axis=0)
+    evalues, _ = np.linalg.eig(X.T.dot(X))
+
+    evalues = np.array(sorted(evalues))
+    ratio_1st_2nd = math.fabs(evalues[2]/evalues[1])
+
+    epsilon_abs = 1e-10
+    epsilon_ratio = 5e3
+    is_line = sum(evalues < epsilon_abs) > 1 or ratio_1st_2nd > epsilon_ratio
+    if is_line:
+        logger.warning('Shots and/or GCPs are aligned on a single-line. Using %s prior',
+                       config['align_orientation_prior'])
+        return 'orientation_prior'
+    else:
+        logger.info('Shots and/or GCPs are well-conditionned. Using naive 3D-3D alignment.')
+        return 'naive'
+
+
 def align_reconstruction_naive_similarity(config, reconstruction, gcp):
     """Align with GPS and GCP data using direct 3D-3D matches."""
     X, Xp = alignment_constraints(config, reconstruction, gcp)
@@ -85,14 +118,15 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
 
     # Translation-only case
     if len(X) == 1:
-        t = Xp[0] - X[0]
+        logger.warning('Only 1 constraints. Using translation-only alignment.')
+        t = np.array(Xp[0]) - np.array(X[0])
         return 1.0, np.identity(3), t
 
-    # For now, translation only, need to decide on a prior rotation
+    # Will be up to some unknown rotation
     if len(X) == 2:
-        s = np.linalg.norm(Xp[0] - Xp[1])/np.linalg.norm(np.array(X[0]) - np.array(X[1]))
-        t = np.average(Xp, axis=0)-s*np.average(X, axis=0)
-        return s, np.identity(3), t
+        logger.warning('Only 2 constraints. Will be up to some unknown rotation.')
+        X.append(X[1])
+        Xp.append(Xp[1])
 
     # Compute similarity Xp = s A X + b
     X = np.array(X)
@@ -105,7 +139,7 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
     return s, A, b
 
 
-def align_reconstruction_orientation_prior_similarity(reconstruction, config):
+def align_reconstruction_orientation_prior_similarity(reconstruction, config, gcp):
     """Align with GPS data assuming particular a camera orientation.
 
     In some cases, using 3D-3D matches directly fails to find proper

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -623,6 +623,16 @@ class DataSet(object):
                 if 'altitude' in d['gps']:
                     alt += w * d['gps']['altitude']
                     walt += w
+
+        if not wlat and not wlon:
+            for gcp in self._load_ground_control_points(None):
+                lat += gcp.lla[0]
+                lon += gcp.lla[1]
+                alt += gcp.lla[2]
+                wlat += 1
+                wlon += 1
+                walt += 1
+
         if wlat: lat /= wlat
         if wlon: lon /= wlon
         if walt: alt /= walt

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -745,8 +745,19 @@ class DataSet(object):
         It uses reference_lla to convert the coordinates
         to topocentric reference frame.
         """
-        exif = {image: self.load_exif(image) for image in self.images()}
+
         reference = self.load_reference()
+        return self._load_ground_control_points(reference)
+
+    def _load_ground_control_points(self, reference):
+        """Load ground control points.
+
+        It might use reference to convert the coordinates
+        to topocentric reference frame.
+        If reference is None, it won't initialize topocentric data,
+        thus allowing loading raw data only.
+        """
+        exif = {image: self.load_exif(image) for image in self.images()}
 
         gcp = []
         if os.path.isfile(self._gcp_list_file()):

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -1216,9 +1216,9 @@ def grow_reconstruction(data, graph, graph_inliers, reconstruction, images, gcp)
     config = data.config
     report = {'steps': []}
 
+    align_reconstruction(reconstruction, gcp, config)
     bundle(graph, reconstruction, None, config)
     remove_outliers(graph_inliers, reconstruction, config)
-    align_reconstruction(reconstruction, gcp, config)
 
     should_bundle = ShouldBundle(data, reconstruction)
     should_retriangulate = ShouldRetriangulate(data, reconstruction)
@@ -1264,20 +1264,20 @@ def grow_reconstruction(data, graph, graph_inliers, reconstruction, images, gcp)
 
             if should_retriangulate.should():
                 logger.info("Re-triangulating")
+                align_reconstruction(reconstruction, gcp, config)
                 b1rep = bundle(graph_inliers, reconstruction, None, config)
                 rrep = retriangulate(graph, graph_inliers, reconstruction, config)
                 b2rep = bundle(graph_inliers, reconstruction, None, config)
                 remove_outliers(graph_inliers, reconstruction, config)
-                align_reconstruction(reconstruction, gcp, config)
                 step['bundle'] = b1rep
                 step['retriangulation'] = rrep
                 step['bundle_after_retriangulation'] = b2rep
                 should_retriangulate.done()
                 should_bundle.done()
             elif should_bundle.should():
+                align_reconstruction(reconstruction, gcp, config)
                 brep = bundle(graph_inliers, reconstruction, None, config)
                 remove_outliers(graph_inliers, reconstruction, config)
-                align_reconstruction(reconstruction, gcp, config)
                 step['bundle'] = brep
                 should_bundle.done()
             elif config['local_bundle_radius'] > 0:
@@ -1292,9 +1292,10 @@ def grow_reconstruction(data, graph, graph_inliers, reconstruction, images, gcp)
 
     logger.info("-------------------------------------------------------")
 
+    align_reconstruction(reconstruction, gcp, config)
     bundle(graph_inliers, reconstruction, gcp, config)
     remove_outliers(graph_inliers, reconstruction, config)
-    align_reconstruction(reconstruction, gcp, config)
+
     paint_reconstruction(data, graph, reconstruction)
     return reconstruction, report
 

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -1293,7 +1293,6 @@ def grow_reconstruction(data, graph, graph_inliers, reconstruction, images, gcp)
                 step['bundle'] = brep
                 should_bundle.done()
             elif config['local_bundle_radius'] > 0:
-                align_reconstruction(reconstruction, gcp, config)
                 brep = bundle_local(graph_inliers, reconstruction, None, image, config)
                 remove_outliers(graph_inliers, reconstruction, config)
                 step['local_bundle'] = brep

--- a/opensfm/synthetic_data/synthetic_dataset.py
+++ b/opensfm/synthetic_data/synthetic_dataset.py
@@ -28,6 +28,7 @@ class SyntheticDataSet(DataSet):
         self.reference_lla = {'latitude': 0, 'longitude': 0, 'altitude': 0}
         self.matches = None
         self.config['use_altitude_tag'] = True
+        self.config['align_method'] = 'naive'
 
     def images(self):
         return self.image_list

--- a/opensfm/test/test_reconstruction_incremental.py
+++ b/opensfm/test/test_reconstruction_incremental.py
@@ -29,4 +29,4 @@ def test_reconstruction_incremental(scene_synthetic):
     assert 1.5 < errors['position_average'] < 3
     assert 1.1 < errors['position_std'] < 4
     assert 8.0 < errors['gps_std'] < 10.0
-    assert np.allclose(errors['gps_average'], 0.0)
+    assert errors['gps_average'] < 3e-3


### PR DESCRIPTION
This PR aims at improving the alignment behaviour when using GPS and GCP.

More specifically, we propagate the use of `bundle_use_gps` and `bundle_use_gcp` in the alignment. Discussion is welcome whether we should have a distinct option or not.

The global behaviour is also changed as it is done before any bundle, hoping GPS/GCP error will be closer to optimum when starting the bundle. Additionally, we also support edge cases when we have only one or two GCP/GPS (scale/orientation ambiguity will remain though, no a-priori is being made).

Finally, we refactored code a bit so we can support correct topocentric frame when there is no GPS.

Yann