### PR TITLE
Run opensfm for windows

### DIFF
--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -78,6 +78,5 @@ def processes_that_fit_in_memory(desired, per_process):
 
 
 def current_memory_usage():
-    ps = psutil.Process(os.getpid())
-    return ps.memory_info().rss
+    return psutil.Process(os.getpid()).memory_info().rss
     #return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-import resource
+import psutil
 import sys
 
 import cv2
@@ -78,4 +78,6 @@ def processes_that_fit_in_memory(desired, per_process):
 
 
 def current_memory_usage():
-    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit
+    ps = psutil.Process(os.getpid())
+    return ps.memory_info().rss
+    #return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit


### PR DESCRIPTION
I have checked at Ubuntu 16.04, two values(13598720) are equal
-----------------------------------------------------------------------------------
Python 3.5.2 (default, Oct  8 2019, 13:06:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import resource
>>> import psutil
>>> resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
13598720
>>> psutil.Process(os.getpid()).memory_info().rss
13598720
>>> 
-----------------------------------------------------------------------------------

and psutil also runs successfully at Windows

-----------------------------------------------------------------------------------
Microsoft Windows [Version 10.0.17134.950]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Users\KJ>python
Python 3.6.6 (v3.6.6:4cf1f54eb7, Jun 27 2018, 03:37:03) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> import os
>>> psutil.Process(os.getpid()).memory_info().rss
15052800
>>>
-----------------------------------------------------------------------------------

