### PR TITLE
Add Python3 http.server command.

### DIFF
--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -15,6 +15,7 @@ An example dataset is available at ``data/berlin``.  You can reconstruct it usin
 This will run the entire SfM pipeline and produce the file ``data/berlin/reconstruction.meshed.json`` as output. To visualize the result you can start a HTTP server running::
 
     python -m SimpleHTTPServer
+    python3 -m http.server
 
 and then browse `<http://localhost:8000/viewer/reconstruction.html#file=/data/berlin/reconstruction.meshed.json>`_
 You should see something like


### PR DESCRIPTION
Python3 has a slightly different command for launching an HTTP server. This pull request adds that command to `using.rst`.