### PR TITLE
feat: in-house relative pose refinement

### DIFF
--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -421,7 +421,7 @@ def robust_match_calibrated(p1, p2, camera1, camera2, matches, config):
             return np.array([])
         iterations = config['five_point_refine_match_iterations']
         T = multiview.relative_pose_optimize_nonlinear(
-            b1[inliers], b2[inliers], T[:3, 3], T[:3, :3], iterations)
+            b1[inliers], b2[inliers], b"STEWENIUS", T[:3, 3], T[:3, :3], iterations)
 
     inliers = _compute_inliers_bearings(b1, b2, T, threshold)
 

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -6,6 +6,7 @@ import logging
 from timeit import default_timer as timer
 from collections import defaultdict
 
+from opensfm import pygeometry
 from opensfm import pyfeatures
 from opensfm import context
 from opensfm import log
@@ -386,7 +387,7 @@ def robust_match_fundamental(p1, p2, matches, config):
 def _compute_inliers_bearings(b1, b2, T, threshold=0.01):
     R = T[:, :3]
     t = T[:, 3]
-    p = pyopengv.triangulation_triangulate(b1, b2, t, R)
+    p = pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t)
 
     br1 = p.copy()
     br1 /= np.linalg.norm(br1, axis=1)[:, np.newaxis]
@@ -416,7 +417,7 @@ def robust_match_calibrated(p1, p2, camera1, camera2, matches, config):
 
     for relax in [4, 2, 1]:
         inliers = _compute_inliers_bearings(b1, b2, T, relax * threshold)
-        if sum(inliers) < 8:
+        if np.sum(inliers) < 8:
             return np.array([])
         iterations = config['five_point_refine_match_iterations']
         T = multiview.relative_pose_optimize_nonlinear(

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -387,7 +387,7 @@ def robust_match_fundamental(p1, p2, matches, config):
 def _compute_inliers_bearings(b1, b2, T, threshold=0.01):
     R = T[:, :3]
     t = T[:, 3]
-    p = pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t)
+    p = np.array(pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t))
 
     br1 = p.copy()
     br1 /= np.linalg.norm(br1, axis=1)[:, np.newaxis]

--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -619,7 +619,7 @@ def relative_pose_ransac_rotation_only(b1, b2, threshold, iterations,
             b1, b2, threshold, iterations)
 
 
-def relative_pose_optimize_nonlinear(b1, b2, t, R, iterations):
+def relative_pose_optimize_nonlinear(b1, b2, method, t, R, iterations):
     # in-house refinement
     if method == 'mapillary':
         Rt = np.zeros((3, 4))

--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -8,6 +8,7 @@ import numpy as np
 import pyopengv
 
 from opensfm import pyrobust
+from opensfm import pygeometry
 from opensfm import transformations as tf
 
 
@@ -619,8 +620,20 @@ def relative_pose_ransac_rotation_only(b1, b2, threshold, iterations,
 
 
 def relative_pose_optimize_nonlinear(b1, b2, t, R, iterations):
-    try:
-        return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R, iterations)
-    except Exception:
-        # Current master of pyopengv do not accept the iterations argument.
-        return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R)
+    # in-house refinement
+    if method == 'mapillary':
+        Rt = np.zeros((3, 4))
+        Rt[:3, :3] = R.T
+        Rt[:, 3] = -R.T.dot(t)
+        Rt_refined = pygeometry.relative_pose_refinement(Rt, b1, b2, iterations)
+
+        R, t = Rt_refined[:3, :3].copy(), Rt_refined[:, 3].copy()
+        Rt[:3, :3] = R.T
+        Rt[:, 3] = -R.T.dot(t)
+        return Rt
+    else:
+        try:
+            return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R, iterations)
+        except Exception:
+            # Current master of pyopengv do not accept the iterations argument.
+            return pyopengv.relative_pose_optimize_nonlinear(b1, b2, t, R)

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -11,7 +11,6 @@ from itertools import combinations
 import cv2
 import numpy as np
 import networkx as nx
-import pyopengv
 import six
 from timeit import default_timer as timer
 from six import iteritems
