### PR TITLE
feat: added dual camera model

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -482,9 +482,6 @@ def camera_from_exif_metadata(metadata, data):
         camera.focal = calib['focal']
         camera.k1 = calib['k1']
         camera.k2 = calib['k2']
-        camera.focal_prior = calib['focal']
-        camera.k1_prior = calib['k1']
-        camera.k2_prior = calib['k2']
         camera.transition = calib['transition']
         return camera
     elif pt in ['equirectangular', 'spherical']:

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -470,6 +470,23 @@ def camera_from_exif_metadata(metadata, data):
         camera.k1 = calib['k1']
         camera.k2 = calib['k2']
         return camera
+    elif pt == 'dual':
+        calib = (hard_coded_calibration(metadata)
+                 or focal_ratio_calibration(metadata)
+                 or default_calibration(data))
+        camera = types.DualCamera()
+        camera.id = metadata['camera']
+        camera.width = metadata['width']
+        camera.height = metadata['height']
+        camera.projection_type = pt
+        camera.focal = calib['focal']
+        camera.k1 = calib['k1']
+        camera.k2 = calib['k2']
+        camera.focal_prior = calib['focal']
+        camera.k1_prior = calib['k1']
+        camera.k2_prior = calib['k2']
+        camera.transition = calib['transition']
+        return camera
     elif pt in ['equirectangular', 'spherical']:
         camera = types.SphericalCamera()
         camera.id = metadata['camera']

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -63,6 +63,19 @@ def camera_from_json(key, obj):
         camera.k1 = obj.get('k1', 0.0)
         camera.k2 = obj.get('k2', 0.0)
         return camera
+    elif pt == 'dual':
+        camera = types.DualCamera()
+        camera.id = key
+        camera.width = obj.get('width', 0)
+        camera.height = obj.get('height', 0)
+        camera.focal = obj['focal']
+        camera.k1 = obj.get('k1', 0.0)
+        camera.k2 = obj.get('k2', 0.0)
+        camera.focal_prior = obj.get('focal_prior', camera.focal)
+        camera.k1_prior = obj.get('k1_prior', camera.k1)
+        camera.k2_prior = obj.get('k2_prior', camera.k2)
+        camera.transition = obj.get('transition', 1.0)
+        return camera
     elif pt in ['equirectangular', 'spherical']:
         camera = types.SphericalCamera()
         camera.id = key
@@ -217,6 +230,19 @@ def camera_to_json(camera):
             'focal': camera.focal,
             'k1': camera.k1,
             'k2': camera.k2,
+        }
+    elif camera.projection_type == 'dual':
+        return {
+            'projection_type': camera.projection_type,
+            'width': camera.width,
+            'height': camera.height,
+            'focal': camera.focal,
+            'k1': camera.k1,
+            'k2': camera.k2,
+            'focal_prior': camera.focal_prior,
+            'k1_prior': camera.k1_prior,
+            'k2_prior': camera.k2_prior,
+            'transition': camera.transition
         }
     elif camera.projection_type in ['equirectangular', 'spherical']:
         return {

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -71,9 +71,6 @@ def camera_from_json(key, obj):
         camera.focal = obj['focal']
         camera.k1 = obj.get('k1', 0.0)
         camera.k2 = obj.get('k2', 0.0)
-        camera.focal_prior = obj.get('focal_prior', camera.focal)
-        camera.k1_prior = obj.get('k1_prior', camera.k1)
-        camera.k2_prior = obj.get('k2_prior', camera.k2)
         camera.transition = obj.get('transition', 0.5)
         return camera
     elif pt in ['equirectangular', 'spherical']:
@@ -239,9 +236,6 @@ def camera_to_json(camera):
             'focal': camera.focal,
             'k1': camera.k1,
             'k2': camera.k2,
-            'focal_prior': camera.focal_prior,
-            'k1_prior': camera.k1_prior,
-            'k2_prior': camera.k2_prior,
             'transition': camera.transition
         }
     elif camera.projection_type in ['equirectangular', 'spherical']:

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -74,7 +74,7 @@ def camera_from_json(key, obj):
         camera.focal_prior = obj.get('focal_prior', camera.focal)
         camera.k1_prior = obj.get('k1_prior', camera.k1)
         camera.k2_prior = obj.get('k2_prior', camera.k2)
