### PR TITLE
Fix add_absolute_position_constraint call

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -120,7 +120,7 @@ def add_camera_constraints_soft(ra, reconstruction_shots, reconstruction_name):
                 gps_sd = shot.metadata.gps_dop
 
                 ra.add_absolute_position_constraint(
-                        shot_name, gps[0], gps[1], gps[2], gps_sd, key)
+                        shot_name, gps[0], gps[1], gps[2], gps_sd)
 
                 added_shots.add(shot_id)
 


### PR DESCRIPTION
It seems that a regression was introduced in https://github.com/mapillary/OpenSfM/commit/4460775c5f371da107d452d9dffb9205bab1f6d2 as `add_absolute_position_constraint`'s signature does not allow a 6th parameter?

During testing the `add_camera_constraints_soft` seemed to work OK (results looked correct) by simply removing the key parameter. Not sure if `add_absolute_position_constraint` should be modified instead.