@@ -546,7 +545,7 @@ def _two_view_reconstruction_inliers(b1, b2, R, t, threshold):
     Returns:
         array: Inlier indices.
     """
-    p = pyopengv.triangulation_triangulate(b1, b2, t, R)
+    p = pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t)
 
     br1 = p.copy()
     br1 /= np.linalg.norm(br1, axis=1)[:, np.newaxis]
@@ -622,7 +621,9 @@ def two_view_reconstruction(p1, p2, camera1, camera2,
 
     if inliers.sum() > 5:
         T = multiview.relative_pose_optimize_nonlinear(b1[inliers],
-                                                       b2[inliers], t, R,
+                                                       b2[inliers], 
+                                                       b"STEWENIUS",
+                                                       t, R,
                                                        iterations)
         R = T[:, :3]
         t = T[:, 3]

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -545,7 +545,7 @@ def _two_view_reconstruction_inliers(b1, b2, R, t, threshold):
     Returns:
         array: Inlier indices.
     """
-    p = pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t)
+    p = np.array(pygeometry.triangulate_two_bearings_midpoint_many(b1, b2, R, t))
 
     br1 = p.copy()
     br1 /= np.linalg.norm(br1, axis=1)[:, np.newaxis]

--- a/opensfm/src/geometry/pose.h
+++ b/opensfm/src/geometry/pose.h
@@ -2,6 +2,9 @@
 
 #include <Eigen/Eigen>
 #include <Eigen/SVD>
+#include <ceres/tiny_solver.h>
+#include <ceres/rotation.h>
+#include <ceres/tiny_solver_autodiff_function.h>
 #include "triangulation.h"
 
 template <class IT>
@@ -26,9 +29,9 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
        1, 0, 0, 
        0, 0, 1;
 
-  Eigen::Matrix<double, 3, 2> bearings;
-  Eigen::Matrix<double, 3, 2> centers;
-  centers.col(0) << Eigen::Vector3d::Zero();
+  Eigen::Matrix<double, 2, 3> bearings;
+  Eigen::Matrix<double, 2, 3> centers;
+  centers.row(0) << Eigen::Vector3d::Zero();
 
   auto best_decomposition = std::make_pair(0, Eigen::Matrix<double, 3, 4>());
   for (int i = 0; i < 2; ++i) {
@@ -46,16 +49,18 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
       } else {
         rotation = U * W.transpose() * Vt;
       }
-      centers.col(1) << -rotation.transpose()*translation;
+
+      // Since rotation=Rcamera and translation=Tcamera parametrization
+      centers.row(1) << -rotation.transpose()*translation;
 
       int are_in_front = 0;
       for (IT it = begin; it != end; ++it) {
-        bearings.col(0) << it->first;
-        bearings.col(1) << rotation.transpose()*it->second;
-        const auto point = geometry::TriangulateBearingsMidpointSolve(centers, bearings);
+        bearings.row(0) << it->first;
+        bearings.row(1) << rotation.transpose()*it->second;
+        const Eigen::Vector3d point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
         const bool is_in_front =
-            bearings.col(0).dot(point) > 0.0 &&
-            bearings.col(1).dot(rotation * point + translation) > 0.0;
+            bearings.row(0).dot(point) > 0.0 &&
+            bearings.row(1).dot(rotation * point + translation) > 0.0;
         are_in_front += is_in_front;
 
         const auto maximum_possible = are_in_front + (end - it);
@@ -72,12 +77,88 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
       }
     }
   }
+
+  // Rcamera and Tcamera parametrization
   return best_decomposition.second;
 }
 