-        camera.transition = obj.get('transition', 1.0)
+        camera.transition = obj.get('transition', 0.5)
         return camera
     elif pt in ['equirectangular', 'spherical']:
         camera = types.SphericalCamera()

--- a/opensfm/mesh.py
+++ b/opensfm/mesh.py
@@ -20,10 +20,21 @@ def triangle_mesh(shot_id, r, graph, data):
         return triangle_mesh_perspective(shot_id, r, graph)
     elif shot.camera.projection_type == 'fisheye':
         return triangle_mesh_fisheye(shot_id, r, graph)
+    elif shot.camera.projection_type == 'dual':
+        return triangle_mesh_dual(shot_id, r, graph)
     elif shot.camera.projection_type in ['equirectangular', 'spherical']:
         return triangle_mesh_equirectangular(shot_id, r, graph)
     else:
         raise NotImplementedError
+
+
+def triangle_mesh_dual(shot_id, r, graph):
+    shot = r.shots[shot_id]
+    cam = shot.camera
+    if cam.transition < 0.5:
+        return triangle_mesh_fisheye(shot_id, r, graph)
+    else:
+        return triangle_mesh_perspective(shot_id, r, graph)
 
 
 def triangle_mesh_perspective(shot_id, r, graph):

--- a/opensfm/mesh.py
+++ b/opensfm/mesh.py
@@ -21,17 +21,11 @@ def triangle_mesh(shot_id, r, graph, data):
     elif shot.camera.projection_type == 'fisheye':
         return triangle_mesh_fisheye(shot_id, r, graph)
     elif shot.camera.projection_type == 'dual':
-        return triangle_mesh_dual(shot_id, r, graph)
+        return triangle_mesh_fisheye(shot_id, r, graph)
     elif shot.camera.projection_type in ['equirectangular', 'spherical']:
         return triangle_mesh_equirectangular(shot_id, r, graph)
     else:
         raise NotImplementedError
-
-
-def triangle_mesh_dual(shot_id, r, graph):
-    shot = r.shots[shot_id]
-    cam = shot.camera
-    return triangle_mesh_fisheye(shot_id, r, graph)
 
 
 def triangle_mesh_perspective(shot_id, r, graph):

--- a/opensfm/mesh.py
+++ b/opensfm/mesh.py
@@ -31,10 +31,7 @@ def triangle_mesh(shot_id, r, graph, data):
 def triangle_mesh_dual(shot_id, r, graph):
     shot = r.shots[shot_id]
     cam = shot.camera
-    if cam.transition < 0.5:
-        return triangle_mesh_fisheye(shot_id, r, graph)
-    else:
-        return triangle_mesh_perspective(shot_id, r, graph)
+    return triangle_mesh_fisheye(shot_id, r, graph)
 
 
 def triangle_mesh_perspective(shot_id, r, graph):

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -67,7 +67,7 @@ def _add_camera_to_bundle(ba, camera, camera_prior, constant):
     elif camera.projection_type == 'dual':
         ba.add_dual_camera(
             camera.id, camera.focal, camera.k1, camera.k2,
-            camera.focal_prior, camera.k1_prior, camera.k2_prior,
+            camera_prior.focal_prior, camera_prior.k1_prior, camera_prior.k2_prior,
             camera.transition, constant)        
     elif camera.projection_type in ['equirectangular', 'spherical']:
         ba.add_equirectangular_camera(camera.id)

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -64,6 +64,11 @@ def _add_camera_to_bundle(ba, camera, camera_prior, constant):
             camera.id, camera.focal, camera.k1, camera.k2,
             camera_prior.focal, camera_prior.k1, camera_prior.k2,
             constant)
+    elif camera.projection_type == 'dual':
+        ba.add_dual_camera(
+            camera.id, camera.focal, camera.k1, camera.k2,
+            camera.focal_prior, camera.k1_prior, camera.k2_prior,
+            camera.transition, constant)        
     elif camera.projection_type in ['equirectangular', 'spherical']:
         ba.add_equirectangular_camera(camera.id)
 
@@ -91,6 +96,12 @@ def _get_camera_from_bundle(ba, camera):
         camera.focal = c.focal
         camera.k1 = c.k1
         camera.k2 = c.k2
