### PR TITLE
Set GPS DOP value to 15 (default) if EXIF reports it as 0

### DIFF
--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -510,6 +510,8 @@ def get_image_metadata(data, image):
         x, y, z = reference.to_topocentric(lat, lon, alt)
         metadata.gps_position = [x, y, z]
         metadata.gps_dop = exif['gps'].get('dop', 15.0)
+        if metadata.gps_dop == 0.0:
+            metadata.gps_dop = 15.0
     else:
         metadata.gps_position = [0.0, 0.0, 0.0]
         metadata.gps_dop = 999999.0


### PR DESCRIPTION
I've found that certain cameras report a GPS DOP value of 0. I interpret this as meaning "no data" instead of indicating absolute precision (that doesn't seem possible).

I can post examples of problems with reconstructions when GPS DOP is set to zero if needed.

Let me know your thoughts?