### PR TITLE
fix: replace auto by Eigen types 

### DIFF
--- a/opensfm/src/geometry/absolute_pose.h
+++ b/opensfm/src/geometry/absolute_pose.h
@@ -13,28 +13,28 @@ Eigen::Matrix3d RotationMatrixAroundAxis(const double cos_theta, const double si
 // Perspective-Three-Point Problem" from Ke and al.
 template <class IT>
 std::vector<Eigen::Matrix<double, 3, 4>> AbsolutePoseThreePoints(IT begin, IT end) {
-  const auto b1 = begin->first;
-  const auto b2 = (begin+1)->first;
-  const auto b3 = (begin+2)->first;
-  const auto p1 = begin->second;
-  const auto p2 = (begin+1)->second;
-  const auto p3 = (begin+2)->second;
+  const Eigen::Vector3d  b1 = begin->first;
+  const Eigen::Vector3d b2 = (begin+1)->first;
+  const Eigen::Vector3d b3 = (begin+2)->first;
+  const Eigen::Vector3d p1 = begin->second;
+  const Eigen::Vector3d p2 = (begin+1)->second;
+  const Eigen::Vector3d p3 = (begin+2)->second;
 
   // Compute k1, k2 and k3
-  const auto k1 = (p1-p2).normalized();
-  const auto k3 = (b1.cross(b2)).normalized();
-  const auto k2 = (k1.cross(k3)).normalized();
+  const Eigen::Vector3d k1 = (p1-p2).normalized();
+  const Eigen::Vector3d k3 = (b1.cross(b2)).normalized();
+  const Eigen::Vector3d k2 = (k1.cross(k3)).normalized();
 
   // Compute ui and vi for i = 1, 2
-  const auto u1 = p1 - p3;
-  const auto u2 = p2 - p3;
-  const auto v1 = b1.cross(b3);
-  const auto v2 = b2.cross(b3);
+  const Eigen::Vector3d u1 = p1 - p3;
+  const Eigen::Vector3d u2 = p2 - p3;
+  const Eigen::Vector3d v1 = b1.cross(b3);
+  const Eigen::Vector3d v2 = b2.cross(b3);
 
   // Compute sigma and k3"
-  const auto u1_k1 = u1.cross(k1);
+  const Eigen::Vector3d u1_k1 = u1.cross(k1);
   const auto sigma = u1_k1.norm();
-  const auto k3_second = u1_k1/sigma;
+  const Eigen::Vector3d k3_second = u1_k1/sigma;
 
   // Compute fij's
   const auto k3_b3 = k3.dot(b3);
@@ -80,7 +80,7 @@ std::vector<Eigen::Matrix<double, 3, 4>> AbsolutePoseThreePoints(IT begin, IT en
 
   std::vector<Eigen::Matrix<double, 3, 4>> RTs;
 
-  const double eps = 1e-20;
+  constexpr double eps = 1e-20;
   for(const auto& root : roots){
     const auto cos_theta_1 = root;
     const auto sin_theta_1 = Sign(k3_b3)*std::sqrt(1.0-SQUARE(cos_theta_1));
@@ -89,11 +89,11 @@ std::vector<Eigen::Matrix<double, 3, 4>> AbsolutePoseThreePoints(IT begin, IT en
     const auto cos_theta_3 = t*(g1*cos_theta_1 + g2);
     const auto sin_theta_3 = t*(g3*cos_theta_1 + g4);
 
-    const auto c1 = RotationMatrixAroundAxis(cos_theta_1, sin_theta_1, e1);
-    const auto c2 = RotationMatrixAroundAxis(cos_theta_3, sin_theta_3, e2);
+    const Eigen::Matrix3d c1 = RotationMatrixAroundAxis(cos_theta_1, sin_theta_1, e1);
+    const Eigen::Matrix3d c2 = RotationMatrixAroundAxis(cos_theta_3, sin_theta_3, e2);
 
-    const auto rotation = ClosestRotationMatrix(c_barre*c1*c2*c_barre_barre);
-    const auto translation = p3 - (sigma*sin_theta_1)/k3_b3*(rotation*b3);
+    const Eigen::Matrix3d rotation = ClosestRotationMatrix(c_barre*c1*c2*c_barre_barre);
+    const Eigen::Vector3d translation = p3 - (sigma*sin_theta_1)/k3_b3*(rotation*b3);
 
     // Rcamera and Tcamera parametrization
     Eigen::Matrix<double, 3, 4> RT;

--- a/opensfm/src/geometry/relative_pose.h
+++ b/opensfm/src/geometry/relative_pose.h
@@ -59,8 +59,8 @@ Eigen::Matrix<double, 3, 4> RelativePoseFromEssential(
         bearings.row(1) = rotation.transpose()*it->second;
         const Eigen::Vector3d point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
         
-        const auto projected_x = point.normalized();
-        const auto projected_y = (rotation*point+translation).normalized();
+        const Eigen::Vector3d projected_x = point.normalized();
+        const Eigen::Vector3d projected_y = (rotation*point+translation).normalized();
         score += ((projected_x.dot(it->first) + projected_y.dot(it->second))*0.5);
       }
 
@@ -115,10 +115,10 @@ struct RelativePoseCost {
       auto point = geometry::TriangulateTwoBearingsMidpointSolve(centers, bearings);
 
       // Point in x stays at identity, y is brought in second camera with R*(y-t)
-      const auto projected_x = point.normalized();
+      const Eigen::Matrix<T, 3, 1> projected_x = point.normalized();
       const Eigen::Matrix<T, 3, 1> y_centered = point-translation;
       ceres::AngleAxisRotatePoint(rotation.data(), y_centered.data(), some_tmp.data());
-      const auto projected_y = some_tmp.normalized();
+      const Eigen::Matrix<T, 3, 1> projected_y = some_tmp.normalized();
       residuals[i] = 1.0 - ((projected_x.dot(x) + projected_y.dot(y))*T(0.5));
     }
     residuals[MAX_ERRORS] = 1.0 - translation.norm();

--- a/opensfm/src/geometry/src/triangulation.cc
+++ b/opensfm/src/geometry/src/triangulation.cc
@@ -48,7 +48,7 @@ py::object TriangulateBearingsDLT(const std::vector<Eigen::Matrix<double, 3, 4>>
   Eigen::MatrixXd world_bearings(count, 3);
   bool angle_ok = false;
   for (int i = 0; i < count && !angle_ok; ++i) {
-    const auto Rt = Rts[i];
+    const Eigen::Matrix<double, 3, 4> Rt = Rts[i];
     world_bearings.row(i) = Rt.block<3, 3>(0, 0).transpose() * bearings.row(i).transpose();
     for (int j = 0; j < i && !angle_ok; ++j) {
       const double angle = AngleBetweenVectors(world_bearings.row(i), world_bearings.row(j));
@@ -66,7 +66,7 @@ py::object TriangulateBearingsDLT(const std::vector<Eigen::Matrix<double, 3, 4>>
   X /= X(3);
 
   for (int i = 0; i < count; ++i) {
-    const auto projected = Rts[i] * X;
+    const Eigen::Vector3d projected = Rts[i] * X;
     if (AngleBetweenVectors(projected, bearings.row(i)) > threshold) {
       return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::none());
     }
@@ -117,8 +117,8 @@ py::object TriangulateBearingsMidpoint(const Eigen::Matrix<double, -1, 3> &cente
 
   // Check reprojection error
   for (int i = 0; i < count; ++i) {
-    const auto projected = X - centers.row(i).transpose();
-    const auto measured = bearings.row(i);
+    const Eigen::Vector3d projected = X - centers.row(i).transpose();
+    const Eigen::Vector3d measured = bearings.row(i);
     if (AngleBetweenVectors(projected, measured) > threshold_list[i]) {
       return TriangulateReturn(TRIANGULATION_BAD_REPROJECTION, py::none());
     }

--- a/opensfm/src/geometry/transform.h
+++ b/opensfm/src/geometry/transform.h
@@ -28,8 +28,8 @@ Eigen::Matrix3d RotationBetweenPoints(IT begin, IT end) {
 
   Eigen::JacobiSVD<Eigen::Matrix3d> svd(
       M, Eigen::ComputeFullU | Eigen::ComputeFullV);
-  const auto U = svd.matrixU();
-  const auto V = svd.matrixV();
+  const Eigen::Matrix3d U = svd.matrixU();
+  const Eigen::Matrix3d V = svd.matrixV();
   Eigen::Matrix3d rotation = U * V.transpose();
   if(rotation.determinant() < 0.){
     rotation *= -1.0;


### PR DESCRIPTION
This PR replaces `auto` by the actual `Eigen` types to avoid double computations or potential incorrect results as suggested in [Eigen Pitfalls](https://eigen.tuxfamily.org/dox/TopicPitfalls.html).