### PR TITLE
feat: analytical jacobian of cameras

### DIFF
--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -443,11 +443,11 @@ struct ErrorTraits {
   using Type = ReprojectionError2D;
   static constexpr int Size = 2;
 };
-template <>
-struct ErrorTraits<SphericalCamera> {
-  using Type = ReprojectionError3D;
-  static constexpr int Size = 3;
-};
+// template <>
+// struct ErrorTraits<SphericalCamera> {
+//   using Type = ReprojectionError3D;
+//   static constexpr int Size = 3;
+// };
 
 struct AddProjectionError {
   template <class T>
@@ -542,13 +542,13 @@ void BundleAdjuster::Run() {
           index = i;
         }
       }
-      if(index >= 0){
-        ceres::CostFunction *transition_barrier =
-            new ceres::AutoDiffCostFunction<BAParameterBarrier, 1,
-                                            DualCamera::Size>(
-                new BAParameterBarrier(0.0, 1.0, index));
-        problem.AddResidualBlock(transition_barrier, NULL, data.data());
-      }
+      // if(index >= 0){
+      //   ceres::CostFunction *transition_barrier =
+      //       new ceres::AutoDiffCostFunction<BAParameterBarrier, 1,
+                                            //SizeTraits<DualCamera>::Size>(
+      //           new BAParameterBarrier(0.0, 1.0, index));
+      //   problem.AddResidualBlock(transition_barrier, NULL, data.data());
+      // }
     }
   }
   

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -545,7 +545,7 @@ void BundleAdjuster::Run() {
       if(index >= 0){
         ceres::CostFunction *transition_barrier =
             new ceres::AutoDiffCostFunction<BAParameterBarrier, 1,
-                                            SizeTraits<DualCamera>::Size>(
+                                            DualCamera::Size>(
                 new BAParameterBarrier(0.0, 1.0, index));
         problem.AddResidualBlock(transition_barrier, NULL, data.data());
       }

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -443,11 +443,11 @@ struct ErrorTraits {
   using Type = ReprojectionError2D;
   static constexpr int Size = 2;
 };
-// template <>
-// struct ErrorTraits<SphericalCamera> {
-//   using Type = ReprojectionError3D;
-//   static constexpr int Size = 3;
-// };
+template <>
+struct ErrorTraits<SphericalCamera> {
+  using Type = ReprojectionError3D;
+  static constexpr int Size = 3;
+};
 
 struct AddProjectionError {
   template <class T>
@@ -542,13 +542,13 @@ void BundleAdjuster::Run() {
           index = i;
         }
       }
-      // if(index >= 0){
-      //   ceres::CostFunction *transition_barrier =
-      //       new ceres::AutoDiffCostFunction<BAParameterBarrier, 1,
-                                            //SizeTraits<DualCamera>::Size>(
-      //           new BAParameterBarrier(0.0, 1.0, index));
-      //   problem.AddResidualBlock(transition_barrier, NULL, data.data());
-      // }
+      if(index >= 0){
+        ceres::CostFunction *transition_barrier =
+            new ceres::AutoDiffCostFunction<BAParameterBarrier, 1,
+                                            SizeTraits<DualCamera>::Size>(
+                new BAParameterBarrier(0.0, 1.0, index));
+        problem.AddResidualBlock(transition_barrier, NULL, data.data());
+      }
     }
   }
   

