### PR TITLE
feat: use opengv iteration control

### DIFF
--- a/bin/plot_inliers
+++ b/bin/plot_inliers
@@ -551,7 +551,8 @@ def plot_two_view_reconstruction(fw, ip, index, track_points1, track_points2, da
     camera2 = cameras[data.load_exif(ip.im2)['camera']]
 
     threshold, pixels1, pixels2 = thresholds(ip.im1_array, ip.im2_array, 'five_point_algo_threshold', 0.006, data)
-    R, t, inliers = reconstruct.two_view_reconstruction(track_points1, track_points2, camera1, camera2, threshold)
+    iterations = data.config['five_point_refine_rec_iterations']
+    R, t, inliers = reconstruct.two_view_reconstruction(track_points1, track_points2, camera1, camera2, threshold, iterations)
 
     inliers1 = track_points1[inliers, :]
     inliers2 = track_points2[inliers, :]

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -66,9 +66,9 @@ matching_bow_gps_distance: 0          # Maximum GPS distance for preempting imag
 matching_bow_gps_neighbors: 0         # Number of images (selected by GPS distance) to preempt before using selection by BoW distance. Set to 0 to use no limit (or disable if matching_bow_gps_distance is also 0)
 matching_bow_other_cameras: False     # If True, BoW image selection will use N neighbors from the same camera + N neighbors from any different camera.
 matching_vlad_neighbors: 0            # Number of images to match selected by VLAD distance. Set to 0 to disable
-matching_vlad_gps_distance: 0          # Maximum GPS distance for preempting images before using selection by VLAD distance. Set to 0 to disable
-matching_vlad_gps_neighbors: 0         # Number of images (selected by GPS distance) to preempt before using selection by VLAD distance. Set to 0 to use no limit (or disable if matching_vlad_gps_distance is also 0)
-matching_vlad_other_cameras: False     # If True, VLAD image selection will use N neighbors from the same camera + N neighbors from any different camera.
+matching_vlad_gps_distance: 0         # Maximum GPS distance for preempting images before using selection by VLAD distance. Set to 0 to disable
+matching_vlad_gps_neighbors: 0        # Number of images (selected by GPS distance) to preempt before using selection by VLAD distance. Set to 0 to use no limit (or disable if matching_vlad_gps_distance is also 0)
+matching_vlad_other_cameras: False    # If True, VLAD image selection will use N neighbors from the same camera + N neighbors from any different camera.
 matching_use_filters: False           # If True, removes static matches using ad-hoc heuristics
 
 # Params for geometric estimation
@@ -77,6 +77,8 @@ robust_matching_calib_threshold: 0.004  # Outlier threshold for essential matrix
 robust_matching_min_match: 20           # Minimum number of matches to accept matches between two images
 five_point_algo_threshold: 0.004        # Outlier threshold for essential matrix estimation during incremental reconstruction in radians
 five_point_algo_min_inliers: 20         # Minimum number of inliers for considering a two view reconstruction valid
+five_point_refine_match_iterations: 10  # Number of LM iterations to run when refining relative pose during matching
+five_point_refine_rec_iterations: 1000  # Number of LM iterations to run when refining relative pose during reconstruction
 triangulation_threshold: 0.006          # Outlier threshold for accepting a triangulated point in radians
 triangulation_min_ray_angle: 1.0        # Minimum angle between views to accept a triangulated point
 triangulation_type: FULL                # Triangulation type : either considering all rays (FULL), or sing a RANSAC variant (ROBUST)

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -418,8 +418,9 @@ def robust_match_calibrated(p1, p2, camera1, camera2, matches, config):
         inliers = _compute_inliers_bearings(b1, b2, T, relax * threshold)
         if sum(inliers) < 8:
             return np.array([])
+        iterations = config['five_point_refine_match_iterations']
         T = pyopengv.relative_pose_optimize_nonlinear(
-            b1[inliers], b2[inliers], T[:3, 3], T[:3, :3])
+            b1[inliers], b2[inliers], T[:3, 3], T[:3, :3], iterations)
 
     inliers = _compute_inliers_bearings(b1, b2, T, threshold)
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -419,7 +419,7 @@ def robust_match_calibrated(p1, p2, camera1, camera2, matches, config):
         if sum(inliers) < 8:
             return np.array([])
         iterations = config['five_point_refine_match_iterations']
-        T = pyopengv.relative_pose_optimize_nonlinear(
+        T = multiview.relative_pose_optimize_nonlinear(
             b1[inliers], b2[inliers], T[:3, 3], T[:3, :3], iterations)
 
     inliers = _compute_inliers_bearings(b1, b2, T, threshold)

--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -596,4 +596,8 @@ def relative_pose_ransac_rotation_only(b1, b2, threshold, iterations,
 
 
 def relative_pose_optimize_nonlinear(b1, b2, t, R, iterations):
-    return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R, iterations)
+    try:
+        return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R, iterations)
+    except Exception:
+        # Current master of pyopengv do not accept the iterations argument.
+        return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R)

--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -595,5 +595,5 @@ def relative_pose_ransac_rotation_only(b1, b2, threshold, iterations,
             b1, b2, threshold, iterations)
 
 
-def relative_pose_optimize_nonlinear(b1, b2, t, R):
-    return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R)
+def relative_pose_optimize_nonlinear(b1, b2, t, R, iterations):
+    return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R, iterations)


### PR DESCRIPTION
This PR aims at speeding-up the matching by reducing the number or iterations during nonlinear refinement of the relative pose, leveraging a patch to opengv that allow such.

We do 10 iterations during matching, and 1K (default) during two view reconstruction. Experiments shows a nice speed-up (1.6x factor) and no regression in matching results.