### PR TITLE
Avoid broken NVM files by renaming input files

### DIFF
--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -604,7 +604,7 @@ class UndistortedDataSet(object):
         """Path of undistorted version of an image."""
         image_format = self.config['undistorted_image_format']
         if ' ' in image:
-            image.replace(' ', '') + hex(hash(image))
+            image = image.replace(' ', '') + hex(hash(image))
         filename = image + '.' + image_format
         return os.path.join(self._undistorted_image_path(), filename)
 

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -603,6 +603,8 @@ class UndistortedDataSet(object):
     def _undistorted_image_file(self, image):
         """Path of undistorted version of an image."""
         image_format = self.config['undistorted_image_format']
+        if ' ' in image:
+            image.replace(' ', '') + hex(hash(image))
         filename = image + '.' + image_format
         return os.path.join(self._undistorted_image_path(), filename)
 


### PR DESCRIPTION
In https://github.com/mapillary/OpenSfM/issues/554 I noted that generated undistorted images with spaces in filenames break subsequent export steps and external tooling making use of NVM files. 
This transformation maintains all filenames without spaces, but ensures any filenames with spaces are corrected using a collision-avoiding naming strategy.