### PR TITLE
Decrease unit test time

### DIFF
--- a/opensfm/test/data_generation.py
+++ b/opensfm/test/data_generation.py
@@ -102,15 +102,6 @@ def create_berlin_test_folder(tmpdir):
     return opensfm.dataset.DataSet(path)
 
 
-def create_lund_test_folder(tmpdir, config=None):
-    path = str(tmpdir.mkdir('lund'))
-    os.symlink(os.path.abspath('data/lund/images'),
-               os.path.join(path, 'images'))
-    if config:
-        save_config(config, path)
-    return opensfm.dataset.DataSet(path)
-
-
 def save_config(config, path):
     with io.open_wt(os.path.join(path, 'config.yaml')) as fout:
         yaml.safe_dump(config, fout, default_flow_style=False)


### PR DESCRIPTION
This PR decreases the time it takes to run the unit test stage in CI by ~120 seconds. The unit test run time is still ~50 seconds longer than before the merge of https://github.com/mapillary/OpenSfM/pull/466 because of the feature extraction of the lund dataset which is required for the `match_candidates_from_metadata` tests.

 With this PR the features are extracted once in a module fixture instead of once for each of the four tests.