### PR TITLE
build: fix linker error with opencv

### DIFF
--- a/opensfm/src/dense/CMakeLists.txt
+++ b/opensfm/src/dense/CMakeLists.txt
@@ -15,7 +15,8 @@ target_include_directories(dense_test PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(dense_test
                       PUBLIC
                       dense
-                      ${TEST_MAIN})
+                      ${TEST_MAIN}
+                      ${OpenCV_LIBS})
 add_test(dense_test dense_test)
 
 pybind11_add_module(pydense python/pybind.cc)


### PR DESCRIPTION
This PR fixes a linker error during building:
```[ 70%] Linking CXX executable dense_test
CMakeFiles/dense_test.dir/test/depthmap_test.cc.o: In function `cvflann::anyimpl::big_any_policy<cv::String>::static_delete(void**)':
depthmap_test.cc:(.text._ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE13static_deleteEPPv[_ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE13static_deleteEPPv]+0x15): undefined reference to `cv::String::deallocate()'
CMakeFiles/dense_test.dir/test/depthmap_test.cc.o: In function `cvflann::anyimpl::big_any_policy<cv::String>::move(void* const*, void**)':
depthmap_test.cc:(.text._ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE4moveEPKPvPS5_[_ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE4moveEPKPvPS5_]+0x10): undefined reference to `cv::String::deallocate()'
depthmap_test.cc:(.text._ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE4moveEPKPvPS5_[_ZN7cvflann7anyimpl14big_any_policyIN2cv6StringEE4moveEPKPvPS5_]+0x24): undefined reference to `cv::String::deallocate()'
collect2: error: ld returned 1 exit status
dense/CMakeFiles/dense_test.dir/build.make:149: recipe for target 'dense/dense_test' failed```