### PR TITLE
BROKEN  fix: get the number of features right

### DIFF
--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -49,7 +49,7 @@ class FeatureLoader(object):
 
     def load_features_index(self, data, image, features):
         index = self.index_cache.get(image)
-        current_features = self.load_points_features_colors(data, image)
+        _, current_features, _ = self.load_points_features_colors(data, image)
         use_load = len(current_features) == len(features) and index is None
         use_rebuild = len(current_features) != len(features)
         if use_load:

--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -48,7 +48,9 @@ class FeatureLoader(object):
         return masks
 
     def load_features_index(self, data, image, features):
-        index = self.index_cache.get(image)
+        cached = self.index_cache.get(image)
+        index = cached[1] if cached else None
+
         _, current_features, _ = self.load_points_features_colors(data, image)
         use_load = len(current_features) == len(features) and index is None
         use_rebuild = len(current_features) != len(features)
@@ -57,7 +59,7 @@ class FeatureLoader(object):
         if use_rebuild:
             index = ft.build_flann_index(features, data.config)
         if use_load or use_rebuild:
-            self.index_cache.put(image, index)
+            self.index_cache.put(image, (features, index))
         return index
 
     def load_points_features_colors(self, data, image):

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -270,8 +270,8 @@ def load_histograms(data, images):
             logger.error("Could not load words for image {}".format(im))
             continue
 
-        mask = data.load_masks(data, im) if hasattr(data, 'load_masks') else None
-        filtered_words = words[mask] if mask else words
+        mask = data.load_mask(data, im) if hasattr(data, 'load_mask') else None
+        filtered_words = words[mask] if mask is not None else words
         if len(filtered_words) <= min_num_feature:
             logger.warning("Too few filtered features in image {}: {}".format(
                 im, len(filtered_words)))


### PR DESCRIPTION
There is something funky going on here, @YanNoun.

Before this fix, we are always rebuilding the index because we get `len(current_features)==3`

After the fix, running on lund we get a segmentation fault. The problem is that the flann index is created with a filtered array here
https://github.com/mapillary/OpenSfM/blob/master/opensfm/matching.py#L107-L108
This array is not cached and gets garbage collected. So the second time that we try to use the same index, it points to that array that no longer exists.

One way to solve that would be to filter the feature arrays before caching them.  It could be done in the feature loader itself.