### PR TITLE
feat: relative rotation

### DIFF
--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -645,15 +645,23 @@ def relative_pose_ransac(b1, b2, method, threshold, iterations, probability):
 
 def relative_pose_ransac_rotation_only(b1, b2, threshold, iterations,
                                        probability):
-    try:
-        return pyopengv.relative_pose_ransac_rotation_only(
-            b1, b2, threshold,
-            iterations=iterations,
-            probability=probability)
-    except Exception:
-        # Older versions of pyopengv do not accept the probability argument.
-        return pyopengv.relative_pose_ransac_rotation_only(
-            b1, b2, threshold, iterations)
+    # in-house estimation
+    if in_house_multiview:
+        threshold = np.arccos(1 - threshold)
+        params = pyrobust.RobustEstimatorParams()
+        params.iterations = 1000
+        result = pyrobust.ransac_relative_rotation(b1, b2, threshold, params, pyrobust.RansacType.RANSAC)
+        return result.lo_model.T
+    else:
+        try:
+            return pyopengv.relative_pose_ransac_rotation_only(
+                b1, b2, threshold,
+                iterations=iterations,
+                probability=probability)
+        except Exception:
+            # Older versions of pyopengv do not accept the probability argument.
+            return pyopengv.relative_pose_ransac_rotation_only(
+                b1, b2, threshold, iterations)
 
 
 def relative_pose_optimize_nonlinear(b1, b2, method, t, R, iterations):

--- a/opensfm/src/geometry/absolute_pose.h
+++ b/opensfm/src/geometry/absolute_pose.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <foundation/numeric.h>
+#include <geometry/transform.h>
 #include <Eigen/Eigen>
 #include <complex>
 #include <iostream>
@@ -103,34 +104,6 @@ std::vector<Eigen::Matrix<double, 3, 4>> AbsolutePoseThreePoints(IT begin, IT en
   return RTs;
 }
 
-template <class IT>
-std::pair<Eigen::Vector3d, Eigen::Vector3d> ComputeAverage(IT begin, IT end){
-  Eigen::Vector3d q_average = Eigen::Vector3d::Zero();
-  Eigen::Vector3d p_average = Eigen::Vector3d::Zero();
-  for(IT it = begin; it != end; ++it){
-    q_average += it->first;
-    p_average += it->second;
-  }
-  q_average /= (end-begin);
-  p_average /= (end-begin);
-  return std::make_pair(q_average, p_average);
-}
-
-template <class IT>
-Eigen::Matrix3d RotationBetweenPoints(IT begin, IT end){
-  const auto averages = ComputeAverage(begin, end);
-  Eigen::Matrix3d M = Eigen::Matrix3d::Zero();
-  for(IT it = begin; it != end; ++it){
-    const Eigen::Vector3d q = it->first-averages.first;
-    const Eigen::Vector3d p = it->second-averages.second;
-    M += q*p.transpose();
-  }
-
-  Eigen::JacobiSVD<Eigen::Matrix3d> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
-  const auto U = svd.matrixU();
-  const auto V = svd.matrixV();
-  return U*V.transpose();
-}
 
 template <class IT>
 Eigen::Vector3d TranslationBetweenPoints(IT begin, IT end, const Eigen::Matrix3d& rotation){

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -21,5 +21,6 @@ PYBIND11_MODULE(pygeometry, m) {
   m.def("absolute_pose_n_points_known_rotation", geometry::AbsolutePoseNPointsKnownRotation);
   m.def("essential_n_points", geometry::EssentialNPoints);
   m.def("relative_pose_from_essential", geometry::RelativePoseFromEssential);
+  m.def("relative_rotation_n_points", geometry::RelativeRotationNPoints);
   m.def("relative_pose_refinement", geometry::RelativePoseRefinement);
 }

--- a/opensfm/src/geometry/relative_pose.h
+++ b/opensfm/src/geometry/relative_pose.h
@@ -165,4 +165,7 @@ Eigen::Matrix<double, 3, 4> RelativePoseRefinement(
     const Eigen::Matrix<double, -1, 3> &x1,
     const Eigen::Matrix<double, -1, 3> &x2,
     int iterations);
+Eigen::Matrix3d RelativeRotationNPoints(
+    const Eigen::Matrix<double, -1, 3> &x1,
+    const Eigen::Matrix<double, -1, 3> &x2);
 }

