### PR TITLE
Refactor undistorted folder

### DIFF
--- a/bin/export_bundler
+++ b/bin/export_bundler
@@ -3,11 +3,8 @@ import os.path, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import argparse
 
-import json
-import numpy as np
-
-import opensfm.dataset as dataset
-import opensfm.io as io
+from opensfm import dataset
+from opensfm import io
 
 
 if __name__ == "__main__":
@@ -37,8 +34,9 @@ if __name__ == "__main__":
     images = data.images()
 
     if args.undistorted:
-        reconstructions = data.load_undistorted_reconstruction()
-        track_graph = data.load_undistorted_tracks_graph()
+        udata = dataset.UndistortedDataSet(data, 'undistorted')
+        reconstructions = udata.load_undistorted_reconstruction()
+        track_graph = udata.load_undistorted_tracks_graph()
         images = reconstructions[0].shots.keys()
     else:
         reconstructions = data.load_reconstruction()

--- a/bin/export_pmvs
+++ b/bin/export_pmvs
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     data = dataset.DataSet(args.dataset)
+    udata = dataset.UndistortedDataSet(data, 'undistorted')
     if args.output:
         base_output_path = args.output
     else:
@@ -39,7 +40,7 @@ if __name__ == "__main__":
     # load tracks for vis.dat
     try:
         if args.undistorted:
-            graph = data.load_undistorted_tracks_graph()
+            graph = udata.load_undistorted_tracks_graph()
         else:
             graph = data.load_tracks_graph()
         tracks, images = tracking.tracks_and_images(graph)
@@ -49,7 +50,7 @@ if __name__ == "__main__":
         use_vis_data = False
 
     if args.undistorted:
-        reconstructions = data.load_undistorted_reconstruction()
+        reconstructions = udata.load_undistorted_reconstruction()
     else:
         reconstructions = data.load_reconstruction()
 
@@ -90,7 +91,7 @@ if __name__ == "__main__":
             # radially undistort the original image
             camera = shot.camera
             if args.undistorted:
-                undistorted_image = data.load_undistorted_image(image)
+                undistorted_image = udata.load_undistorted_image(image)
             else:
                 original_image = data.load_image(image)[:, :, ::-1]
                 original_h, original_w = original_image.shape[:2]

--- a/bin/migrate_undistort.sh
+++ b/bin/migrate_undistort.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Migrate dataset to the new undistort folder structure.
+
+if [ $# -le 0 ] 
+then
+    echo "Migrate dataset to the new undistort folder structure." 
+    echo
+	echo "Usage:"
+    echo
+    echo "    $0 dataset"
+    echo
+	exit 1
+fi 
+
+cd $1
+
+if [ -d "undistorted/images" ]
+then
+    echo "Some folders already ported. Aborting."
+    exit 2
+fi
+
+mv undistorted undistorted_images
+mkdir undistorted
+mv undistorted_images undistorted/images
+mv undistorted_masks undistorted/masks
+mv undistorted_segmentations undistorted/segmentations
+mv undistorted_instances undistorted/instances
+mv undistorted_tracks.csv undistorted/tracks.csv
+mv undistorted_reconstruction.json undistorted/reconstruction.json
+mv depthmaps undistorted/depthmaps

--- a/bin/plot_depthmaps
+++ b/bin/plot_depthmaps
@@ -83,37 +83,41 @@ if __name__ == "__main__":
                         help='path to the dataset to be processed')
     parser.add_argument('--image',
                         help='name of the image to show')
+    parser.add_argument('--subfolder',
+                        help='undistorted subfolder',
+                        default='undistorted')
     parser.add_argument('--save-figs',
                         help='save figures istead of showing them',
                         action='store_true')
     args = parser.parse_args()
 
     data = dataset.DataSet(args.dataset)
+    udata = dataset.UndistortedDataSet(data, args.subfolder)
 
     if args.image:
         images = [args.image]
     else:
-        reconstructions = data.load_undistorted_reconstruction()
+        reconstructions = udata.load_undistorted_reconstruction()
         images = []
         for reconstruction in reconstructions:
             images.extend(reconstruction.shots.keys())
 
     for image in images:
-        if not data.raw_depthmap_exists(image):
+        if not udata.raw_depthmap_exists(image):
             continue
 
-        depth, plane, score, nghbr, nghbrs = data.load_raw_depthmap(image)
-        clean_depth, clean_plane, clean_score = data.load_clean_depthmap(image)
+        depth, plane, score, nghbr, nghbrs = udata.load_raw_depthmap(image)
+        clean_depth, clean_plane, clean_score = udata.load_clean_depthmap(image)
 
         print("Plotting depthmap for {0}".format(image))
         pl.close("all")
         pl.figure(figsize=(30, 16), dpi=90, facecolor='w', edgecolor='k')
         title = "Shot: " + image + "\n" + "\n".join(wrap("Neighbors: " + ', '.join(nghbrs), 80))