+    elif camera.projection_type == 'dual':
+        c = ba.get_dual_camera(camera.id)
+        camera.focal = c.focal
+        camera.k1 = c.k1
+        camera.k2 = c.k2
+        camera.transition = c.transition
 
 
 def triangulate_gcp(point, shots):

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -67,8 +67,8 @@ def _add_camera_to_bundle(ba, camera, camera_prior, constant):
     elif camera.projection_type == 'dual':
         ba.add_dual_camera(
             camera.id, camera.focal, camera.k1, camera.k2,
-            camera_prior.focal_prior, camera_prior.k1_prior, camera_prior.k2_prior,
-            camera.transition, constant)        
+            camera_prior.focal, camera_prior.k1, camera_prior.k2,
+            camera.transition, constant)     
     elif camera.projection_type in ['equirectangular', 'spherical']:
         ba.add_equirectangular_camera(camera.id)
 

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -34,6 +34,7 @@ enum BACameraType {
   BA_PERSPECTIVE_CAMERA,
   BA_BROWN_PERSPECTIVE_CAMERA,
   BA_FISHEYE_CAMERA,
+  BA_DUAL_CAMERA,
   BA_EQUIRECTANGULAR_CAMERA
 };
 
@@ -49,6 +50,7 @@ enum {
   BA_CAMERA_FOCAL,
   BA_CAMERA_K1,
   BA_CAMERA_K2,
+  BA_CAMERA_TRANSITION,
   BA_CAMERA_NUM_PARAMS
 };
 
