### PR TITLE
use IMREAD_UNCHANGED for undistort

### DIFF
--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -97,7 +97,7 @@ def undistort_image_and_masks(arguments):
     logger.debug('Undistorting image {}'.format(shot.id))
 
     # Undistort image
-    image = data.load_image(shot.id, anydepth=True)
+    image = data.load_image(shot.id, unchanged=True, anydepth=True)
     if image is not None:
         max_size = data.config['undistorted_image_max_size']
         undistorted = undistort_image(shot, undistorted_shots, image,

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -66,13 +66,13 @@ class DataSet(object):
         """Open image file and return file object."""
         return open(self._image_file(image), 'rb')
 
-    def load_image(self, image, anydepth=False):
+    def load_image(self, image, unchanged=False, anydepth=False):
         """Load image pixels as numpy array.
 
         The array is 3D, indexed by y-coord, x-coord, channel.
         The channels are in RGB order.
         """
-        return io.imread(self._image_file(image), anydepth=anydepth)
+        return io.imread(self._image_file(image), unchanged=unchanged, anydepth=anydepth)
 
     def image_size(self, image):
         """Height and width of the image."""


### PR DESCRIPTION
Hello :hand:

This PR proposes the addition of the `IMREAD_UNCHANGED` flag to the undistort command.

Reason:

When loading images with a single band or N-band (!= 3) camera, OpenCV will convert the image to a 3 channel image (losing the original band information).

Discussion for breaking changes and additional features:

This may break certain applications *if* such applications take as input single band or N-band images (N != 3) and make assumptions that the output of undistortion is always a 3 band RGB image. If that's the case, perhaps it might be beneficial to add a `--unchanged` or `--preserve-bands` flag to the undistort command. If that's the case, please let me know and I'll add it. :pray: 