### PR TITLE
[Bug] Return default calib values for brown camera

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -412,6 +412,10 @@ def focal_xy_calibration(exif):
 def default_calibration(data):
     return {
         'focal': data.config['default_focal_prior'],
+        'focal_x': data.config['default_focal_prior'],
+        'focal_y': data.config['default_focal_prior'],
+        'c_x': 0.0,
+        'c_y': 0.0,
         'k1': 0.0,
         'k2': 0.0,
         'p1': 0.0,


### PR DESCRIPTION
Hello :hand:

This is a simple fix for a problem I encountered while processing a dataset.

If the camera model is `brown` and the code ends up calling `default_calibration`, the resulting dictionary does not include the necessary keys to initialize the brown model (which ends up triggering an exception when accessing `focal_x`).

Specifically, if this line is called https://github.com/mapillary/OpenSfM/blob/1eab045b4565d4f3ab8669d23908daa693761341/opensfm/exif.py#L448 followed by https://github.com/mapillary/OpenSfM/blob/1eab045b4565d4f3ab8669d23908daa693761341/opensfm/exif.py#L454 the program crashes.

Returning the proper dict keys fixes the problem.