-        plot_depthmap(data.load_undistorted_image(image), title, depth, clean_depth, plane, score, nghbr)
+        plot_depthmap(udata.load_undistorted_image(image), title, depth, clean_depth, plane, score, nghbr)
         pl.tight_layout()
 
         if args.save_figs:
-            p = args.dataset + '/plot_depthmaps'
+            p = udata.data_path + '/plot_depthmaps'
             io.mkdir_p(p)
             pl.savefig(p + '/' + image + '.png')
             pl.close()

--- a/doc/source/dataset.rst
+++ b/doc/source/dataset.rst
@@ -26,6 +26,7 @@ Dataset Structure
        └── depthmaps/
            └── merged.ply
 
+Previous versions of OpenSfM used a different folder structure where undistorted data was not grouped into a single folder.  Please, read and use ``bin/migrate_undistort.sh`` to port old datasets to the new folder structure.
 
 
 Reconstruction file format

--- a/doc/source/dataset.rst
+++ b/doc/source/dataset.rst
@@ -12,16 +12,19 @@ Dataset Structure
    ├── masks/
    ├── gcp_list.txt
    ├── exif/
+   ├── camera_models.json
    ├── features/
    ├── matches/
    ├── tracks.csv
    ├── reconstruction.json
    ├── reconstruction.meshed.json
-   ├── undistorted/
-   ├── undistorted_tracks.json
-   ├── undistorted_reconstruction.json
-   └── depthmaps/
-       └── merged.ply
+   └── undistorted/
+       ├── images/
+       ├── masks/
+       ├── tracks.csv
+       ├── reconstruction.json
+       └── depthmaps/
+           └── merged.ply
 
 
 

--- a/opensfm/commands/compute_depthmaps.py
+++ b/opensfm/commands/compute_depthmaps.py
@@ -11,15 +11,26 @@ class Command:
     help = "Compute depthmap"
 
     def add_arguments(self, parser):
-        parser.add_argument('dataset', help='dataset to process')
-        parser.add_argument('--interactive',
-                            help='plot results as they are being computed',
-                            action='store_true')
+        parser.add_argument(
+            'dataset',
+            help='dataset to process',
+        )
+        parser.add_argument(
+            '--subfolder',
+            help='undistorted subfolder where to load and store data',
+            default='undistorted'
+        )
+        parser.add_argument(
+            '--interactive',
+            help='plot results as they are being computed',
+            action='store_true',
+        )
 
     def run(self, args):
         data = dataset.DataSet(args.dataset)
+        udata = dataset.UndistortedDataSet(data, args.subfolder)
         data.config['interactive'] = args.interactive
-        reconstructions = data.load_undistorted_reconstruction()
-        graph = data.load_undistorted_tracks_graph()
+        reconstructions = udata.load_undistorted_reconstruction()
+        graph = udata.load_undistorted_tracks_graph()
 
-        dense.compute_depthmaps(data, graph, reconstructions[0])
+        dense.compute_depthmaps(udata, graph, reconstructions[0])

--- a/opensfm/commands/export_geocoords.py
+++ b/opensfm/commands/export_geocoords.py
@@ -79,8 +79,10 @@ class Command:
             data.save_reconstruction(reconstructions, output)
 
         if args.dense:
-            output = args.output or 'depthmaps/merged.geocoords.ply'
-            self._transform_dense_point_cloud(data, transformation, output)
+            output = args.output or 'undistorted/depthmaps/merged.geocoords.ply'
+            output_path = os.path.join(data.data_path, output)
+            udata = dataset.UndistortedDataSet(data, 'undistorted')
+            self._transform_dense_point_cloud(udata, transformation, output_path)
 
     def _get_transformation(self, reference, projection):
         """Get the linear transform from reconstruction coords to geocoords."""
@@ -141,11 +143,10 @@ class Command:
         for point in reconstruction.points.values():
             point.coordinates = list(np.dot(A, point.coordinates) + b)
 
-    def _transform_dense_point_cloud(self, data, transformation, output):
+    def _transform_dense_point_cloud(self, udata, transformation, output_path):
         """Apply a transformation to the merged point cloud."""
         A, b = transformation[:3, :3], transformation[:3, 3]
-        input_path = os.path.join(data._depthmap_path(), 'merged.ply')
-        output_path = os.path.join(data.data_path, output)
+        input_path = os.path.join(udata._depthmap_path(), 'merged.ply')
         with io.open_rt(input_path) as fin:
             with io.open_wt(output_path) as fout:
                 for i, line in enumerate(fin):

--- a/opensfm/commands/export_openmvs.py
+++ b/opensfm/commands/export_openmvs.py
@@ -19,8 +19,9 @@ class Command:
 
     def run(self, args):
         data = dataset.DataSet(args.dataset)
-        reconstructions = data.load_undistorted_reconstruction()
-        graph = data.load_undistorted_tracks_graph()
+        udata = dataset.UndistortedDataSet(data, 'undistorted')
+        reconstructions = udata.load_undistorted_reconstruction()
+        graph = udata.load_undistorted_tracks_graph()
 
         if reconstructions:
             self.export(reconstructions[0], graph, data)
