### PR TITLE
fix: define static members

### DIFF
--- a/opensfm/src/robust/CMakeLists.txt
+++ b/opensfm/src/robust/CMakeLists.txt
@@ -4,7 +4,15 @@ set(ROBUST_FILES
     robust_estimator.h
     essential_model.h
     line_model.h
+    absolute_pose_model.h
     relative_pose_model.h
+    relative_rotation_model.h
+    absolute_pose_known_rotation_model.h
+    src/absolute_pose_model.cc
+    src/absolute_pose_known_rotation_model.cc
+    src/relative_rotation_model.cc
+    src/relative_pose_model.cc
+    src/line_model.cc
     src/instanciations.cc
 )
 add_library(robust ${ROBUST_FILES})

--- a/opensfm/src/robust/essential_model.h
+++ b/opensfm/src/robust/essential_model.h
@@ -59,3 +59,7 @@ class EssentialMatrix : public Model<EssentialMatrix<E>, 1, 10> {
     return e;
   }
 };
+
+
+template <class E>
+const int EssentialMatrix<E>::MINIMAL_SAMPLES;

--- a/opensfm/src/robust/src/absolute_pose_known_rotation_model.cc
+++ b/opensfm/src/robust/src/absolute_pose_known_rotation_model.cc
@@ -1,0 +1,3 @@
+#include "robust/absolute_pose_known_rotation_model.h"
+
+const int AbsolutePoseKnownRotation::MINIMAL_SAMPLES;

--- a/opensfm/src/robust/src/absolute_pose_model.cc
+++ b/opensfm/src/robust/src/absolute_pose_model.cc
@@ -1,0 +1,3 @@
+#include "robust/absolute_pose_model.h"
+
+const int AbsolutePose::MINIMAL_SAMPLES;

--- a/opensfm/src/robust/src/line_model.cc
+++ b/opensfm/src/robust/src/line_model.cc
@@ -1,0 +1,3 @@
+#include "robust/line_model.h"
+
+const int Line::MINIMAL_SAMPLES;

--- a/opensfm/src/robust/src/relative_pose_model.cc
+++ b/opensfm/src/robust/src/relative_pose_model.cc
@@ -1,0 +1,3 @@
+#include "robust/relative_pose_model.h"
+
+const int RelativePose::MINIMAL_SAMPLES;

--- a/opensfm/src/robust/src/relative_rotation_model.cc
+++ b/opensfm/src/robust/src/relative_rotation_model.cc
@@ -1,0 +1,3 @@
+#include "robust/relative_rotation_model.h"
+
+const int RelativeRotation::MINIMAL_SAMPLES;


### PR DESCRIPTION
The static const int members are optimized out when building
in release mode. Therefore, it has been working well having
them declared in the header only. However, when building in
debug mode, the missing definition yields to undeclared
symbols in the library.