### PR TITLE
Added camera_projection_type config

### DIFF
--- a/opensfm/commands/extract_metadata.py
+++ b/opensfm/commands/extract_metadata.py
@@ -63,6 +63,10 @@ class Command:
          # EXIF data in Image
         d = exif.extract_exif_from_file(data.open_image_file(image))
 
+        # Override projection type if needed
+        if data.config['camera_projection_type'] != 'AUTO':
+            d['projection_type'] = data.config['camera_projection_type'].lower()
+
         # Image Height and Image Width
         if d['width'] <= 0 or not data.config['use_exif_size']:
             d['height'], d['width'] = data.image_size(image)

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -93,6 +93,7 @@ bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlie
 bundle_outlier_auto_ratio: 3.0          # For AUTO filtering type, projections with larger reprojection than ratio-times-mean, are removed
 bundle_outlier_fixed_threshold: 0.006   # For FIXED filtering type, projections with larger reprojection error after bundle adjustment are removed
 optimize_camera_parameters: yes         # Optimize internal camera parameters during bundle
+camera_projection_type: AUTO        # The projection type of the camera : attempt to detect it from metadata (AUTO), or set it manually (PERSPECTIVE, BROWN, FISHEYE) 
 
 retriangulation: yes                # Retriangulate all points from time to time
 retriangulation_ratio: 1.2          # Retriangulate when the number of points grows by this ratio

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -5,6 +5,7 @@ default_config_yaml = '''
 # Metadata
 use_exif_size: yes
 default_focal_prior: 0.85
+camera_projection_type: AUTO        # The projection type of the camera : attempt to detect it from metadata (AUTO), or set it manually (PERSPECTIVE, BROWN, FISHEYE) 
 
 # Params for features
 feature_type: HAHOG           # Feature type (AKAZE, SURF, SIFT, HAHOG, ORB)
@@ -93,7 +94,6 @@ bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlie
 bundle_outlier_auto_ratio: 3.0          # For AUTO filtering type, projections with larger reprojection than ratio-times-mean, are removed
 bundle_outlier_fixed_threshold: 0.006   # For FIXED filtering type, projections with larger reprojection error after bundle adjustment are removed
 optimize_camera_parameters: yes         # Optimize internal camera parameters during bundle
-camera_projection_type: AUTO        # The projection type of the camera : attempt to detect it from metadata (AUTO), or set it manually (PERSPECTIVE, BROWN, FISHEYE) 
 
 retriangulation: yes                # Retriangulate all points from time to time
 retriangulation_ratio: 1.2          # Retriangulate when the number of points grows by this ratio

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -5,7 +5,7 @@ default_config_yaml = '''
 # Metadata
 use_exif_size: yes
 default_focal_prior: 0.85
-camera_projection_type: AUTO        # The projection type of the camera : attempt to detect it from metadata (AUTO), or set it manually (PERSPECTIVE, BROWN, FISHEYE) 
+camera_projection_type: AUTO        # The projection type of the camera : attempt to detect it from metadata (AUTO), or set it manually (PERSPECTIVE, BROWN, FISHEYE, SPHERICAL) 
 
 # Params for features
 feature_type: HAHOG           # Feature type (AKAZE, SURF, SIFT, HAHOG, ORB)

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -363,7 +363,7 @@ def hard_coded_calibration(exif):
 
 
 def focal_ratio_calibration(exif):
-    if exif['focal_ratio']:
+    if exif.get('focal_ratio'):
         return {
             'focal': exif['focal_ratio'],
             'k1': 0.0,
@@ -375,12 +375,13 @@ def focal_ratio_calibration(exif):
 
 
 def focal_xy_calibration(exif):
-    if exif['focal_x']:
+    focal = exif.get('focal_x', exif.get('focal_ratio'))
+    if focal:
         return {
-            'focal_x': exif['focal_x'],
-            'focal_y': exif['focal_y'],
-            'c_x': exif['c_x'],
-            'c_y': exif['c_y'],
+            'focal_x': focal,
+            'focal_y': focal,
+            'c_x': exif.get('c_x', 0.0),
+            'c_y': exif.get('c_y', 0.0),
             'k1': 0.0,
             'k2': 0.0,
             'p1': 0.0,

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -450,6 +450,22 @@ def camera_from_exif_metadata(metadata, data):
         camera.p2_prior = calib['p2']
         camera.k3_prior = calib['k3']
         return camera
+    elif pt == 'fisheye':
+        calib = (hard_coded_calibration(metadata)
+                 or focal_ratio_calibration(metadata)
+                 or default_calibration(data))
+        camera = types.FisheyeCamera()
+        camera.id = metadata['camera']
+        camera.width = metadata['width']
+        camera.height = metadata['height']
+        camera.projection_type = pt
+        camera.focal = calib['focal']
+        camera.k1 = calib['k1']
+        camera.k2 = calib['k2']
+        camera.focal_prior = calib['focal']
+        camera.k1_prior = calib['k1']
+        camera.k2_prior = calib['k2']
+        return camera
     elif pt in ['equirectangular', 'spherical']:
         camera = types.SphericalCamera()
         camera.id = metadata['camera']


### PR DESCRIPTION
Hello :hand:

This PR proposes the addition of a new `camera_projection_type` config to forcibly set the camera model, ignoring the information from EXIFs. This only works for sets of images that all share the same camera model, but existing behavior remains unchanged by leaving the default set to `AUTO`.

We've found that many cameras lack the metadata necessary to be detected as fisheye (the XMP tag `GPano:ProjectionType` is lacking in many cameras) and it seems that `perspective` is (always?) favored over `brown`.

I think I've interpreted the default values for `c_x` and `c_y` correctly (0,0 represents the center?) and I've added a fallback while retrieving the `focal_x`/`focal_y` keys to use `focal_ratio`.

I might have missed something while implementing this, in which case please let me know and I'll make adjustments. :+1:

If this seems like a terrible idea, also let me know. xD