+template< class IT >
+struct RelativePoseCost {
+  RelativePoseCost(IT begin, IT end): begin_(begin), end_(end){}
+  int NumResiduals() const {
+    return (end_-begin_)+1;
+  }
+
+  template<typename T>
+  bool operator()(const T* const parameters, T* residuals) const {
+    Eigen::Map<const Eigen::Matrix<T, 3, 1>> rotation(parameters);
+    Eigen::Map<const Eigen::Matrix<T, 3, 1>> translation(parameters+3);
+    Eigen::Matrix<T, 3, 1> rotation_transpose = -rotation;
+    Eigen::Matrix<T, 3, 1> minus_translation = -translation;
+
+    Eigen::Matrix<T, 2, 3> bearings;
+    Eigen::Matrix<T, 2, 3> centers;
+    centers.row(0) << Eigen::Matrix<T, 3, 1>::Zero();
+    centers.row(1) << translation;
+    Eigen::Matrix<T, 3, 1> some_tmp = Eigen::Matrix<T, 3, 1>::Zero();
+
+    int count = 0;
+    for (IT it = begin_; it != end_; ++it) {
+      const Eigen::Matrix<T, 3, 1> x = it->first.template cast<T>();
+      const Eigen::Matrix<T, 3, 1> y = it->second.template cast<T>();
+
+      // Bearing : x stay at identity, y is brought to the world with R(t)
+      bearings.row(0) << x;
+      ceres::AngleAxisRotatePoint(rotation_transpose.data(), y.data(), bearings.row(1).data());
+
+      // Triangulate
+      auto point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
+
+      // Point in x stays at identy, y is brought in second camera with R*(y-t)
+      const auto projected_x = point.normalized();
+      const Eigen::Matrix<T, 3, 1> y_centered = point-translation;
+      ceres::AngleAxisRotatePoint(rotation.data(), y_centered.data(), some_tmp.data());
+      const auto projected_y = some_tmp.normalized();
+      residuals[0] += 1.0 - ((projected_x.dot(x) + projected_y.dot(y))*T(0.5));
+    }
+    residuals[1] = 1.0 - translation.norm();
+  }
+  IT begin_;
+  IT end_;
+};
+
+template <class IT>
+Eigen::Matrix<double, 3, 4> RelativePoseRefinement(
+  const Eigen::Matrix<double, 3, 4>& relative_pose, IT begin, IT end, int iterations) {
+  Eigen::Matrix<double, 6, 1> parameters;
+  parameters.setZero();
+
+  // Use Rcamera and Tworld parametrization
+  ceres::RotationMatrixToAngleAxis(relative_pose.block<3, 3>(0, 0).data(), parameters.data());
+  parameters.tail<3>(3) = -relative_pose.block<3, 3>(0, 0).transpose()*relative_pose.col(3);
+
+  using RelativePoseFunction = ceres::TinySolverAutoDiffFunction<RelativePoseCost<IT>, 2, 6>;
+  RelativePoseCost<IT> cost(begin, end);
+  RelativePoseFunction f(cost);
+
+  ceres::TinySolver<RelativePoseFunction> solver;
+  solver.options.max_num_iterations = iterations;
+  solver.Solve(f, &parameters);
+
+  // Back with Tcamera parametrization
+  Eigen::Matrix<double, 3, 4> relative_pose_result;
+  ceres::AngleAxisToRotationMatrix(parameters.data(), relative_pose_result.block<3, 3>(0, 0).data());
+  relative_pose_result.col(3) = -relative_pose_result.block<3, 3>(0, 0)*parameters.tail<3>(3);
+  return relative_pose_result;
+}
 namespace geometry {
 Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
     const Eigen::Matrix3d& essential,
     const Eigen::Matrix<double, -1, 3> &x1,
     const Eigen::Matrix<double, -1, 3> &x2);
+Eigen::Matrix<double, 3, 4> RelativePoseRefinement(
+    const Eigen::Matrix<double, 3, 4>& relative_pose,
+    const Eigen::Matrix<double, -1, 3> &x1,
+    const Eigen::Matrix<double, -1, 3> &x2,
+    int iterations);
 }

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -12,7 +12,10 @@
 PYBIND11_MODULE(pygeometry, m) {
   m.def("triangulate_bearings_dlt", geometry::TriangulateBearingsDLT);
   m.def("triangulate_bearings_midpoint", geometry::TriangulateBearingsMidpoint);
+  m.def("triangulate_two_bearings_midpoint", geometry::TriangulateTwoBearingsMidpointSolve<double>);
+  m.def("triangulate_two_bearings_midpoint_many", geometry::TriangulateTwoBearingsMidpointMany);
   m.def("essential_five_points", geometry::EssentialFivePoints);
   m.def("essential_n_points", geometry::EssentialNPoints);
   m.def("relative_pose_from_essential", geometry::RelativePoseFromEssential);
+  m.def("relative_pose_refinement", geometry::RelativePoseRefinement);
 }