@@ -39,7 +40,7 @@ class Command:
 
         for shot in reconstruction.shots.values():
             if shot.camera.projection_type == 'perspective':
-                image_path = data._undistorted_image_file(shot.id)
+                image_path = udata._undistorted_image_file(shot.id)
                 exporter.add_shot(
                     str(os.path.abspath(image_path)),
                     str(shot.id),
@@ -53,5 +54,5 @@ class Command:
             coordinates = np.array(point.coordinates, dtype=np.float64)
             exporter.add_point(coordinates, shots)
 
-        io.mkdir_p(data.data_path + '/openmvs')
-        exporter.export(data.data_path + '/openmvs/scene.mvs')
+        io.mkdir_p(udata.data_path + '/openmvs')
+        exporter.export(udata.data_path + '/openmvs/scene.mvs')

--- a/opensfm/commands/export_ply.py
+++ b/opensfm/commands/export_ply.py
@@ -38,14 +38,15 @@ class Command:
             data.save_ply(reconstructions[0], None, no_cameras, no_points)
 
         if args.depthmaps and reconstructions:
+            udata = dataset.UndistortedDataSet(data, 'undistorted')
             for id, shot in reconstructions[0].shots.items():
-                rgb = data.load_undistorted_image(id)
+                rgb = udata.load_undistorted_image(id)
                 for t in ('clean', 'raw'):
-                    path_depth = data._depthmap_file(id, t + '.npz')
+                    path_depth = udata._depthmap_file(id, t + '.npz')
                     if not os.path.exists(path_depth):
                         continue
                     depth = np.load(path_depth)['depth']
                     rgb = scale_down_image(rgb, depth.shape[1], depth.shape[0])
                     ply = depthmap_to_ply(shot, depth, rgb)
-                    with io.open_wt(data._depthmap_file(id, t + '.ply')) as fout:
+                    with io.open_wt(udata._depthmap_file(id, t + '.ply')) as fout:
                         fout.write(ply)

--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -11,32 +11,28 @@ from six import iteritems
 
 logger = logging.getLogger(__name__)
 
+
 class Command:
     name = 'export_visualsfm'
     help = "Export reconstruction to NVM_V3 format from VisualSfM"
 
     def add_arguments(self, parser):
         parser.add_argument('dataset', help='dataset to process')
-        parser.add_argument('--undistorted',
-                            action='store_true',
-                            help='export the undistorted reconstruction')
         parser.add_argument('--points',
                             action='store_true',
                             help='export points')
 
     def run(self, args):
         data = dataset.DataSet(args.dataset)
-        if args.undistorted:
-            reconstructions = data.load_undistorted_reconstruction()
-            graph = data.load_undistorted_tracks_graph()
-        else:
-            reconstructions = data.load_reconstruction()
-            graph = data.load_tracks_graph()
+        udata = dataset.UndistortedDataSet(data, 'undistorted')
+
+        reconstructions = udata.load_undistorted_reconstruction()
+        graph = udata.load_undistorted_tracks_graph()
 
         if reconstructions:
-            self.export(reconstructions[0], graph, data, args.points)
+            self.export(reconstructions[0], graph, udata, args.points)
 
-    def export(self, reconstruction, graph, data, with_points):
+    def export(self, reconstruction, graph, udata, with_points):
         lines = ['NVM_V3', '', str(len(reconstruction.shots))]
         shot_size_cache = {}
         shot_index = {}
@@ -46,7 +42,7 @@ class Command:
             q = tf.quaternion_from_matrix(shot.pose.get_rotation_matrix())
             o = shot.pose.get_origin()
 
-            shot_size_cache[shot.id] = data.undistorted_image_size(shot.id)
+            shot_size_cache[shot.id] = udata.undistorted_image_size(shot.id)
             shot_index[shot.id] = i
             i += 1
 
@@ -57,14 +53,14 @@ class Command:
                 focal_normalized = shot.camera.focal
 
             words = [
-                self.image_path(shot.id, data),
+                self.image_path(shot.id, udata),
                 focal_normalized * max(shot_size_cache[shot.id]),
                 q[0], q[1], q[2], q[3],
                 o[0], o[1], o[2],
                 '0', '0',
             ]
             lines.append(' '.join(map(str, words)))
-        
+
         if with_points:
             lines.append('')
             points = reconstruction.points
@@ -85,7 +81,7 @@ class Command:
                         y = (0.5 + v[1]) * shot_size_cache[shot_key][0]
                         view_line.append(' '.join(
                             map(str, [shot_index[shot_key], view['feature_id'], x, y])))
-                
+
                 lines.append(' '.join(map(str, coord)) + ' ' + 
                              ' '.join(map(str, color)) + ' ' + 
                              str(len(view_line)) + ' ' + ' '.join(view_line))
@@ -94,10 +90,10 @@ class Command:
 
         lines += ['0', '', '0']
 
-        with io.open_wt(data.data_path + '/reconstruction.nvm') as fout:
+        with io.open_wt(udata.data_path + '/reconstruction.nvm') as fout:
             fout.write('\n'.join(lines))
 
-    def image_path(self, image, data):
+    def image_path(self, image, udata):
         """Path to the undistorted image relative to the dataset path."""
-        path = data._undistorted_image_file(image)
-        return os.path.relpath(path, data.data_path)
+        path = udata._undistorted_image_file(image)
+        return os.path.relpath(path, udata.data_path)

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -46,7 +46,7 @@ class DataSet(object):
         self.config = config.load_config(config_file)
 
     def _load_image_list(self):
-        """Load image list from image_list.txt or list image/ folder."""
+        """Load image list from image_list.txt or list images/ folder."""
         image_list_file = os.path.join(self.data_path, 'image_list.txt')
         if os.path.isfile(image_list_file):
             with io.open_rt(image_list_file) as fin:
@@ -79,8 +79,11 @@ class DataSet(object):
         """Height and width of the image."""
         return io.image_size(self._image_file(image))
 
-    def _undistorted_image_path(self):
+    def _undistorted_path(self):
         return os.path.join(self.data_path, 'undistorted')
+
+    def _undistorted_image_path(self):
+        return os.path.join(self.data_path, 'undistorted/images')
 
     def _undistorted_image_file(self, image):
         """Path of undistorted version of an image."""
@@ -156,7 +159,7 @@ class DataSet(object):
         return np.array(mask, dtype=bool)
 
     def _undistorted_mask_path(self):
-        return os.path.join(self.data_path, 'undistorted_masks')
+        return os.path.join(self.data_path, 'undistorted/masks')
 
     def _undistorted_mask_file(self, image):
         """Path of undistorted version of a mask."""
@@ -191,7 +194,7 @@ class DataSet(object):
         return detection
 
     def _undistorted_detection_path(self):
-        return os.path.join(self.data_path, 'undistorted_detections')
+        return os.path.join(self.data_path, 'undistorted/detections')
 
     def _undistorted_detection_file(self, image):
         """Path of undistorted version of a detection."""
@@ -228,7 +231,7 @@ class DataSet(object):
         return segmentation
 
     def _undistorted_segmentation_path(self):
-        return os.path.join(self.data_path, 'undistorted_segmentations')
+        return os.path.join(self._undistorted_path(), 'segmentations')
 
     def _undistorted_segmentation_file(self, image):
         """Path of undistorted version of a segmentation."""
@@ -332,7 +335,7 @@ class DataSet(object):
                 return mask & smask
 
     def _depthmap_path(self):
-        return os.path.join(self.data_path, 'depthmaps')
+        return os.path.join(self._undistorted_path(), 'depthmaps')
 
     def _depthmap_file(self, image, suffix):
         """Path to the depthmap file"""
@@ -547,10 +550,10 @@ class DataSet(object):
             tracking.save_tracks_graph(fout, graph)
 
     def load_undistorted_tracks_graph(self):
-        return self.load_tracks_graph('undistorted_tracks.csv')
+        return self.load_tracks_graph('undistorted/tracks.csv')
 
     def save_undistorted_tracks_graph(self, graph):
-        return self.save_tracks_graph(graph, 'undistorted_tracks.csv')
+        return self.save_tracks_graph(graph, 'undistorted/tracks.csv')
 
     def _reconstruction_file(self, filename):
         """Return path of reconstruction file"""
@@ -570,11 +573,12 @@ class DataSet(object):
 
     def load_undistorted_reconstruction(self):
         return self.load_reconstruction(
-            filename='undistorted_reconstruction.json')
+            filename='undistorted/reconstruction.json')
 
     def save_undistorted_reconstruction(self, reconstruction):
