### PR TITLE
Failure on unsorted data in apply_transformations

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -263,7 +263,7 @@ def align_reconstructions(reconstruction_shots,
 
 
 def apply_transformations(transformations):
-    submodels = itertools.groupby(transformations.keys(), lambda key: key.submodel_path)
+    submodels = itertools.groupby(sorted(transformations.keys(), key=lambda key: key.submodel_path), lambda key: key.submodel_path)
     for submodel_path, keys in submodels:
         data = dataset.DataSet(submodel_path)
         if not data.reconstruction_exists():


### PR DESCRIPTION
The original use of groupby expects a sorted transformations.keys() iterable. When this is not true, the function will repeatedly reload the original dataset and discard random alignments.
This results in alignment failures between submodels of large reconstructions.