--- a/opensfm/src/geometry/src/pose.cc
+++ b/opensfm/src/geometry/src/pose.cc
@@ -15,4 +15,20 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
   }
   return ::RelativePoseFromEssential(essential, samples.begin(), samples.end());
 }
+
+Eigen::Matrix<double, 3, 4> RelativePoseRefinement(
+    const Eigen::Matrix<double, 3, 4>& relative_pose,
+    const Eigen::Matrix<double, -1, 3> &x1,
+    const Eigen::Matrix<double, -1, 3> &x2,
+    int iterations){
+  if((x1.cols() != x2.cols()) || (x1.rows() != x2.rows())){
+    throw std::runtime_error("Features matrices have different sizes.");
+  }
+  std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> samples(x1.rows());
+  for (int i = 0; i < x1.rows(); ++i) {
+    samples[i].first = x1.row(i).normalized();
+    samples[i].second = x2.row(i).normalized();
+  }
+  return ::RelativePoseRefinement(relative_pose, samples.begin(), samples.end(), iterations);
+}
 }

--- a/opensfm/src/geometry/src/triangulation.cc
+++ b/opensfm/src/geometry/src/triangulation.cc
@@ -96,7 +96,7 @@ py::object TriangulateBearingsMidpoint(const Eigen::Matrix<double, -1, 3> &cente
                                        const Eigen::Matrix<double, -1, 3> &bearings,
                                        const std::vector<double>&threshold_list,
                                        double min_angle) {
-  const int count = os.rows();
+  const int count = centers.rows();
 
   // Check angle between rays
   bool angle_ok = false;
@@ -117,7 +117,7 @@ py::object TriangulateBearingsMidpoint(const Eigen::Matrix<double, -1, 3> &cente
 
   // Check reprojection error
   for (int i = 0; i < count; ++i) {
-    const auto projected = X - os.row(i).transpose();
+    const auto projected = X - centers.row(i).transpose();
     const auto measured = bearings.row(i);
     if (AngleBetweenVectors(projected, measured) > threshold_list[i]) {
       return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::none());

--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -23,11 +23,12 @@ double AngleBetweenVectors(const Eigen::Vector3d &u, const Eigen::Vector3d &v);
 py::list TriangulateReturn(int error, py::object value);
 
 Eigen::Vector4d TriangulateBearingsDLTSolve(
-    const Eigen::Matrix<double, 3, -1> &bs,
+    const Eigen::Matrix<double, -1, 3> &bs,
     const std::vector< Eigen::Matrix<double, 3, 4> > &Rts);
 
-py::object TriangulateBearingsDLT(const py::list &Rts_list,
-                                  const py::list &bs_list, double threshold,
+py::object TriangulateBearingsDLT(const std::vector<Eigen::Matrix<double, 3, 4>> &Rts,
+                                  const Eigen::Matrix<double, -1, 3> &bearings,
+                                  double threshold,
                                   double min_angle);
 
 // Point minimizing the squared distance to all rays
@@ -35,13 +36,58 @@ py::object TriangulateBearingsDLT(const py::list &Rts_list,
 //   Srikumar Ramalingam, Suresh K. Lodha and Peter Sturm
 //   "A generic structure-from-motion framework"
 //   CVIU 2006
-Eigen::Vector3d TriangulateBearingsMidpointSolve(
-    const Eigen::Matrix<double, 3, -1> &os,
-    const Eigen::Matrix<double, 3, -1> &bs);
+template< class T >
+Eigen::Matrix<T, 3, 1> TriangulateBearingsMidpointSolve(
+    const Eigen::Matrix<T, -1, 3> &centers,
+    const Eigen::Matrix<T, -1, 3> &bearings){
+  int nviews = bearings.rows();
+  assert(nviews == centers.rows());
+  assert(nviews >= 2);
 
-py::object TriangulateBearingsMidpoint(const py::list &os_list,
-                                       const py::list &bs_list,
-                                       const py::list &threshold_list,
+  Eigen::Matrix<T, 3, 3> BBt;
+  Eigen::Matrix<T, 3, 1> BBtA, A;
+  BBt.setZero();
+  BBtA.setZero();
+  A.setZero();
+  for (int i = 0; i < nviews; ++i) {
+    BBt += bearings.row(i).transpose() * bearings.row(i);
+    BBtA += bearings.row(i).transpose() * bearings.row(i) * centers.row(i).transpose();
+    A += centers.row(i);
+  }
+  Eigen::Matrix<T, 3, 3> Cinv = (T(nviews) * Eigen::Matrix<T, 3, 3>::Identity() - BBt).inverse();
+
+  return (Eigen::Matrix<T, 3, 3>::Identity() + BBt * Cinv) * A / T(nviews) - Cinv * BBtA;
+}
+
+template< class T >
+Eigen::Matrix<T, 3, 1> TriangulateTwoBearingsMidpointSolve(
+    const Eigen::Matrix<T, 2, 3> &centers,
+    const Eigen::Matrix<T, 2, 3> &bearings)
+{
+  const auto translation = centers.row(1)-centers.row(0);
+  Eigen::Matrix<T, 2, 1>  b;
+  b[0] = translation.dot(bearings.row(0));
+  b[1] = translation.dot(bearings.row(1));
+  Eigen::Matrix<T, 2, 2> A;
+  A(0,0) = bearings.row(0).dot(bearings.row(0));
+  A(1,0) = bearings.row(0).dot(bearings.row(1));
+  A(0,1) = -A(1,0);
+  A(1,1) = -bearings.row(1).dot(bearings.row(1));
+  const auto lambdas = A.inverse() * b;
+  const auto x1 = centers.row(0) + lambdas[0] * bearings.row(0);
+  const auto x2 = centers.row(1) + lambdas[1] * bearings.row(1);
+  return (x1 + x2)/T(2.0);
+};
+
+std::vector<Eigen::Vector3d> TriangulateTwoBearingsMidpointMany(
+    const Eigen::Matrix<double, -1, 3> &bearings1,
+    const Eigen::Matrix<double, -1, 3> &bearings2,
+    const Eigen::Matrix3d& rotation,
+    const Eigen::Vector3d& translation);
+
+py::object TriangulateBearingsMidpoint(const Eigen::Matrix<double, -1, 3> &centers,
+                                       const Eigen::Matrix<double, -1, 3> &bearings,
+                                       const std::vector<double> &threshold_list,
                                        double min_angle);
 
 }  // namespace geometry

--- a/opensfm/src/robust/relative_pose_model.h
+++ b/opensfm/src/robust/relative_pose_model.h
@@ -39,13 +39,13 @@ class RelativePose : public Model<RelativePose, 1, 10> {
     const auto x = d.first.normalized();
     const auto y = d.second.normalized();
 
-    Eigen::Matrix<double, 3, 2> bearings;
-    Eigen::Matrix<double, 3, 2> centers;
-    centers.col(0) << Eigen::Vector3d::Zero();
-    centers.col(1) << -rotation.transpose()*translation;
-    bearings.col(0) << x;
-    bearings.col(1) << rotation.transpose()*y;
-    const auto point = geometry::TriangulateBearingsMidpointSolve(centers, bearings);
+    Eigen::Matrix<double, 2, 3> bearings;
+    Eigen::Matrix<double, 2, 3> centers;
+    centers.row(0) << Eigen::Vector3d::Zero();
+    centers.row(1) << -rotation.transpose()*translation;
+    bearings.row(0) << x;
+    bearings.row(1) << rotation.transpose()*y;
+    const auto point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
     const auto projected_x = point.normalized();
     const auto projected_y = (rotation*point+translation).normalized();
 

--- a/opensfm/src/robust/relative_pose_model.h
+++ b/opensfm/src/robust/relative_pose_model.h
@@ -41,10 +41,10 @@ class RelativePose : public Model<RelativePose, 1, 10> {
 
     Eigen::Matrix<double, 2, 3> bearings;
     Eigen::Matrix<double, 2, 3> centers;
-    centers.row(0) << Eigen::Vector3d::Zero();
-    centers.row(1) << -rotation.transpose()*translation;
-    bearings.row(0) << x;
-    bearings.row(1) << rotation.transpose()*y;
+    centers.row(0) = Eigen::Vector3d::Zero();
+    centers.row(1) = -rotation.transpose()*translation;
+    bearings.row(0) = x;
+    bearings.row(1) = rotation.transpose()*y;
     const auto point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
     const auto projected_x = point.normalized();
     const auto projected_y = (rotation*point+translation).normalized();

--- a/opensfm/test/test_multiview.py
+++ b/opensfm/test/test_multiview.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 
 from opensfm import multiview
@@ -75,3 +76,16 @@ def test_relative_pose_from_essential(one_pair_and_its_E):
     pose.translation /= np.linalg.norm(pose.translation)
     expected = pose.get_Rt()
     assert np.allclose(expected, result, rtol=1e-10)
+
+
+def test_relative_pose_refinement(one_pair_and_its_E):
+    f1, f2, _, pose = one_pair_and_its_E
+    pose.translation /= np.linalg.norm(pose.translation)
+
+    noisy_pose = copy.deepcopy(pose)
+    noisy_pose.translation += np.random.rand(3)*1e-2
+    noisy_pose.rotation += np.random.rand(3)*1e-2
+    result = pygeometry.relative_pose_refinement(noisy_pose.get_Rt(), f1, f2, 1000)
+
+    expected = pose.get_Rt()
+    assert np.linalg.norm(expected-result) < 5e-2

--- a/opensfm/test/test_triangulation.py
+++ b/opensfm/test/test_triangulation.py
@@ -54,6 +54,19 @@ def unit_vector(x):
     return np.array(x) / np.linalg.norm(x)
 
 
+def test_triangulate_bearings_dlt():
+    rt1 = np.append(np.identity(3), [[0], [0], [0]], axis=1)
+    rt2 = np.append(np.identity(3), [[-1], [0], [0]], axis=1)
+    b1 = unit_vector([0.0, 0, 1])
+    b2 = unit_vector([-1.0, 0, 1])
+    max_reprojection = 0.01
+    min_ray_angle = np.radians(2.0)
+    res, X = pygeometry.triangulate_bearings_dlt(
+        [rt1, rt2], [b1, b2], max_reprojection, min_ray_angle)
+    assert np.allclose(X, [0, 0, 1.0])
+    assert res == 0
+
+
 def test_triangulate_bearings_midpoint():
     o1 = np.array([0.0, 0, 0])
     b1 = unit_vector([0.0, 0, 1])
@@ -63,6 +76,16 @@ def test_triangulate_bearings_midpoint():
     min_ray_angle = np.radians(2.0)
     res, X = pygeometry.triangulate_bearings_midpoint(
         [o1, o2], [b1, b2], 2 * [max_reprojection], min_ray_angle)
-
     assert np.allclose(X, [0, 0, 1.0])
     assert res == 0
+
+
+def test_triangulate_two_bearings_midpoint():
+    o1 = np.array([0.0, 0, 0])
+    b1 = unit_vector([0.0, 0, 1])
+    o2 = np.array([1.0, 0, 0])
+    b2 = unit_vector([-1.0, 0, 1])
+    max_reprojection = 0.01
+    min_ray_angle = np.radians(2.0)
+    X = pygeometry.triangulate_two_bearings_midpoint([o1, o2], [b1, b2])
+    assert np.allclose(X, [0, 0, 1.0])


### PR DESCRIPTION
This PR move a step forward in removing `opengv` by implementing in-house relative pose refinement and two-view triangulation. We also refactored triangulation methods and add some additional unit tests.