+        io.mkdir_p(self._undistorted_path())
         return self.save_reconstruction(
-            reconstruction, filename='undistorted_reconstruction.json')
+            reconstruction, filename='undistorted/reconstruction.json')
 
     def _reference_lla_path(self):
         return os.path.join(self.data_path, 'reference_lla.json')

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -11,7 +11,6 @@ import six
 
 from opensfm import io
 from opensfm import config
-from opensfm import context
 from opensfm import geo
 from opensfm import tracking
 from opensfm import features
@@ -79,31 +78,6 @@ class DataSet(object):
         """Height and width of the image."""
         return io.image_size(self._image_file(image))
 
-    def _undistorted_path(self):
-        return os.path.join(self.data_path, 'undistorted')
-
-    def _undistorted_image_path(self):
-        return os.path.join(self.data_path, 'undistorted/images')
-
-    def _undistorted_image_file(self, image):
-        """Path of undistorted version of an image."""
-        image_format = self.config['undistorted_image_format']
-        filename = image + '.' + image_format
-        return os.path.join(self._undistorted_image_path(), filename)
-
-    def load_undistorted_image(self, image):
-        """Load undistorted image pixels as a numpy array."""
-        return io.imread(self._undistorted_image_file(image))
-
-    def save_undistorted_image(self, image, array):
-        """Save undistorted image pixels."""
-        io.mkdir_p(self._undistorted_image_path())
-        io.imwrite(self._undistorted_image_file(image), array)
-
-    def undistorted_image_size(self, image):
-        """Height and width of the undistorted image."""
-        return io.image_size(self._undistorted_image_file(image))
-
     def _load_mask_list(self):
         """Load mask list from mask_list.txt or list masks/ folder."""
         mask_list_file = os.path.join(self.data_path, 'mask_list.txt')
