### PR TITLE
Catch division by zero

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -222,8 +222,10 @@ class EXIF:
         if not mm_per_unit:
             return None
         pixels_per_unit = get_tag_as_float(self.tags, 'EXIF FocalPlaneXResolution')
-        if pixels_per_unit == 0:
-            return None
+        if pixels_per_unit <= 0:
+            pixels_per_unit = get_tag_as_float(self.tags, 'EXIF FocalPlaneYResolution')
+            if pixels_per_unit <= 0:
+                return None
         units_per_pixel = 1 / pixels_per_unit
         width_in_pixels = self.extract_image_size()[0]
         return width_in_pixels * units_per_pixel * mm_per_unit

--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -222,6 +222,8 @@ class EXIF:
         if not mm_per_unit:
             return None
         pixels_per_unit = get_tag_as_float(self.tags, 'EXIF FocalPlaneXResolution')
+        if pixels_per_unit == 0:
+            return None
         units_per_pixel = 1 / pixels_per_unit
         width_in_pixels = self.extract_image_size()[0]
         return width_in_pixels * units_per_pixel * mm_per_unit


### PR DESCRIPTION
Hello :hand:

I've found a camera (DJI Zenmuse Z30) that reports "bad" `FocalPlaneXResolution` values of `0`, triggering a division by zero error.

Since `extract_sensor_width` can return `None` I think it should return that instead of failing.

Related: https://github.com/OpenDroneMap/ODM/issues/1089
