### PR TITLE
Fix mask for rotated images

### DIFF
--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -71,12 +71,15 @@ def detect(args):
         data.feature_type().upper(), image))
 
     start = timer()
-    mask = data.load_combined_mask(image)
-    if mask is not None:
-        logger.info('Found mask to apply for image {}'.format(image))
 
-    p_unsorted, f_unsorted, c_unsorted = features.extract_features(
-        data.load_image(image), data.config, mask)
+    p_unmasked, f_unmasked, c_unmasked = features.extract_features(
+        data.load_image(image), data.config, mask=None)
+
+    fmask = data.load_features_mask(image, p_unmasked)
+
+    p_unsorted = p_unmasked[fmask]
+    f_unsorted = f_unmasked[fmask]
+    c_unsorted = c_unmasked[fmask]
 
     if len(p_unsorted) == 0:
         logger.warning('No features found in image {}'.format(image))

--- a/opensfm/commands/detect_features.py
+++ b/opensfm/commands/detect_features.py
@@ -73,7 +73,7 @@ def detect(args):
     start = timer()
 
     p_unmasked, f_unmasked, c_unmasked = features.extract_features(
-        data.load_image(image), data.config, mask=None)
+        data.load_image(image), data.config)
 
     fmask = data.load_features_mask(image, p_unmasked)
 

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -70,15 +70,8 @@ def denormalized_image_coordinates(norm_coords, width, height):
     return p
 
 
-def mask_and_normalize_features(points, desc, colors, width, height, mask=None):
-    """Remove features outside the mask and normalize image coordinates."""
-
-    if mask is not None:
-        ids = np.array([_in_mask(point, width, height, mask) for point in points])
-        points = points[ids]
-        desc = desc[ids]
-        colors = colors[ids]
-
+def normalize_features(points, desc, colors, width, height):
+    """Normalize feature coordinates and size."""
     points[:, :2] = normalized_image_coordinates(points[:, :2], width, height)
     points[:, 2:3] /= max(width, height)
     return points, desc, colors
@@ -254,7 +247,7 @@ def extract_features_orb(image, config):
     return points, desc
 
 
-def extract_features(color_image, config, mask=None):
+def extract_features(color_image, config):
     """Detect features in an image.
 
     The type of feature detected is determined by the ``feature_type``
@@ -292,8 +285,8 @@ def extract_features(color_image, config, mask=None):
     ys = points[:, 1].round().astype(int)
     colors = color_image[ys, xs]
 
-    return mask_and_normalize_features(points, desc, colors,
-                                       image.shape[1], image.shape[0], mask)
+    return normalize_features(points, desc, colors,
+                              image.shape[1], image.shape[0])
 
 
 def build_flann_index(features, config):

--- a/opensfm/upright.py
+++ b/opensfm/upright.py
@@ -29,24 +29,24 @@ def opensfm_to_upright(coords, width, height, orientation,
            [ 320.,  240.]])
     """
 
-    R_T = {
+    R = {
         1: np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-        3: np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]]),
-        6: np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]),
-        8: np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]]),
+        3: np.array([[-1, 0, 1], [0, -1, 1], [0, 0, 1]]),
+        6: np.array([[0, -1, 1], [1, 0, 0], [0, 0, 1]]),
+        8: np.array([[0, 1, 0], [-1, 0, 1], [0, 0, 1]]),
     }
 
     w = float(width)
     h = float(height)
     s = max(w, h)
 
-    H_inv = np.array([[s / w,     0, 0.5],
-                      [    0, s / h, 0.5],
-                      [    0,     0,   1]])
+    H = np.array([[s / w,     0, 0.5],
+                  [    0, s / h, 0.5],
+                  [    0,     0,   1]])
 
-    T_inv = np.dot(R_T[orientation], H_inv)
+    T = np.dot(R[orientation], H)
 
-    p = np.dot(coords, T_inv[:2, :2].T) + T_inv[:2, 2].reshape(1, 2)
+    p = np.dot(coords, T[:2, :2].T) + T[:2, 2].reshape(1, 2)
 
     upright_width = width if orientation < 6 else height
     upright_height = height if orientation < 6 else width


### PR DESCRIPTION
We had a bug on the rotation matrix that rotates features according to the exif tag.
This PR fixes the bug and refactors the feature extraction code to always use the same mask.