@@ -158,26 +132,6 @@ class DataSet(object):
 
         return np.array(mask, dtype=bool)
 
-    def _undistorted_mask_path(self):
-        return os.path.join(self.data_path, 'undistorted/masks')
-
-    def _undistorted_mask_file(self, image):
-        """Path of undistorted version of a mask."""
-        return os.path.join(self._undistorted_mask_path(), image + '.png')
-
-    def undistorted_mask_exists(self, image):
-        """Check if the undistorted mask file exists."""
-        return os.path.isfile(self._undistorted_mask_file(image))
-
-    def load_undistorted_mask(self, image):
-        """Load undistorted mask pixels as a numpy array."""
-        return io.imread(self._undistorted_mask_file(image), grayscale=True)
-
-    def save_undistorted_mask(self, image, array):
-        """Save the undistorted image mask."""
-        io.mkdir_p(self._undistorted_mask_path())
-        io.imwrite(self._undistorted_mask_file(image), array)
-
     def _detection_path(self):
         return os.path.join(self.data_path, 'detections')
 
@@ -193,28 +147,6 @@ class DataSet(object):
             detection = None
         return detection
 
-    def _undistorted_detection_path(self):
-        return os.path.join(self.data_path, 'undistorted/detections')
-
-    def _undistorted_detection_file(self, image):
-        """Path of undistorted version of a detection."""
-        return os.path.join(self._undistorted_detection_path(), image + '.png')
-
-    def undistorted_detection_exists(self, image):
-        """Check if the undistorted detection file exists."""
-        return os.path.isfile(self._undistorted_detection_file(image))
-
-    def load_undistorted_detection(self, image):
-        """Load an undistorted image detection."""
-        detection = io.imread(self._undistorted_detection_file(image),
-                              grayscale=True)
-        return detection
-
-    def save_undistorted_detection(self, image, array):
-        """Save the undistorted image detection."""
-        io.mkdir_p(self._undistorted_detection_path())
-        io.imwrite(self._undistorted_detection_file(image), array)
-
     def _segmentation_path(self):
         return os.path.join(self.data_path, 'segmentations')
 
@@ -229,28 +161,6 @@ class DataSet(object):
         else:
             segmentation = None
         return segmentation
