### PR TITLE
Add support for more FocalPlaneResolutionUnit values

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -14,7 +14,8 @@ from opensfm import types
 logger = logging.getLogger(__name__)
 
 inch_in_mm = 25.4
-
+cm_in_mm = 10
+um_in_mm = 0.001
 
 def eval_frac(value):
     try:
@@ -214,7 +215,11 @@ class EXIF:
         if resolution_unit == 2:    # inch
             return inch_in_mm
         elif resolution_unit == 3:  # cm
-            return 10
+            return cm_in_mm
+        elif resolution_unit == 4:  # mm
+            return 1
+        elif resolution_unit == 5:  # um
+            return um_in_mm
         else:
             logger.warning('Unknown EXIF resolution unit value: {}'.format(resolution_unit))
             return None


### PR DESCRIPTION
Hello! :hand:

It looks like `get_mm_per_unit` was missing a few enum values for units. This causes errors with certain camera vendors (found this from a Parrot Sequoia dataset). The enum values are taken (per  comment indications) directly from https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/EXIF.html (`FocalPlaneResolutionUnit`).

I've introduced the `cm_in_mm` and `um_in_mm` variables to be consistent with the `inch_in_mm` conversion. 

:clinking_glasses: 