@@ -126,6 +128,23 @@ struct BAFisheyeCamera : public BACamera{
   void SetFocal(double v) { parameters[BA_CAMERA_FOCAL] = v; }
   void SetK1(double v) { parameters[BA_CAMERA_K1] = v; }
   void SetK2(double v) { parameters[BA_CAMERA_K2] = v; }
+};
+
+struct BADualCamera : public BACamera{
+  double parameters[BA_CAMERA_NUM_PARAMS];
+  double focal_prior;
+  double k1_prior;
+  double k2_prior;
+
+  BACameraType type() { return BA_DUAL_CAMERA; }
+  double GetFocal() { return parameters[BA_CAMERA_FOCAL]; }
+  double GetK1() { return parameters[BA_CAMERA_K1]; }
+  double GetK2() { return parameters[BA_CAMERA_K2]; }
+  double GetTransition() { return parameters[BA_CAMERA_TRANSITION]; }
+  void SetFocal(double v) { parameters[BA_CAMERA_FOCAL] = v; }
+  void SetK1(double v) { parameters[BA_CAMERA_K1] = v; }
+  void SetK2(double v) { parameters[BA_CAMERA_K2] = v; }
+  void SetTransition(double t) { parameters[BA_CAMERA_TRANSITION] = t; }
 };
 
 struct BAEquirectangularCamera : public BACamera {
@@ -410,6 +429,17 @@ class BundleAdjuster {
       double k2_prior,
       bool constant);
 
+  void AddDualCamera(
+      const std::string &id,
+      double focal,
+      double k1,
+      double k2,
+      double focal_prior,
+      double k1_prior,
+      double k2_prior,
+      double transition,
+      bool constant);
+
   void AddEquirectangularCamera(const std::string &id);
 
   void AddShot(
@@ -561,6 +591,7 @@ class BundleAdjuster {
   BAPerspectiveCamera GetPerspectiveCamera(const std::string &id);
   BABrownPerspectiveCamera GetBrownPerspectiveCamera(const std::string &id);
   BAFisheyeCamera GetFisheyeCamera(const std::string &id);
+  BADualCamera GetDualCamera(const std::string &id);
   BAEquirectangularCamera GetEquirectangularCamera(const std::string &id);
   BAShot GetShot(const std::string &id);
   BAReconstruction GetReconstruction(const std::string &id);

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -50,8 +50,15 @@ enum {
   BA_CAMERA_FOCAL,
   BA_CAMERA_K1,
   BA_CAMERA_K2,
-  BA_CAMERA_TRANSITION,
   BA_CAMERA_NUM_PARAMS
+};
+
+enum {
+  BA_DUAL_CAMERA_FOCAL,
+  BA_DUAL_CAMERA_K1,
+  BA_DUAL_CAMERA_K2,
+  BA_DUAL_CAMERA_TRANSITION,
+  BA_DUAL_CAMERA_NUM_PARAMS
 };
 
 enum {
@@ -131,20 +138,20 @@ struct BAFisheyeCamera : public BACamera{
 };
 
 struct BADualCamera : public BACamera{
-  double parameters[BA_CAMERA_NUM_PARAMS];
+  double parameters[BA_DUAL_CAMERA_NUM_PARAMS];
   double focal_prior;
   double k1_prior;
   double k2_prior;
 
   BACameraType type() { return BA_DUAL_CAMERA; }
-  double GetFocal() { return parameters[BA_CAMERA_FOCAL]; }
-  double GetK1() { return parameters[BA_CAMERA_K1]; }
-  double GetK2() { return parameters[BA_CAMERA_K2]; }
-  double GetTransition() { return parameters[BA_CAMERA_TRANSITION]; }
-  void SetFocal(double v) { parameters[BA_CAMERA_FOCAL] = v; }
-  void SetK1(double v) { parameters[BA_CAMERA_K1] = v; }
-  void SetK2(double v) { parameters[BA_CAMERA_K2] = v; }
-  void SetTransition(double t) { parameters[BA_CAMERA_TRANSITION] = t; }
+  double GetFocal() { return parameters[BA_DUAL_CAMERA_FOCAL]; }
+  double GetK1() { return parameters[BA_DUAL_CAMERA_K1]; }
+  double GetK2() { return parameters[BA_DUAL_CAMERA_K2]; }
+  double GetTransition() { return parameters[BA_DUAL_CAMERA_TRANSITION]; }
+  void SetFocal(double v) { parameters[BA_DUAL_CAMERA_FOCAL] = v; }
+  void SetK1(double v) { parameters[BA_DUAL_CAMERA_K1] = v; }
+  void SetK2(double v) { parameters[BA_DUAL_CAMERA_K2] = v; }
+  void SetTransition(double t) { parameters[BA_DUAL_CAMERA_TRANSITION] = t; }
 };
 
 struct BAEquirectangularCamera : public BACamera {

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -480,6 +480,25 @@ struct BAStdDeviationConstraint {
   }
 };
 
+struct BAParameterBarrier {
+  BAParameterBarrier(double lower_bound, double upper_bound, int index)
+      : lower_bound_(lower_bound), upper_bound_(upper_bound), index_(index) {}
+
+  template <typename T>
+  bool operator()(const T* const parameters, T* residuals) const {
+    T eps = T(1e-10);
+    T value = parameters[index_];
+    T zero = 2.0*ceres::log((T(upper_bound_)-T(lower_bound_))*0.5);
+    T penalty = ceres::log(value-T(lower_bound_)+eps)+ceres::log(T(upper_bound_)-value+eps);
+    residuals[0] = penalty + zero;
+    return true;
+  }
+
+  double lower_bound_;
+  double upper_bound_;
+  int index_;
+};
+
 void BundleAdjuster::Run() {
   ceres::Problem problem;
 
@@ -494,40 +513,51 @@ void BundleAdjuster::Run() {
   }
 
   for (auto &i : cameras_) {
-    if (i.second->constant) {
-      switch (i.second->type()) {
-        case BA_PERSPECTIVE_CAMERA: {
-          BAPerspectiveCamera &c =
-              static_cast<BAPerspectiveCamera &>(*i.second);
-          problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
+    switch (i.second->type()) {
+      case BA_PERSPECTIVE_CAMERA: {
+        BAPerspectiveCamera &c =
+            static_cast<BAPerspectiveCamera &>(*i.second);
+        problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
+        if (i.second->constant) {
           problem.SetParameterBlockConstant(c.parameters);
-          break;
         }
-        case BA_BROWN_PERSPECTIVE_CAMERA: {
-          BABrownPerspectiveCamera &c =
-              static_cast<BABrownPerspectiveCamera &>(*i.second);
-          problem.AddParameterBlock(c.parameters, BA_BROWN_CAMERA_NUM_PARAMS);
-          problem.SetParameterBlockConstant(c.parameters);
-          break;
-        }
-        case BA_FISHEYE_CAMERA: {
-          BAFisheyeCamera &c = static_cast<BAFisheyeCamera &>(*i.second);
-          problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
-          problem.SetParameterBlockConstant(c.parameters);
-          break;
-        }
-        case BA_DUAL_CAMERA: {
-          BADualCamera &c = static_cast<BADualCamera &>(*i.second);
-          problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
-          problem.SetParameterBlockConstant(c.parameters);
-          break;
-        }
-        case BA_EQUIRECTANGULAR_CAMERA:
-          // No parameters for now
-          break;
+        break;
       }
+      case BA_BROWN_PERSPECTIVE_CAMERA: {
+        BABrownPerspectiveCamera &c =
+            static_cast<BABrownPerspectiveCamera &>(*i.second);
+        problem.AddParameterBlock(c.parameters, BA_BROWN_CAMERA_NUM_PARAMS);
+        if (i.second->constant) {
+          problem.SetParameterBlockConstant(c.parameters);
+        }
+        break;
+      }
+      case BA_FISHEYE_CAMERA: {
+        BAFisheyeCamera &c = static_cast<BAFisheyeCamera &>(*i.second);
+        problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
+        if (i.second->constant) {
+          problem.SetParameterBlockConstant(c.parameters);
+        }
+        break;
+      }
+      case BA_DUAL_CAMERA: {
+        BADualCamera &c = static_cast<BADualCamera &>(*i.second);
+        problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
+        ceres::CostFunction* transition_barrier =
+            new ceres::AutoDiffCostFunction<BAParameterBarrier, 1, BA_CAMERA_NUM_PARAMS>(
+                new BAParameterBarrier(0.0, 1.0, BA_CAMERA_TRANSITION));
+        problem.AddResidualBlock(transition_barrier, NULL, c.parameters);
+        if (i.second->constant) {
+          problem.SetParameterBlockConstant(c.parameters);
+        }
+        break;
+      }
+      case BA_EQUIRECTANGULAR_CAMERA:
+        // No parameters for now
+        break;
     }
   }
+  
   for (auto &i : reconstructions_) {
     for (auto &s : i.second.scales) {
       if (i.second.constant) {

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -84,10 +84,10 @@ void BundleAdjuster::AddDualCamera(
   cameras_[id] = std::unique_ptr<BADualCamera>(new BADualCamera());
   BADualCamera &c = static_cast<BADualCamera &>(*cameras_[id]);
   c.id = id;
-  c.parameters[BA_CAMERA_FOCAL] = focal;
-  c.parameters[BA_CAMERA_K1] = k1;
-  c.parameters[BA_CAMERA_K2] = k2;
-  c.parameters[BA_CAMERA_TRANSITION] = transition;
+  c.parameters[BA_DUAL_CAMERA_FOCAL] = focal;
+  c.parameters[BA_DUAL_CAMERA_K1] = k1;
+  c.parameters[BA_DUAL_CAMERA_K2] = k2;
+  c.parameters[BA_DUAL_CAMERA_TRANSITION] = transition;
   c.constant = constant;
   c.focal_prior = focal_prior;
   c.k1_prior = k1_prior;
@@ -542,10 +542,10 @@ void BundleAdjuster::Run() {
       }
       case BA_DUAL_CAMERA: {
         BADualCamera &c = static_cast<BADualCamera &>(*i.second);
-        problem.AddParameterBlock(c.parameters, BA_CAMERA_NUM_PARAMS);
+        problem.AddParameterBlock(c.parameters, BA_DUAL_CAMERA_NUM_PARAMS);
         ceres::CostFunction* transition_barrier =
-            new ceres::AutoDiffCostFunction<BAParameterBarrier, 1, BA_CAMERA_NUM_PARAMS>(
-                new BAParameterBarrier(0.0, 1.0, BA_CAMERA_TRANSITION));
+            new ceres::AutoDiffCostFunction<BAParameterBarrier, 1, BA_DUAL_CAMERA_NUM_PARAMS>(
+                new BAParameterBarrier(0.0, 1.0, BA_DUAL_CAMERA_TRANSITION));
         problem.AddResidualBlock(transition_barrier, NULL, c.parameters);
         if (i.second->constant) {
           problem.SetParameterBlockConstant(c.parameters);
@@ -638,7 +638,8 @@ void BundleAdjuster::Run() {
         BAPerspectiveCamera &c = static_cast<BAPerspectiveCamera &>(*i.second);
 
         ceres::CostFunction* cost_function =
-            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError, 3, 4>(
+            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError, 
+              BA_CAMERA_NUM_PARAMS, BA_CAMERA_NUM_PARAMS>(
                 new BasicRadialInternalParametersPriorError(c.focal_prior, focal_prior_sd_,
                                                             c.k1_prior, k1_sd_,
                                                             c.k2_prior, k2_sd_));
@@ -653,7 +654,8 @@ void BundleAdjuster::Run() {
         BABrownPerspectiveCamera &c = static_cast<BABrownPerspectiveCamera &>(*i.second);
 
         ceres::CostFunction* cost_function =
-            new ceres::AutoDiffCostFunction<BrownInternalParametersPriorError, 9, 9>(
+            new ceres::AutoDiffCostFunction<BrownInternalParametersPriorError,
+              BA_BROWN_CAMERA_NUM_PARAMS, BA_BROWN_CAMERA_NUM_PARAMS>(
                 new BrownInternalParametersPriorError(c.focal_x_prior, focal_prior_sd_,
                                                       c.focal_y_prior, focal_prior_sd_,
                                                       c.c_x_prior, c_prior_sd_,
@@ -674,7 +676,8 @@ void BundleAdjuster::Run() {
         BAFisheyeCamera &c = static_cast<BAFisheyeCamera &>(*i.second);
 
         ceres::CostFunction* cost_function =
-            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError, 3, 4>(
+            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError,
+              BA_CAMERA_NUM_PARAMS, BA_CAMERA_NUM_PARAMS>(
                 new BasicRadialInternalParametersPriorError(c.focal_prior, focal_prior_sd_,
                                                             c.k1_prior, k1_sd_,
                                                             c.k2_prior, k2_sd_));
@@ -689,7 +692,8 @@ void BundleAdjuster::Run() {
         BADualCamera &c = static_cast<BADualCamera &>(*i.second);
 
         ceres::CostFunction* cost_function =
-            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError, 3, 4>(
+            new ceres::AutoDiffCostFunction<BasicRadialInternalParametersPriorError,
+              BA_CAMERA_NUM_PARAMS, BA_DUAL_CAMERA_NUM_PARAMS>(
                 new BasicRadialInternalParametersPriorError(c.focal_prior, focal_prior_sd_,
                                                             c.k1_prior, k1_sd_,
                                                             c.k2_prior, k2_sd_));
@@ -960,7 +964,7 @@ void BundleAdjuster::AddObservationResidualBlock(
     {
       BAPerspectiveCamera &c = static_cast<BAPerspectiveCamera &>(*observation.camera);
       ceres::CostFunction* cost_function =
-          new ceres::AutoDiffCostFunction<PerspectiveReprojectionError, 2, 4, 6, 3>(
+          new ceres::AutoDiffCostFunction<PerspectiveReprojectionError, 2, 3, 6, 3>(
               new PerspectiveReprojectionError(observation.coordinates[0],
                                                observation.coordinates[1],
                                                observation.std_deviation));
@@ -992,7 +996,7 @@ void BundleAdjuster::AddObservationResidualBlock(
     {
       BAFisheyeCamera &c = static_cast<BAFisheyeCamera &>(*observation.camera);
       ceres::CostFunction* cost_function =
-          new ceres::AutoDiffCostFunction<FisheyeReprojectionError, 2, 4, 6, 3>(
+          new ceres::AutoDiffCostFunction<FisheyeReprojectionError, 2, 3, 6, 3>(
               new FisheyeReprojectionError(observation.coordinates[0],
                                            observation.coordinates[1],
                                            observation.std_deviation));

--- a/opensfm/src/bundle/src/projection_errors.h
+++ b/opensfm/src/bundle/src/projection_errors.h
@@ -168,10 +168,10 @@ void FisheyeProject(const T* const camera,
 
 template <typename T>
 void DualProject(const T* const camera, const T point[3], T projection[2]) {
-  const T& focal = camera[BA_CAMERA_FOCAL];
-  const T& transition = camera[BA_CAMERA_TRANSITION];
-  const T& k1 = camera[BA_CAMERA_K1];
-  const T& k2 = camera[BA_CAMERA_K2];
+  const T& focal = camera[BA_DUAL_CAMERA_FOCAL];
+  const T& transition = camera[BA_DUAL_CAMERA_TRANSITION];
+  const T& k1 = camera[BA_DUAL_CAMERA_K1];
+  const T& k2 = camera[BA_DUAL_CAMERA_K2];
   const T& x = point[0];
   const T& y = point[1];
   const T& z = point[2];

--- a/opensfm/src/csfm.cc
+++ b/opensfm/src/csfm.cc
@@ -88,6 +88,7 @@ PYBIND11_MODULE(csfm, m) {
     .def("get_perspective_camera", &BundleAdjuster::GetPerspectiveCamera)
     .def("get_brown_perspective_camera", &BundleAdjuster::GetBrownPerspectiveCamera)
     .def("get_fisheye_camera", &BundleAdjuster::GetFisheyeCamera)
+    .def("get_dual_camera", &BundleAdjuster::GetDualCamera)
     .def("get_equirectangular_camera", &BundleAdjuster::GetEquirectangularCamera)
     .def("get_shot", &BundleAdjuster::GetShot)
     .def("get_point", &BundleAdjuster::GetPoint)
@@ -96,6 +97,7 @@ PYBIND11_MODULE(csfm, m) {
     .def("add_perspective_camera", &BundleAdjuster::AddPerspectiveCamera)
     .def("add_brown_perspective_camera", &BundleAdjuster::AddBrownPerspectiveCamera)
     .def("add_fisheye_camera", &BundleAdjuster::AddFisheyeCamera)
+    .def("add_dual_camera", &BundleAdjuster::AddDualCamera)
     .def("add_equirectangular_camera", &BundleAdjuster::AddEquirectangularCamera)
     .def("add_shot", &BundleAdjuster::AddShot)
     .def("add_point", &BundleAdjuster::AddPoint)
@@ -184,6 +186,17 @@ PYBIND11_MODULE(csfm, m) {
     .def_readwrite("constant", &BAFisheyeCamera::constant)
     .def_readwrite("focal_prior", &BAFisheyeCamera::focal_prior)
     .def_readwrite("id", &BAFisheyeCamera::id)
+  ;
+
+  py::class_<BADualCamera>(m, "BADualCamera")
+    .def(py::init())
+    .def_property("focal", &BADualCamera::GetFocal, &BADualCamera::SetFocal)
+    .def_property("k1", &BADualCamera::GetK1, &BADualCamera::SetK1)
+    .def_property("k2", &BADualCamera::GetK2, &BADualCamera::SetK2)
+    .def_property("transition", &BADualCamera::GetTransition, &BADualCamera::SetTransition)
+    .def_readwrite("constant", &BADualCamera::constant)
+    .def_readwrite("focal_prior", &BADualCamera::focal_prior)
+    .def_readwrite("id", &BADualCamera::id)
   ;
 
   py::class_<BAShot>(m, "BAShot")

--- a/opensfm/test/test_types.py
+++ b/opensfm/test/test_types.py
@@ -225,7 +225,7 @@ def _get_dual_camera():
     camera = types.DualCamera()
     camera.width = 800
     camera.height = 600
-    camera.focal = 0.6
+    camera.focal = 0.3
     camera.k1 = -0.1
     camera.k2 = 0.01
     camera.transition = 0.5

--- a/opensfm/test/test_types.py
+++ b/opensfm/test/test_types.py
@@ -108,6 +108,17 @@ def test_fisheye_camera_projection():
     assert np.allclose(pixel, projected)
 
 
+def test_dual_camera_projection():
+    """Test dual projection--backprojection loop."""
+    if not context.OPENCV3:
+        return
+    camera = _get_dual_camera()
+    pixel = [0.1, 0.2]
+    bearing = camera.pixel_bearing(pixel)
+    projected = camera.project(bearing)
+    assert np.allclose(pixel, projected)
+
+
 def test_spherical_camera_projection():
     """Test spherical projection--backprojection loop."""
     camera = _get_spherical_camera()
@@ -207,6 +218,17 @@ def _get_fisheye_camera():
     camera.focal = 0.6
     camera.k1 = -0.1
     camera.k2 = 0.01
+    return camera
+
+
+def _get_dual_camera():
+    camera = types.DualCamera()
+    camera.width = 800
+    camera.height = 600
+    camera.focal = 0.6
+    camera.k1 = -0.1
+    camera.k2 = 0.01
+    camera.transition = 0.5
     return camera
 
 

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -607,7 +607,7 @@ class DualCamera(Camera):
 
         undistorted = cv2.undistortPoints(points, no_K, distortion)
         undistorted = undistorted.reshape((-1, 2))
-        r = np.sqrt(undistorted[:, 0]**2 + undistorted[:, 0]**2)
+        r = np.sqrt(undistorted[:, 0]**2 + undistorted[:, 1]**2)
 
         # inverse iteration for finding theta from r
         theta_fish = r

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -576,10 +576,21 @@ class DualCamera(Camera):
 
         point /= self.focal
         x_u, y_u = cv2.undistortPoints(point, no_K, distortion).flat
+        r = np.sqrt(x_u**2 + y_u**2)
 
-        theta = np.sqrt(x_u**2 + y_u**2)
-        s = math.tan(theta)/(self.transition*math.tan(theta) + (1.0 - self.transition)*theta)
+        # inverse iteration for finding theta from r
+        theta_fish = r
+        theta_persp = np.arctan2(r, 1.0)
+        theta_0 = self.transition*theta_persp + (1.0 - self.transition)*theta_fish
+        r_0 = self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0
 
+        for i in range(3):
+            secant = 1.0/math.cos(theta_0)
+            d_theta = (self.transition*secant**2 - self.transition + 1)
+            theta_0 = (r - r_0)/d_theta + theta_0
+            r_0 = self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0
+
+        s = math.tan(theta_0)/(self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0)
         x_dual = x_u*s
         y_dual = y_u*s
 

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -528,9 +528,6 @@ class DualCamera(Camera):
         self.focal = None
         self.k1 = None
         self.k2 = None
-        self.focal_prior = None
-        self.k1_prior = None
-        self.k2_prior = None
         if projection_type == 'perspective':
             self.transition = 1.0
         elif projection_type == 'fisheye':

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -582,13 +582,11 @@ class DualCamera(Camera):
         theta_fish = r
         theta_persp = np.arctan2(r, 1.0)
         theta_0 = self.transition*theta_persp + (1.0 - self.transition)*theta_fish
-        r_0 = self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0
-
         for i in range(3):
+            r_0 = self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0
             secant = 1.0/math.cos(theta_0)
             d_theta = (self.transition*secant**2 - self.transition + 1)
             theta_0 = (r - r_0)/d_theta + theta_0
-            r_0 = self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0
 
         s = math.tan(theta_0)/(self.transition*math.tan(theta_0) + (1.0 - self.transition)*theta_0)
         x_dual = x_u*s
@@ -613,13 +611,11 @@ class DualCamera(Camera):
         theta_fish = r
         theta_persp = np.arctan2(r, 1.0)
         theta_0 = self.transition*theta_persp + (1.0 - self.transition)*theta_fish
-        r_0 = self.transition*np.tan(theta_0) + (1.0 - self.transition)*theta_0
-
         for i in range(3):
+            r_0 = self.transition*np.tan(theta_0) + (1.0 - self.transition)*theta_0
             secant = 1.0/np.cos(theta_0)
             d_theta = (self.transition*secant**2 - self.transition + 1)
             theta_0 = (r - r_0)/d_theta + theta_0
-            r_0 = self.transition*np.tan(theta_0) + (1.0 - self.transition)*theta_0
 
         s = np.tan(theta_0)/(self.transition*np.tan(theta_0) + (1.0 - self.transition)*theta_0)
         x_dual = undistorted[:, 0]*s

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -569,7 +569,7 @@ class DualCamera(Camera):
 
         point = np.asarray(pixel).reshape((1, 1, 2))
         distortion = np.array([self.k1, self.k2, 0., 0.])
-        if self.transition > 0.5:
+        if self.transition >= 0.5:
             x, y = cv2.undistortPoints(point, self.get_K(), distortion).flat
         else:
             x, y = cv2.fisheye.undistortPoints(point, self.get_K(), distortion).flat
@@ -580,7 +580,7 @@ class DualCamera(Camera):
         """Unit vector pointing to the pixel viewing directions."""
         points = pixels.reshape((-1, 1, 2)).astype(np.float64)
         distortion = np.array([self.k1, self.k2, 0., 0.])
-        if self.transition > 0.5:
+        if self.transition >= 0.5:
             up = cv2.undistortPoints(points, self.get_K(), distortion)
         else:
             up = cv2.fisheye.undistortPoints(points, self.get_K(), distortion)


### PR DESCRIPTION
This PR introduce a new camera model dubbed `dual` than can seamlessly switch between fisheye and perspective projection using an additional parameter called `transition`. More formally, one can rewrite the projection as : 

`proj(dual) = transition * proj(perspective) + (1 - transition) * proj(fisheye)`

Inverse projection (aka. `bearings`) is done using an inverse iterative scheme (only 3 iterations are sufficient), as one can't retrieve the incident angle `theta` from the the distorted points.

`transition` is soft-constrained between 0 and 1 in the bundle, using a log-barrier penalty.

Corresponding `mapillary_sfm` commit is here : https://github.com/mapillary/mapillary_sfm/commit/3330e863714877e8c6674a4e28adbd34b68b3607