-
-    def _undistorted_segmentation_path(self):
-        return os.path.join(self._undistorted_path(), 'segmentations')
-
-    def _undistorted_segmentation_file(self, image):
-        """Path of undistorted version of a segmentation."""
-        return os.path.join(self._undistorted_segmentation_path(), image + '.png')
-
-    def undistorted_segmentation_exists(self, image):
-        """Check if the undistorted segmentation file exists."""
-        return os.path.isfile(self._undistorted_segmentation_file(image))
-
-    def load_undistorted_segmentation(self, image):
-        """Load an undistorted image segmentation."""
-        segmentation = io.imread(self._undistorted_segmentation_file(image),
-                                 grayscale=True)
-        return segmentation
-
-    def save_undistorted_segmentation(self, image, array):
-        """Save the undistorted image segmentation."""
-        io.mkdir_p(self._undistorted_segmentation_path())
-        io.imwrite(self._undistorted_segmentation_file(image), array)
 
     def segmentation_ignore_values(self, image):
         """List of label values to ignore.
@@ -276,22 +186,6 @@ class DataSet(object):
 
         return self._mask_from_segmentation(segmentation, ignore_values)
 
-    def load_undistorted_segmentation_mask(self, image):
-        """Build a mask from the undistorted segmentation.
-
-        The mask is non-zero only for pixels with segmentation
-        labels not in segmentation_ignore_values.
-        """
-        ignore_values = self.segmentation_ignore_values(image)
-        if not ignore_values:
-            return None
-
-        segmentation = self.load_undistorted_segmentation(image)
-        if segmentation is None:
-            return None
-
-        return self._mask_from_segmentation(segmentation, ignore_values)
-
     def _mask_from_segmentation(self, segmentation, ignore_values):
         mask = np.ones(segmentation.shape, dtype=np.uint8)
         for value in ignore_values:
@@ -308,20 +202,6 @@ class DataSet(object):
         smask = self.load_segmentation_mask(image)
         return self._combine_masks(mask, smask)
 
-    def load_undistorted_combined_mask(self, image):
-        """Combine undistorted binary mask with segmentation mask.
-
-        Return a mask that is non-zero only where the binary
-        mask and the segmentation mask are non-zero.
-        """
-        mask = None
-        if self.undistorted_mask_exists(image):
-            mask = self.load_undistorted_mask(image)
-        smask = None
-        if self.undistorted_segmentation_exists(image):
-            smask = self.load_undistorted_segmentation_mask(image)
-        return self._combine_masks(mask, smask)
-
     def _combine_masks(self, mask, smask):
         if mask is None:
             if smask is None:
@@ -333,55 +213,6 @@ class DataSet(object):
                 return mask
             else:
                 return mask & smask
-
-    def _depthmap_path(self):
-        return os.path.join(self._undistorted_path(), 'depthmaps')
-
-    def _depthmap_file(self, image, suffix):
-        """Path to the depthmap file"""
-        return os.path.join(self._depthmap_path(), image + '.' + suffix)
-
-    def raw_depthmap_exists(self, image):
-        return os.path.isfile(self._depthmap_file(image, 'raw.npz'))
-
-    def save_raw_depthmap(self, image, depth, plane, score, nghbr, nghbrs):
-        io.mkdir_p(self._depthmap_path())
-        filepath = self._depthmap_file(image, 'raw.npz')
-        np.savez_compressed(filepath, depth=depth, plane=plane, score=score, nghbr=nghbr, nghbrs=nghbrs)
-
-    def load_raw_depthmap(self, image):
-        o = np.load(self._depthmap_file(image, 'raw.npz'))
-        return o['depth'], o['plane'], o['score'], o['nghbr'], o['nghbrs']
-
-    def clean_depthmap_exists(self, image):
-        return os.path.isfile(self._depthmap_file(image, 'clean.npz'))
-
-    def save_clean_depthmap(self, image, depth, plane, score):
-        io.mkdir_p(self._depthmap_path())
-        filepath = self._depthmap_file(image, 'clean.npz')
-        np.savez_compressed(filepath, depth=depth, plane=plane, score=score)
-
-    def load_clean_depthmap(self, image):
-        o = np.load(self._depthmap_file(image, 'clean.npz'))
-        return o['depth'], o['plane'], o['score']
-
-    def pruned_depthmap_exists(self, image):
-        return os.path.isfile(self._depthmap_file(image, 'pruned.npz'))
-
-    def save_pruned_depthmap(self, image, points, normals, colors, labels, detections):
-        io.mkdir_p(self._depthmap_path())
-        filepath = self._depthmap_file(image, 'pruned.npz')
-        np.savez_compressed(filepath,
-                            points=points, normals=normals,
-                            colors=colors, labels=labels,
-                            detections=detections)
-
-    def load_pruned_depthmap(self, image):
-        o = np.load(self._depthmap_file(image, 'pruned.npz'))
-        if 'detections' not in o:
-            return o['points'], o['normals'], o['colors'], o['labels'], np.zeros(o['labels'].shape)
-        else:
-            return o['points'], o['normals'], o['colors'], o['labels'], o['detections']
 
     def _is_image_file(self, filename):
         extensions = {'jpg', 'jpeg', 'png', 'tif', 'tiff', 'pgm', 'pnm', 'gif'}
@@ -549,12 +380,6 @@ class DataSet(object):
         with io.open_wt(self._tracks_graph_file(filename)) as fout:
             tracking.save_tracks_graph(fout, graph)
 
-    def load_undistorted_tracks_graph(self):
-        return self.load_tracks_graph('undistorted/tracks.csv')
-
-    def save_undistorted_tracks_graph(self, graph):
-        return self.save_tracks_graph(graph, 'undistorted/tracks.csv')
-
     def _reconstruction_file(self, filename):
         """Return path of reconstruction file"""
         return os.path.join(self.data_path, filename or 'reconstruction.json')
@@ -570,15 +395,6 @@ class DataSet(object):
     def save_reconstruction(self, reconstruction, filename=None, minify=False):
         with io.open_wt(self._reconstruction_file(filename)) as fout:
             io.json_dump(io.reconstructions_to_json(reconstruction), fout, minify)
-
-    def load_undistorted_reconstruction(self):
-        return self.load_reconstruction(
-            filename='undistorted/reconstruction.json')
-
-    def save_undistorted_reconstruction(self, reconstruction):
-        io.mkdir_p(self._undistorted_path())
-        return self.save_reconstruction(
-            reconstruction, filename='undistorted/reconstruction.json')
 
     def _reference_lla_path(self):
         return os.path.join(self.data_path, 'reference_lla.json')
@@ -760,11 +576,201 @@ class DataSet(object):
         logger.warning("image_as_array() is deprecated. Use load_image() instead.")
         return self.load_image(image)
 
-    def undistorted_image_as_array(self, image):
-        logger.warning("undistorted_image_as_array() is deprecated. "
-                       "Use load_undistorted_image() instead.")
-        return self.load_undistorted_image(image)
-
     def mask_as_array(self, image):
         logger.warning("mask_as_array() is deprecated. Use load_mask() instead.")
         return self.load_mask(image)
+
+
+class UndistortedDataSet(object):
+    """Accessors to the undistorted data of a dataset.
+
+    Data include undistorted images, masks, and segmentation as well
+    the undistorted reconstruction, tracks graph and computed depth maps.
+
+    All data is stored inside a single folder which should be a subfolder
+    of the base, distorted dataset.
+    """
+    def __init__(self, base_dataset, undistorted_subfolder):
+        """Init dataset associated to a folder."""
+        self.base = base_dataset
+        self.config = self.base.config
+        self.subfolder = undistorted_subfolder
+        self.data_path = os.path.join(self.base.data_path, self.subfolder)
+
+    def _undistorted_image_path(self):
+        return os.path.join(self.data_path, 'images')
+
+    def _undistorted_image_file(self, image):
+        """Path of undistorted version of an image."""
+        image_format = self.config['undistorted_image_format']
+        filename = image + '.' + image_format
+        return os.path.join(self._undistorted_image_path(), filename)
+
+    def load_undistorted_image(self, image):
+        """Load undistorted image pixels as a numpy array."""
+        return io.imread(self._undistorted_image_file(image))
+
+    def save_undistorted_image(self, image, array):
+        """Save undistorted image pixels."""
+        io.mkdir_p(self._undistorted_image_path())
+        io.imwrite(self._undistorted_image_file(image), array)
+
+    def undistorted_image_size(self, image):
+        """Height and width of the undistorted image."""
+        return io.image_size(self._undistorted_image_file(image))
+
+    def _undistorted_mask_path(self):
+        return os.path.join(self.data_path, 'masks')
+
+    def _undistorted_mask_file(self, image):
+        """Path of undistorted version of a mask."""
+        return os.path.join(self._undistorted_mask_path(), image + '.png')
+
+    def undistorted_mask_exists(self, image):
+        """Check if the undistorted mask file exists."""
+        return os.path.isfile(self._undistorted_mask_file(image))
+
+    def load_undistorted_mask(self, image):
+        """Load undistorted mask pixels as a numpy array."""
+        return io.imread(self._undistorted_mask_file(image), grayscale=True)
+
+    def save_undistorted_mask(self, image, array):
+        """Save the undistorted image mask."""
+        io.mkdir_p(self._undistorted_mask_path())
+        io.imwrite(self._undistorted_mask_file(image), array)
+
+    def _undistorted_detection_path(self):
+        return os.path.join(self.data_path, 'detections')
+
+    def _undistorted_detection_file(self, image):
+        """Path of undistorted version of a detection."""
+        return os.path.join(self._undistorted_detection_path(), image + '.png')
+
+    def undistorted_detection_exists(self, image):
+        """Check if the undistorted detection file exists."""
+        return os.path.isfile(self._undistorted_detection_file(image))
+
+    def load_undistorted_detection(self, image):
+        """Load an undistorted image detection."""
+        return io.imread(self._undistorted_detection_file(image),
+                         grayscale=True)
+
+    def save_undistorted_detection(self, image, array):
+        """Save the undistorted image detection."""
+        io.mkdir_p(self._undistorted_detection_path())
+        io.imwrite(self._undistorted_detection_file(image), array)
+
+    def _undistorted_segmentation_path(self):
+        return os.path.join(self.data_path, 'segmentations')
+
+    def _undistorted_segmentation_file(self, image):
+        """Path of undistorted version of a segmentation."""
+        return os.path.join(self._undistorted_segmentation_path(), image + '.png')
+
+    def undistorted_segmentation_exists(self, image):
+        """Check if the undistorted segmentation file exists."""
+        return os.path.isfile(self._undistorted_segmentation_file(image))
+
+    def load_undistorted_segmentation(self, image):
+        """Load an undistorted image segmentation."""
+        return io.imread(self._undistorted_segmentation_file(image),
+                         grayscale=True)
+
+    def save_undistorted_segmentation(self, image, array):
+        """Save the undistorted image segmentation."""
+        io.mkdir_p(self._undistorted_segmentation_path())
+        io.imwrite(self._undistorted_segmentation_file(image), array)
+
+    def load_undistorted_segmentation_mask(self, image):
+        """Build a mask from the undistorted segmentation.
+
+        The mask is non-zero only for pixels with segmentation
+        labels not in segmentation_ignore_values.
+        """
+        ignore_values = self.base.segmentation_ignore_values(image)
+        if not ignore_values:
+            return None
+
+        segmentation = self.load_undistorted_segmentation(image)
+        if segmentation is None:
+            return None
+
+        return self.base._mask_from_segmentation(segmentation, ignore_values)
+
+    def load_undistorted_combined_mask(self, image):
+        """Combine undistorted binary mask with segmentation mask.
+
+        Return a mask that is non-zero only where the binary
+        mask and the segmentation mask are non-zero.
+        """
+        mask = None
+        if self.undistorted_mask_exists(image):
+            mask = self.load_undistorted_mask(image)
+        smask = None
+        if self.undistorted_segmentation_exists(image):
+            smask = self.load_undistorted_segmentation_mask(image)
+        return self.base._combine_masks(mask, smask)
+
+    def _depthmap_path(self):
+        return os.path.join(self.data_path, 'depthmaps')
+
+    def _depthmap_file(self, image, suffix):
+        """Path to the depthmap file"""
+        return os.path.join(self._depthmap_path(), image + '.' + suffix)
+
+    def raw_depthmap_exists(self, image):
+        return os.path.isfile(self._depthmap_file(image, 'raw.npz'))
+
+    def save_raw_depthmap(self, image, depth, plane, score, nghbr, nghbrs):
+        io.mkdir_p(self._depthmap_path())
+        filepath = self._depthmap_file(image, 'raw.npz')
+        np.savez_compressed(filepath, depth=depth, plane=plane, score=score, nghbr=nghbr, nghbrs=nghbrs)
+
+    def load_raw_depthmap(self, image):
+        o = np.load(self._depthmap_file(image, 'raw.npz'))
+        return o['depth'], o['plane'], o['score'], o['nghbr'], o['nghbrs']
+
+    def clean_depthmap_exists(self, image):
+        return os.path.isfile(self._depthmap_file(image, 'clean.npz'))
+
+    def save_clean_depthmap(self, image, depth, plane, score):
+        io.mkdir_p(self._depthmap_path())
+        filepath = self._depthmap_file(image, 'clean.npz')
+        np.savez_compressed(filepath, depth=depth, plane=plane, score=score)
+
+    def load_clean_depthmap(self, image):
+        o = np.load(self._depthmap_file(image, 'clean.npz'))
+        return o['depth'], o['plane'], o['score']
+
+    def pruned_depthmap_exists(self, image):
+        return os.path.isfile(self._depthmap_file(image, 'pruned.npz'))
+
+    def save_pruned_depthmap(self, image, points, normals, colors, labels, detections):
+        io.mkdir_p(self._depthmap_path())
+        filepath = self._depthmap_file(image, 'pruned.npz')
+        np.savez_compressed(filepath,
+                            points=points, normals=normals,
+                            colors=colors, labels=labels,
+                            detections=detections)
+
+    def load_pruned_depthmap(self, image):
+        o = np.load(self._depthmap_file(image, 'pruned.npz'))
+        if 'detections' not in o:
+            return o['points'], o['normals'], o['colors'], o['labels'], np.zeros(o['labels'].shape)
+        else:
+            return o['points'], o['normals'], o['colors'], o['labels'], o['detections']
+
+    def load_undistorted_tracks_graph(self):
+        return self.base.load_tracks_graph(os.path.join(self.subfolder, 'tracks.csv'))
+
+    def save_undistorted_tracks_graph(self, graph):
+        return self.base.save_tracks_graph(graph, os.path.join(self.subfolder, 'tracks.csv'))
+
+    def load_undistorted_reconstruction(self):
+        return self.base.load_reconstruction(
+            filename=os.path.join(self.subfolder, 'reconstruction.json'))
+
+    def save_undistorted_reconstruction(self, reconstruction):
+        io.mkdir_p(self.data_path)
+        return self.base.save_reconstruction(
+            reconstruction, filename=os.path.join(self.subfolder, 'reconstruction.json'))

--- a/opensfm/dense.py
+++ b/opensfm/dense.py
@@ -20,7 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def compute_depthmaps(data, graph, reconstruction):
-    """Compute and refine depthmaps for all shots."""
+    """Compute and refine depthmaps for all shots.
+
+    Args:
+        data: an UndistortedDataset
+        graph: the tracks graph
+        reconstruction: the undistorted reconstruction
+    """
     logger.info('Computing neighbors')
     config = data.config
     processes = config['processes']

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,8 @@ testpaths = opensfm
 norecursedirs = opensfm/src
 addopts = --doctest-modules
 
+[flake8]
+ignore = E402
+
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
This PR moves all files related to undistorted reconstructions to the `undistorted` subfolder. This includes undistorted images, masks, reconstructions, and depth maps. This makes it easier to have different undistorted versions of a reconstruction or to store them in other subfolders while decluttering the main folder.

The dataset methods related to undistorted data are moved to a new `UndistortedDataSet` class which keeps track of which subfolder the undistorted data is in.

This PR breaks the folder structure compatibility because depthmaps are stored in a different place. We should release a version before merging this so we can refer to it as the most recent using the older folder structure.

The new folder structure looks like tihs:
```
project/
├── config.yaml
├── images/
├── masks/
├── gcp_list.txt
├── exif/
├── camera_models.json
├── features/
├── matches/
├── tracks.csv
├── reconstruction.json
├── reconstruction.meshed.json
└── undistorted/
    ├── images/
    ├── masks/
    ├── tracks.csv
    ├── reconstruction.json
    └── depthmaps/
        └── merged.ply
```

The script `bin/migrate_undistort.sh` can be used to migrate existing datasets to the new folder structure.