--- a/opensfm/src/geometry/camera.h
+++ b/opensfm/src/geometry/camera.h
@@ -8,16 +8,16 @@
 class Camera {
  public:
   enum class Parameters : int {
-    Focal,
-    AspectRatio,
-    Cx,
-    Cy,
+    Transition,
     K1,
     K2,
     K3,
     P1,
     P2,
-    Transition,
+    Focal,
+    AspectRatio,
+    Cx,
+    Cy,
     None
   };
 

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -308,28 +308,27 @@ struct DistoBrown : CameraFunctor<2, 5, 2>{
     const auto& y = point[1];
     const auto& z = point[2];
 
-    const auto x2 = x * x;
-    const auto x4 = x2 * x2;
-    const auto y2 = y * y;
-    const auto y4 = y2 * y2;
-    const auto r2 = x2 + y2;
+    const T x2 = x * x;
+    const T x4 = x2 * x2;
+    const T y2 = y * y;
+    const T y4 = y2 * y2;
+    const T r2 = x2 + y2;
+    const T r4 = r2 * r2;
+    const T r6 = r4 * r2;
 
-    jacobian[0] = T(7.0) * k3 * x4 * x2 + T(5.0) * k2 * x4 +
-                  T(15.0) * k3 * y2 * x4 + T(3.0) * k1 * x2 +
-                  T(9.0) * k3 * y4 * x2 + T(6.0) * k2 * y2 * x2 + k3 * y2 * y4 +
-                  k2 * y4 + k1 * y2 + T(1.0) + p1 * y + T(6.0) * p2 * x;
-    jacobian[1] = x * (T(6.0) * k3 * y * y4 + T(4.0) * k2 * y * y2 +
-                       T(12.0) * k3 * x2 * y2 * y + T(2.0) * k1 * y +
-                       T(6.0) * k3 * x4 * y + T(4.0) * k2 * x2 * y) +
-                  p1 * x + T(2.0) * p2 * y;
-    jacobian[Stride] = y * (T(6.0) * k3 * x * x4 + T(4.0) * k2 * x * x2 +
-                            T(12.0) * k3 * y2 * x2 * x + T(2.0) * k1 * x +
-                            T(6.0) * k3 * y4 * x + T(4.0) * k2 * y2 * x) +
-                       p2 * y + T(2.0) * p1 * x;
-    jacobian[Stride + 1] =
-        T(7.0) * k3 * y4 * y2 + T(5.0) * k2 * y4 + T(15.0) * k3 * x2 * y4 +
-        T(3.0) * k1 * y2 + T(9.0) * k3 * x4 * y2 + T(6.0) * k2 * x2 * y2 +
-        k3 * x2 * x4 + k2 * x4 + k1 * x2 + T(1.0) + p2 * x + T(6.0) * p1 * y;
+    jacobian[0] = T(5.0) * k2 * x4 + T(3.0) * k1 * x2 + T(6.0) * k3 * x2 * r4 +
+                  T(6.0) * k2 * x2 * y2 + k3 * r6 + k2 * y4 + k1 * y2 + T(1.0) +
+                  T(2.0) * p1 * y + T(6.0) * p2 * x;
+    jacobian[1] =
+        x * (T(2.0) * k1 * y + T(4.0) * k2 * y * r2 + T(6.0) * k3 * y * r4) +
+        T(2.0) * p1 * x + T(2.0) * p2 * y;
+    jacobian[Stride + 1] = T(5.0) * k2 * y4 + T(3.0) * k1 * y2 +
+                           T(6.0) * k3 * y2 * r4 + T(6.0) * k2 * x2 * y2 +
+                           k3 * r6 + k2 * x4 + k1 * x2 + T(1.0) +
+                           T(2.0) * p2 * x + T(6.0) * p1 * y;
+    jacobian[Stride] =
+        y * (T(2.0) * k1 * x + T(4.0) * k2 * x * r2 + T(6.0) * k3 * x * r4) +
+        T(2.0) * p2 * y + T(2.0) * p1 * x;
 
     if (COMP_PARAM) {
       jacobian[2] = x * r2;

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -695,7 +695,7 @@ struct ProjectGeneric {
   struct ForwardWrapper : public FUNC {
     template <class T>
     static void Apply(const T* in, const T* parameters, T* out) {
-      Forward(in, parameters, out);
+      FUNC::Forward(in, parameters, out);
     }
   };
 
@@ -703,7 +703,7 @@ struct ProjectGeneric {
   struct BackwardWrapper : public FUNC {
     template <class T>
     static void Apply(const T* in, const T* parameters, T* out) {
-      Backward(in, parameters, out);
+      FUNC::Backward(in, parameters, out);
     }
   };
 

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -622,10 +622,10 @@ void ComposeDerivatives(
       jacobian2.template block<OutSize2, ParamSize2>(0, OutSize1);
 }
 
-/* Below are some utilities to generalize computation of jacobian of
- * composition of functions f(g(h(i ... ))). Most of the implementation
- * consists in recursing variadic template arguments. Usage is then
- * summarized as : ComposeForwardDerivatives<Func1, Func2, ... FuncN>() */
+/* Below are some utilities to generalize computation of functions (or their
+ * jacobian) of composition of functions f(g(h(i ... ))). Most of the
+ * implementation consists in recursing variadic template arguments. Usage is
+ * then summarized as : ComposeForwardDerivatives<Func1, Func2, ... FuncN>() */
 template <class FUNC>
 static constexpr int ComposeStrides() {
   return FUNC::template Stride<true>();

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -36,7 +36,7 @@ struct FisheyeProjection : CameraFunctor<3, 0, 2>{
   static void ForwardDerivatives(const T* point, const T* /* p */, T* projected,
                                  T* jacobian) {
     // dx, dy, dz
-    constexpr int stride = COMP_PARAM*ParamSize + InSize;
+    constexpr int stride = Stride<COMP_PARAM>();
     const T r2 = SquaredNorm(point);
     const T r = sqrt(r2);
     const T R2 = r2 + point[2] * point[2];
@@ -89,7 +89,7 @@ struct PerspectiveProjection : CameraFunctor<3, 0, 2> {
   static void ForwardDerivatives(const T* point, const T* /* p */, T* projected,
                                  T* jacobian) {
     // dx, dy, dz
-    constexpr int stride = COMP_PARAM*ParamSize + InSize;
+    constexpr int stride = Stride<COMP_PARAM>();
     jacobian[0] = T(1.0) / point[2];
     jacobian[1] = T(0.0);
     jacobian[2] = -point[0] / (point[2] * point[2]);

--- a/opensfm/src/geometry/src/camera.cc
+++ b/opensfm/src/geometry/src/camera.cc
@@ -9,9 +9,9 @@ Camera::Camera(const std::vector<Camera::Parameters>& types, const VecXd& values
 Camera Camera::CreatePerspectiveCamera(double focal, double k1, double k2) {
   Camera camera;
   camera.type_ = ProjectionType::PERSPECTIVE;
-  camera.types_= {Camera::Parameters::Focal, Camera::Parameters::K1, Camera::Parameters::K2};
+  camera.types_= {Camera::Parameters::K1, Camera::Parameters::K2, Camera::Parameters::Focal};
   camera.values_.resize(3);
-  camera.values_ << focal, k1, k2;
+  camera.values_ << k1, k2, focal;
   return camera;
 };
 
@@ -23,23 +23,25 @@ Camera Camera::CreateBrownCamera(double focal, double aspect_ratio,
     throw std::runtime_error("Invalid distortion coefficients size");
   }
   camera.type_ = ProjectionType::BROWN;
-  camera.types_ = {Camera::Parameters::Focal, Camera::Parameters::AspectRatio,
-                   Camera::Parameters::Cx,    Camera::Parameters::Cy,
-                   Camera::Parameters::K1,    Camera::Parameters::K2,
-                   Camera::Parameters::K3,    Camera::Parameters::P1,
-                   Camera::Parameters::P2};
+  camera.types_ = {Camera::Parameters::K1,          Camera::Parameters::K2,
+                   Camera::Parameters::K3,          Camera::Parameters::P1,
+                   Camera::Parameters::P2,          Camera::Parameters::Focal,
+                   Camera::Parameters::AspectRatio, Camera::Parameters::Cx,
+                   Camera::Parameters::Cy};
   camera.values_.resize(9);
-  camera.values_ << focal, aspect_ratio, principal_point[0], principal_point[1],
-      distortion[0], distortion[1], distortion[2], distortion[3], distortion[4];
+  camera.values_ << distortion[0], distortion[1], distortion[2], distortion[3],
+      distortion[4], focal, aspect_ratio, principal_point[0],
+      principal_point[1];
   return camera;
 };
 
 Camera Camera::CreateFisheyeCamera(double focal, double k1, double k2) {
   Camera camera;
   camera.type_ = ProjectionType::FISHEYE;
-  camera.types_= {Camera::Parameters::Focal, Camera::Parameters::K1, Camera::Parameters::K2};
+  camera.types_ = {Camera::Parameters::K1, Camera::Parameters::K2,
+                   Camera::Parameters::Focal};
   camera.values_.resize(3);
-  camera.values_ << focal, k1, k2;
+  camera.values_ << k1, k2, focal;
   return camera;
 };
 
@@ -47,9 +49,10 @@ Camera Camera::CreateDualCamera(double transition, double focal, double k1,
                                 double k2) {
   Camera camera;
   camera.type_ = ProjectionType::DUAL;
-  camera.types_= {Camera::Parameters::Focal, Camera::Parameters::K1, Camera::Parameters::K2, Camera::Parameters::Transition};
+  camera.types_ = {Camera::Parameters::Transition, Camera::Parameters::K1,
+                   Camera::Parameters::K2, Camera::Parameters::Focal};
   camera.values_.resize(4);
-  camera.values_ << focal, k1, k2, transition;
+  camera.values_ << transition, k1, k2, focal;
   return camera;
 };
 

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -47,7 +47,7 @@ class CameraFixture : public ::testing::Test {
 
   template <class MAT>
   void CheckJacobian(const MAT& jacobian, int size_params) {
-    const double eps = 17e-4;
+    const double eps = 1e-12;
     for (int i = 0; i < 2; ++i) {
       for (int j = 0; j < size_params; ++j) {
         ASSERT_NEAR(projection_expected[i].derivatives()(j), jacobian(i, j), eps);


### PR DESCRIPTION
This PR aims at adding analytical computation of camera projection functions, with the hope, it will speed-up bundle adjustment process. To do so, we had :
 - Generalize camera functions as `CameraFunctors`
 - Implement local jacobians of such camera functors.
 - Implement helper that automatically chain the above local jacobian, along the function composition.
 - Re-use the same to re-express the generic camera models.
 - Add corresponding unit test that uses `Eigen` `autodiff` to check for correctness.

As a bonus, we changed the parameter indexing in the camera class so it matches the ordering of the camera functions composition. This is still cumbersome and needs to be changed.