### PR TITLE
Add --image_list option to export_visualsfm

### DIFF
--- a/opensfm/commands/export_visualsfm.py
+++ b/opensfm/commands/export_visualsfm.py
@@ -62,8 +62,8 @@ class Command:
             i += 1
 
             if type(shot.camera) == types.BrownPerspectiveCamera:
-                # Will aproximate Brown model, not optimal
-                focal_normalized = shot.camera.focal_x
+                # Will approximate Brown model, not optimal
+                focal_normalized = (shot.camera.focal_x + shot.camera.focal_y) / 2.0
             else:
                 focal_normalized = shot.camera.focal
 


### PR DESCRIPTION
Hello :hand:

This PR proposes the addition of a `--image_list` option to the `export_visualsfm` program. This can be useful for cases where a subset of the reconstruction needs to be exported (for example, to extract the reconstruction for a particular camera in datasets that may use multiple cameras).

The default behavior of the program is unchanged.

It also changes the brown model approximation to include both `focal_x` and `focal_y` (to be consistent with https://github.com/mapillary/OpenSfM/blob/master/opensfm/commands/undistort.py#L249)

Please let me know if this could be of use to the project and if changes are needed. :pray: 