### PR TITLE
fix: use DJI XMP EXIF and handle same-GPS case

### DIFF
--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -116,9 +116,16 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
     if len(X) == 0:
         return 1.0, np.identity(3), np.zeros((3))
 
-    # Translation-only case
-    if len(X) == 1:
+    # Translation-only case, either : 
+    #  - a single value
+    #  - identical values
+    same_values = (np.linalg.norm(np.std(Xp, axis=0)) < 1e-10)
+    single_value = (len(X) == 1)
+    if single_value:
         logger.warning('Only 1 constraints. Using translation-only alignment.')
+    if same_values:
+        logger.warning('GPS/GCP data seems to have identical values. Using translation-only alignment.')
+    if same_values or single_value:
         t = np.array(Xp[0]) - np.array(X[0])
         return 1.0, np.identity(3), t
 
@@ -127,13 +134,6 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
         logger.warning('Only 2 constraints. Will be up to some unknown rotation.')
         X.append(X[1])
         Xp.append(Xp[1])
-
-    # Sometimes, consraint data such as GPS EXIFs can
-    # be corrupted, all values being the same
-    std = np.std(Xp, axis=0)
-    if np.linalg.norm(std < 1e-10):
-        logger.warning('GPS/GCP data seems to have identical values : unable to align.')
-        return 1.0, np.identity(3), np.zeros((3))
 
     # Compute similarity Xp = s A X + b
     X = np.array(X)

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -128,6 +128,13 @@ def align_reconstruction_naive_similarity(config, reconstruction, gcp):
         X.append(X[1])
         Xp.append(Xp[1])
 
+    # Sometimes, consraint data such as GPS EXIFs can
+    # be corrupted, all values being the same
+    std = np.std(Xp, axis=0)
+    if np.linalg.norm(std < 1e-10):
+        logger.warning('GPS/GCP data seems to have identical values : unable to align.')
+        return 1.0, np.identity(3), np.zeros((3))
+
     # Compute similarity Xp = s A X + b
     X = np.array(X)
     Xp = np.array(Xp)

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -238,8 +238,22 @@ class EXIF:
             reflon = 'E'
         return reflon, reflat
 
+    def extract_dji_lon_lat(self):
+        lon = self.xmp[0]['@drone-dji:Longitude']
+        lat = self.xmp[0]['@drone-dji:Latitude']
+        lon_number = float(lon[1:])
+        lat_number = float(lat[1:])
+        lon_number = lon_number if lon[0] == '+' else -lon_number
+        lat_number = lat_number if lat[0] == '+' else -lat_number
+        return lon_number, lat_number
+
+    def has_dji_xmp(self):
+        return (len(self.xmp) > 0) and ('@drone-dji:Latitude' in self.xmp[0])
+
     def extract_lon_lat(self):
-        if 'GPS GPSLatitude' in self.tags:
+        if self.has_dji_xmp():
+            lon, lat = self.extract_dji_lon_lat()
+        elif 'GPS GPSLatitude' in self.tags:
             reflon, reflat = self.extract_ref_lon_lat()
             lat = gps_to_decimal(self.tags['GPS GPSLatitude'].values, reflat)
             lon = gps_to_decimal(self.tags['GPS GPSLongitude'].values, reflon)

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -247,6 +247,9 @@ class EXIF:
         lat_number = lat_number if lat[0] == '+' else -lat_number
         return lon_number, lat_number
 
+    def extract_dji_altitude(self):
+        return float(self.xmp[0]['@drone-dji:AbsoluteAltitude'])
+
     def has_dji_xmp(self):
         return (len(self.xmp) > 0) and ('@drone-dji:Latitude' in self.xmp[0])
 
@@ -262,7 +265,9 @@ class EXIF:
         return lon, lat
 
     def extract_altitude(self):
-        if 'GPS GPSAltitude' in self.tags:
+        if self.has_dji_xmp():
+            altitude = self.extract_dji_altitude()
+        elif 'GPS GPSAltitude' in self.tags:
             altitude = eval_frac(self.tags['GPS GPSAltitude'].values[0])
         else:
             altitude = None


### PR DESCRIPTION
This PR aims at fixing two GPS issues :
 - Defective GPS values, all values being the same. Which lead to further issue in computing alignment.
 - DJI drones have buggy firmware versions (Mavic), where classic `GPSLatitude` tags had truncated values (leading to same-values issue, see above). Using DJI-specific XMP tags when available mitigates the issue.

Ping @pierotofy if you can test on more datasets. I got the issue on `hellasgarden' dataset taken with a Mavic Air (?), but can't remember where I got it from, thought it was from OpenSfM GH issues.