--- a/opensfm/src/geometry/src/relative_pose.cc
+++ b/opensfm/src/geometry/src/relative_pose.cc
@@ -1,4 +1,5 @@
 #include <geometry/relative_pose.h>
+#include <geometry/transform.h>
 
 namespace geometry {
 Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
@@ -14,6 +15,20 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
     samples[i].second = x2.row(i);
   }
   return ::RelativePoseFromEssential(essential, samples.begin(), samples.end());
+}
+
+Eigen::Matrix3d RelativeRotationNPoints(
+    const Eigen::Matrix<double, -1, 3> &x1,
+    const Eigen::Matrix<double, -1, 3> &x2) {
+  if((x1.cols() != x2.cols()) || (x1.rows() != x2.rows())){
+    throw std::runtime_error("Features matrices have different sizes.");
+  }
+  std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> samples(x1.rows());
+  for (int i = 0; i < x1.rows(); ++i) {
+    samples[i].first = x1.row(i);
+    samples[i].second = x2.row(i);
+  }
+  return ::RotationBetweenPoints(samples.begin(), samples.end()).transpose();
 }
 
 Eigen::Matrix<double, 3, 4> RelativePoseRefinement(

--- a/opensfm/src/geometry/transform.h
+++ b/opensfm/src/geometry/transform.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <foundation/numeric.h>
+#include <Eigen/Eigen>
+
+template <class IT>
+std::pair<Eigen::Vector3d, Eigen::Vector3d> ComputeAverage(IT begin, IT end){
+  Eigen::Vector3d q_average = Eigen::Vector3d::Zero();
+  Eigen::Vector3d p_average = Eigen::Vector3d::Zero();
+  for(IT it = begin; it != end; ++it){
+    q_average += it->first;
+    p_average += it->second;
+  }
+  q_average /= (end-begin);
+  p_average /= (end-begin);
+  return std::make_pair(q_average, p_average);
+}
+
+template <class IT>
+Eigen::Matrix3d RotationBetweenPoints(IT begin, IT end){
+  const auto averages = ComputeAverage(begin, end);
+  Eigen::Matrix3d M = Eigen::Matrix3d::Zero();
+  for(IT it = begin; it != end; ++it){
+    const Eigen::Vector3d q = it->first-averages.first;
+    const Eigen::Vector3d p = it->second-averages.second;
+    M += q*p.transpose();
+  }
+
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(M, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  const auto U = svd.matrixU();
+  const auto V = svd.matrixV();
+  return U*V.transpose();
+}

--- a/opensfm/src/robust/absolute_pose_known_rotation_model.h
+++ b/opensfm/src/robust/absolute_pose_known_rotation_model.h
@@ -13,6 +13,10 @@ class AbsolutePoseKnownRotation : public Model<AbsolutePoseKnownRotation, 1, 1> 
   using Data = std::pair<Eigen::Vector3d, Eigen::Vector3d>;
   static const int MINIMAL_SAMPLES = 2;
 
+  static double ThresholdAdapter(const double threshold_angle){
+    return 1.0 - std::cos(threshold_angle);
+  }
+
   template <class IT>
   static int Estimate(IT begin, IT end, Type* models){
     models[0] = AbsolutePoseNPointsKnownRotation(begin, end);
@@ -32,7 +36,7 @@ class AbsolutePoseKnownRotation : public Model<AbsolutePoseKnownRotation, 1, 1> 
     const auto projected = (point+translation).normalized();
 
     Error e;
-    e[0] = std::acos(bearing.dot(projected));
+    e[0] = 1.0 - (bearing.dot(projected));
     return e;
   }
 };

--- a/opensfm/src/robust/absolute_pose_model.h
+++ b/opensfm/src/robust/absolute_pose_model.h
@@ -13,6 +13,10 @@ class AbsolutePose : public Model<AbsolutePose, 1, 4> {
   using Data = std::pair<Eigen::Vector3d, Eigen::Vector3d>;
   static const int MINIMAL_SAMPLES = 3;
 
+  static double ThresholdAdapter(const double threshold_angle){
+    return 1.0 - std::cos(threshold_angle);
+  }
+
   template <class IT>
   static int Estimate(IT begin, IT end, Type* models){
     const auto poses = AbsolutePoseThreePoints(begin, end);
@@ -36,7 +40,7 @@ class AbsolutePose : public Model<AbsolutePose, 1, 4> {
     const auto projected = (rotation*point+translation).normalized();
 
     Error e;
-    e[0] = std::acos(bearing.dot(projected));
+    e[0] = 1.0 - (bearing.dot(projected));
     return e;
   }
 };

--- a/opensfm/src/robust/instanciations.h
+++ b/opensfm/src/robust/instanciations.h
@@ -3,6 +3,7 @@
 #include "line_model.h"
 #include "essential_model.h"
 #include "relative_pose_model.h"
+#include "relative_rotation_model.h"
 #include "absolute_pose_model.h"
 #include "absolute_pose_known_rotation_model.h"
 
@@ -19,6 +20,12 @@ ScoreInfo<EssentialMatrixModel::Type> RANSACEssential(
     const RansacType& ransac_type);
 
 ScoreInfo<RelativePose::Type> RANSACRelativePose(
+    const Eigen::Matrix<double, -1, 3>& x1,
+    const Eigen::Matrix<double, -1, 3>& x2, 
+    double threshold, const RobustEstimatorParams& parameters,
+    const RansacType& ransac_type);
+
+ScoreInfo<RelativeRotation::Type> RANSACRelativeRotation(
     const Eigen::Matrix<double, -1, 3>& x1,
     const Eigen::Matrix<double, -1, 3>& x2, 
     double threshold, const RobustEstimatorParams& parameters,

--- a/opensfm/src/robust/model.h
+++ b/opensfm/src/robust/model.h
@@ -11,6 +11,10 @@ class Model {
   static const int MAX_MODELS = M;
   using Error = Eigen::Matrix<double, SIZE, 1>;
 
+  static double ThresholdAdapter(const double threshold){
+    return threshold;
+  }
+
   template <class IT, class MODEL>
   static std::vector<Error> EvaluateModel(const MODEL& model, IT begin, IT end) {
     std::vector<Error> errors;

--- a/opensfm/src/robust/python/pybind.cc
+++ b/opensfm/src/robust/python/pybind.cc
@@ -32,6 +32,7 @@ PYBIND11_MODULE(pyrobust, m) {
   m.def("ransac_line", robust::RANSACLine);
   m.def("ransac_essential", robust::RANSACEssential);
   m.def("ransac_relative_pose", robust::RANSACRelativePose);
+  m.def("ransac_relative_rotation", robust::RANSACRelativeRotation);
   m.def("ransac_absolute_pose", robust::RANSACAbsolutePose);
   m.def("ransac_absolute_pose_known_rotation", robust::RANSACAbsolutePoseKnownRotation);
 
@@ -43,7 +44,7 @@ PYBIND11_MODULE(pyrobust, m) {
       .export_values()
     ;
   AddScoreType<Line::Type>(m, "Line");
-  AddScoreType<robust::EssentialMatrixModel::Type>(m, "EssentialMatrix");
-  AddScoreType<Eigen::Matrix<double, 3, 4>>(m, "RelativePose");
-  AddScoreType<Eigen::Vector3d>(m, "RelativePoseKnownRotation");
+  AddScoreType<Eigen::Matrix3d>(m, "Matrix3d");
+  AddScoreType<Eigen::Matrix<double, 3, 4>>(m, "Matrix34d");
+  AddScoreType<Eigen::Vector3d>(m, "Vector3d");
 }

--- a/opensfm/src/robust/relative_pose_model.h
+++ b/opensfm/src/robust/relative_pose_model.h
@@ -15,6 +15,10 @@ class RelativePose : public Model<RelativePose, 1, 10> {
   using Data = std::pair<Eigen::Vector3d, Eigen::Vector3d>;
   static const int MINIMAL_SAMPLES = 5;
 
+  static double ThresholdAdapter(const double threshold_angle){
+    return 1.0 - std::cos(threshold_angle);
+  }
+
   template <class IT>
   static int Estimate(IT begin, IT end, Type* models){
     const auto essentials = EssentialFivePoints(begin, end);
@@ -50,7 +54,7 @@ class RelativePose : public Model<RelativePose, 1, 10> {
     const auto projected_y = (rotation*point+translation).normalized();
 
     Error e;
-    e[0] = std::acos((projected_x.dot(x) + projected_y.dot(y))*0.5);
+    e[0] = 1.0 - ((projected_x.dot(x) + projected_y.dot(y))*0.5);
     return e;
   }
 };

--- a/opensfm/src/robust/relative_rotation_model.h
+++ b/opensfm/src/robust/relative_rotation_model.h
@@ -1,0 +1,33 @@
+#pragma once
+
+
+#include "model.h"
+#include <foundation/numeric.h>
+#include <geometry/transform.h>
+
+
+class RelativeRotation : public Model<RelativeRotation, 1, 1> {
+ public:
+  using Error = typename Model<RelativeRotation, 1, 1>::Error;
+  using Type = Eigen::Matrix3d;
+  using Data = std::pair<Eigen::Vector3d, Eigen::Vector3d>;
+  static const int MINIMAL_SAMPLES = 3;
+
+  template <class IT>
+  static int Estimate(IT begin, IT end, Type* models){
+    models[0] = RotationBetweenPoints(begin, end).transpose();
+    return 1;
+  }
+
+  template <class IT>
+  static int EstimateNonMinimal(IT begin, IT end, Type* models){
+    models[0] = RotationBetweenPoints(begin, end).transpose();
+    return 1;
+  }
+
+  static Error Evaluate(const Type& model, const Data& d){
+    Error e;
+    e[0] = 1.0 - (model*d.first).dot(d.second);
+    return e;
+  }
+};

--- a/opensfm/src/robust/relative_rotation_model.h
+++ b/opensfm/src/robust/relative_rotation_model.h
@@ -13,6 +13,10 @@ class RelativeRotation : public Model<RelativeRotation, 1, 1> {
   using Data = std::pair<Eigen::Vector3d, Eigen::Vector3d>;
   static const int MINIMAL_SAMPLES = 3;
 
+  static double ThresholdAdapter(const double threshold_angle){
+    return 1.0 - std::cos(threshold_angle);
+  }
+
   template <class IT>
   static int Estimate(IT begin, IT end, Type* models){
     models[0] = RotationBetweenPoints(begin, end).transpose();

--- a/opensfm/src/robust/robust_estimator.h
+++ b/opensfm/src/robust/robust_estimator.h
@@ -117,20 +117,21 @@ template <class MODEL>
 ScoreInfo<typename MODEL::Type> RunEstimation(
     const std::vector<typename MODEL::Data>& samples, double threshold,
     const RobustEstimatorParams& parameters, const RansacType& ransac_type) {
+  const double model_threshold = MODEL::ThresholdAdapter(threshold);
   switch(ransac_type){
     case RANSAC:
     {
-      RansacScoring scorer(threshold);
+      RansacScoring scorer(model_threshold);
       return Estimate<RansacScoring, MODEL>(samples, scorer, parameters);
     }
     case MSAC:
     {
-      MSacScoring scorer(threshold);
+      MSacScoring scorer(model_threshold);
       return Estimate<MSacScoring, MODEL>(samples, scorer, parameters);
     }
     case LMedS:
     {
-      LMedSScoring scorer(threshold);
+      LMedSScoring scorer(model_threshold);
       return Estimate<LMedSScoring, MODEL>(samples, scorer, parameters);
     }
     default:

--- a/opensfm/src/robust/src/instanciations.cc
+++ b/opensfm/src/robust/src/instanciations.cc
@@ -34,7 +34,7 @@ ScoreInfo<RelativePose::Type> RANSACRelativePose(
     const Eigen::Matrix<double, -1, 3>& x2, 
     double threshold, const RobustEstimatorParams& parameters,
     const RansacType& ransac_type) {
-   if((x1.cols() != x2.cols()) || (x1.rows() != x2.rows())){
+  if((x1.cols() != x2.cols()) || (x1.rows() != x2.rows())){
     throw std::runtime_error("Features matrices have different sizes.");
   }
   
@@ -44,6 +44,23 @@ ScoreInfo<RelativePose::Type> RANSACRelativePose(
     samples[i].second = x2.row(i);
   }
   return RunEstimation<RelativePose>(samples, threshold, parameters, ransac_type);
+}
+
+ScoreInfo<RelativeRotation::Type> RANSACRelativeRotation(
+    const Eigen::Matrix<double, -1, 3>& x1,
+    const Eigen::Matrix<double, -1, 3>& x2, 
+    double threshold, const RobustEstimatorParams& parameters,
+    const RansacType& ransac_type){
+  if((x1.cols() != x2.cols()) || (x1.rows() != x2.rows())){
+    throw std::runtime_error("Features matrices have different sizes.");
+  }
+  
+  std::vector<RelativeRotation::Data> samples(x1.rows());
+  for (int i = 0; i < x1.rows(); ++i) {
+    samples[i].first = x1.row(i);
+    samples[i].second = x2.row(i);
+  }
+  return RunEstimation<RelativeRotation>(samples, threshold, parameters, ransac_type);
 }
 
 ScoreInfo<AbsolutePose::Type> RANSACAbsolutePose(

--- a/opensfm/test/test_multiview.py
+++ b/opensfm/test/test_multiview.py
@@ -1,5 +1,6 @@
 import copy
 import random
+import pyopengv
 import numpy as np
 
 from opensfm import multiview
@@ -112,6 +113,25 @@ def test_relative_pose_from_essential(one_pair_and_its_E):
 
     expected = pose.get_Rt()
     assert np.allclose(expected, result, rtol=1e-10)
+
+
+def test_relative_rotation(one_pair_and_its_E):
+    f1, _, _, _ = one_pair_and_its_E
+
+    vec_x = np.random.rand(3)
+    vec_x /= np.linalg.norm(vec_x)
+    vec_y = np.array([-vec_x[1], vec_x[0], 0.])
+    vec_y /= np.linalg.norm(vec_y)
+    vec_z = np.cross(vec_x, vec_y)
+
+    rotation = np.array([vec_x, vec_y, vec_z])
+
+    f1 /= np.linalg.norm(f1, axis=1)[:, None]
+    f2 = [rotation.dot(x) for x in f1]
+
+    result = pygeometry.relative_rotation_n_points(f1, f2)
+
+    assert np.allclose(rotation, result, rtol=1e-10)
 
 
 def test_relative_pose_refinement(one_pair_and_its_E):

--- a/opensfm/test/test_robust.py
+++ b/opensfm/test/test_robust.py
@@ -248,7 +248,7 @@ def test_outliers_relative_rotation_ransac(one_pair_and_its_E):
     params = pyrobust.RobustEstimatorParams()
     params.iterations = 1000
 
-    result = pyrobust.ransac_relative_rotation(f1, f2, 1 - np.cos(np.sqrt(3*scale*scale)), params, pyrobust.RansacType.RANSAC)
+    result = pyrobust.ransac_relative_rotation(f1, f2, np.sqrt(3*scale*scale), params, pyrobust.RansacType.RANSAC)
 
     tolerance = 0.04
     inliers_count = (1 - ratio_outliers) * len(points)


### PR DESCRIPTION
This PR adds the relative rotation robust estimator.

As a bonus, we also greatly improve the speed of most estimator by allowing the `model` to precompute a part of the cost function by using the `ThresholdAdapter` function (identity by default). Typically, we use it for adapting the threshold `t` to be replaced with `1-cos(t)` so the actual angle cost `acos(dot(...))` become `1 - dot(...)` leading to 10x speed-up.