### PR TITLE
feat: plug analytical derivatives in bundle

### DIFF
--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -107,6 +107,7 @@ bundle_max_iterations: 100      # Maximum optimizer iterations.
 
 retriangulation: yes                # Retriangulate all points from time to time
 retriangulation_ratio: 1.2          # Retriangulate when the number of points grows by this ratio
+bundle_analytic_derivatives: yes    # Use analytic derivatives or auto-differentiated ones during bundle adjustment
 bundle_interval: 999999             # Bundle after adding 'bundle_interval' cameras
 bundle_new_points_ratio: 1.2        # Bundle when the number of points grows by this ratio
 local_bundle_radius: 3              # Max image graph distance for images to be included in local bundle adjustment

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -31,7 +31,7 @@ from opensfm.context import parallel_map, current_memory_usage
 logger = logging.getLogger(__name__)
 
 
-USE_ANALYTIC_DERIVATIVES = True
+USE_ANALYTIC_DERIVATIVES = False
 
 
 def _get_camera_from_bundle(ba, camera):

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -31,6 +31,9 @@ from opensfm.context import parallel_map, current_memory_usage
 logger = logging.getLogger(__name__)
 
 
+USE_ANALYTIC_DERIVATIVES = True
+
+
 def _get_camera_from_bundle(ba, camera):
     """Read camera parameters from a bundle adjustment problem."""
     c = ba.get_camera(camera.id)
@@ -101,6 +104,7 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
 
     chrono = Chronometer()
     ba = pybundle.BundleAdjuster()
+    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
 
     for camera in reconstruction.cameras.values():
         camera_prior = camera_priors[camera.id]
@@ -187,6 +191,7 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
 def bundle_single_view(graph, reconstruction, shot_id, camera_priors, config):
     """Bundle adjust a single camera."""
     ba = pybundle.BundleAdjuster()
+    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
     shot = reconstruction.shots[shot_id]
     camera = shot.camera
     camera_prior = camera_priors[camera.id]
@@ -256,6 +261,7 @@ def bundle_local(graph, reconstruction, camera_priors, gcp, central_shot_id, con
                     point_ids.add(track)
 
     ba = pybundle.BundleAdjuster()
+    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
 
     for camera in reconstruction.cameras.values():
         camera_prior = camera_priors[camera.id]

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -31,9 +31,6 @@ from opensfm.context import parallel_map, current_memory_usage
 logger = logging.getLogger(__name__)
 
 
-USE_ANALYTIC_DERIVATIVES = False
-
-
 def _get_camera_from_bundle(ba, camera):
     """Read camera parameters from a bundle adjustment problem."""
     c = ba.get_camera(camera.id)
@@ -101,10 +98,11 @@ def _add_gcp_to_bundle(ba, gcp, shots):
 def bundle(graph, reconstruction, camera_priors, gcp, config):
     """Bundle adjust a reconstruction."""
     fix_cameras = not config['optimize_camera_parameters']
+    use_analytic_derivatives = config['bundle_analytic_derivatives']
 
     chrono = Chronometer()
     ba = pybundle.BundleAdjuster()
-    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
+    ba.set_use_analytic_derivatives(use_analytic_derivatives)
 
     for camera in reconstruction.cameras.values():
         camera_prior = camera_priors[camera.id]
@@ -191,7 +189,7 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
 def bundle_single_view(graph, reconstruction, shot_id, camera_priors, config):
     """Bundle adjust a single camera."""
     ba = pybundle.BundleAdjuster()
-    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
+    ba.set_use_analytic_derivatives(config['bundle_analytic_derivatives'])
     shot = reconstruction.shots[shot_id]
     camera = shot.camera
     camera_prior = camera_priors[camera.id]
@@ -261,7 +259,7 @@ def bundle_local(graph, reconstruction, camera_priors, gcp, central_shot_id, con
                     point_ids.add(track)
 
     ba = pybundle.BundleAdjuster()
-    ba.set_use_analytic_derivatives(USE_ANALYTIC_DERIVATIVES)
+    ba.set_use_analytic_derivatives(config['bundle_analytic_derivatives'])
 
     for camera in reconstruction.cameras.values():
         camera_prior = camera_priors[camera.id]

--- a/opensfm/src/bundle/CMakeLists.txt
+++ b/opensfm/src/bundle/CMakeLists.txt
@@ -23,6 +23,17 @@ if (SUITESPARSE_FOUND)
 endif()
 target_include_directories(bundle PRIVATE ${CMAKE_SOURCE_DIR})
 
+set(BUNDLE_TEST_FILES
+    test/reprojection_errors_test.cc
+)
+add_executable(bundle_test ${BUNDLE_TEST_FILES})
+target_include_directories(bundle_test PRIVATE ${CMAKE_SOURCE_DIR} ${EIGEN_INCLUDE_DIRS})
+target_link_libraries(bundle_test
+                      PUBLIC
+                      bundle
+                      ${TEST_MAIN})
+add_test(bundle_test bundle_test)
+
 pybind11_add_module(pybundle python/pybind.cc)
 target_link_libraries(pybundle PRIVATE
   bundle

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -500,6 +500,7 @@ class BundleAdjuster {
 
   void SetMaxNumIterations(int miter);
   void SetNumThreads(int n);
+  void SetUseAnalyticDerivatives(bool use);
   void SetLinearSolverType(std::string t);
 
   void SetInternalParametersPriorSD(
@@ -542,7 +543,7 @@ class BundleAdjuster {
   std::map<std::string, BAPoint> points_;
 
   
-  bool use_new_{false};
+  bool use_analytic_{false};
 
   // minimization constraints
 

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cmath>
 #include <cstdio>
 #include <iostream>

--- a/opensfm/src/bundle/python/pybind.cc
+++ b/opensfm/src/bundle/python/pybind.cc
@@ -57,6 +57,7 @@ PYBIND11_MODULE(pybundle, m) {
     .def("set_max_num_iterations", &BundleAdjuster::SetMaxNumIterations)
     .def("set_adjust_absolute_position_std", &BundleAdjuster::SetAdjustAbsolutePositionStd)
     .def("set_num_threads", &BundleAdjuster::SetNumThreads)
+    .def("set_use_analytic_derivatives", &BundleAdjuster::SetUseAnalyticDerivatives)
     .def("set_linear_solver_type", &BundleAdjuster::SetLinearSolverType)
     .def("brief_report", &BundleAdjuster::BriefReport)
     .def("full_report", &BundleAdjuster::FullReport)

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -456,6 +456,11 @@ struct ErrorTraitsAnalytic {
   using Type = ReprojectionError2DAnalytic<C>;
 };
 
+template <>
+struct ErrorTraitsAnalytic<SphericalCamera, 1> {
+  using Type = ReprojectionError3DAnalytic;
+};
+
 struct AddProjectionError {
   template <class T>
   static void Apply(bool use_analytical, const BAPointProjectionObservation &obs,

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -323,6 +323,10 @@ void BundleAdjuster::SetNumThreads(int n) {
   num_threads_ = n;
 }
 
+void BundleAdjuster::SetUseAnalyticDerivatives(bool use){
+  use_analytic_ = use;
+}
+
 void BundleAdjuster::SetLinearSolverType(std::string t) {
   linear_solver_type_ = t;
 }
@@ -441,28 +445,38 @@ struct BAParameterBarrier {
 template <class T>
 struct ErrorTraits {
   using Type = ReprojectionError2D;
-  static constexpr int Size = 2;
 };
 template <>
 struct ErrorTraits<SphericalCamera> {
   using Type = ReprojectionError3D;
-  static constexpr int Size = 3;
+};
+
+template <class T, int C>
+struct ErrorTraitsAnalytic {
+  using Type = ReprojectionError2DAnalytic<C>;
 };
 
 struct AddProjectionError {
   template <class T>
-  static void Apply(const BAPointProjectionObservation &obs,
+  static void Apply(bool use_analytical, const BAPointProjectionObservation &obs,
                     ceres::LossFunction *loss, ceres::Problem *problem) {
-    using ErrorType = typename ErrorTraits<T>::Type;
-    constexpr static int ErrorSize = ErrorTraits<T>::Size;
+    constexpr static int ErrorSize = ErrorTraits<T>::Type::Size;
     constexpr static int CameraSize = T::Size;
     constexpr static int ShotSize = 6;
 
-    ceres::CostFunction *cost_function =
-        new ceres::AutoDiffCostFunction<ErrorType, ErrorSize, CameraSize,
-                                        ShotSize, 3>(
-            new ErrorType(obs.camera->GetValue().GetProjectionType(),
-                          obs.coordinates, obs.std_deviation));
+    ceres::CostFunction *cost_function = nullptr;
+    if(use_analytical){
+      using ErrorType = typename ErrorTraitsAnalytic<T, CameraSize>::Type;
+      cost_function = new ErrorType(obs.camera->GetValue().GetProjectionType(),
+                                    obs.coordinates, obs.std_deviation);
+    }
+    else{
+      using ErrorType = typename ErrorTraits<T>::Type;
+      cost_function = new ceres::AutoDiffCostFunction<ErrorType, ErrorSize,
+                                                      CameraSize, ShotSize, 3>(
+          new ErrorType(obs.camera->GetValue().GetProjectionType(),
+                        obs.coordinates, obs.std_deviation));
+    }
     problem->AddResidualBlock(
         cost_function, loss, obs.camera->GetValueData().data(),
         obs.shot->parameters.data(), obs.point->parameters.data());
@@ -471,16 +485,32 @@ struct AddProjectionError {
 
 struct ComputeResidualError {
   template <class T>
-  static void Apply(const BAPointProjectionObservation &obs) {
-    using ErrorType = typename ErrorTraits<T>::Type;
-    constexpr static int ErrorSize = ErrorTraits<T>::Size;
+  static void Apply(bool use_analytical,
+                    const BAPointProjectionObservation &obs) {
+    if (use_analytical) {
+      constexpr static int CameraSize = T::Size;
+      using ErrorType = typename ErrorTraitsAnalytic<T, CameraSize>::Type;
+      constexpr static int ErrorSize = ErrorTraitsAnalytic<T, CameraSize>::Type::Size;
 
-    VecNd<ErrorSize> residuals;
-    ErrorType error(obs.camera->GetValue().GetProjectionType(), obs.coordinates,
-                    1.0);
-    error(obs.camera->GetValueData().data(), obs.shot->parameters.data(),
-          obs.point->parameters.data(), residuals.data());
-    obs.point->reprojection_errors[obs.shot->id] = residuals;
+      VecNd<ErrorSize> residuals;
+      ErrorType error(obs.camera->GetValue().GetProjectionType(),
+                      obs.coordinates, 1.0);
+      const double *params[] = {obs.camera->GetValueData().data(),
+                                obs.shot->parameters.data(),
+                                obs.point->parameters.data()};
+      error.Evaluate(params, residuals.data(), nullptr);
+      obs.point->reprojection_errors[obs.shot->id] = residuals;
+    } else {
+      using ErrorType = typename ErrorTraits<T>::Type;
+      constexpr static int ErrorSize = ErrorTraits<T>::Type::Size;
+
+      VecNd<ErrorSize> residuals;
+      ErrorType error(obs.camera->GetValue().GetProjectionType(),
+                      obs.coordinates, 1.0);
+      error(obs.camera->GetValueData().data(), obs.shot->parameters.data(),
+            obs.point->parameters.data(), residuals.data());
+      obs.point->reprojection_errors[obs.shot->id] = residuals;
+    }
   }
 };
 
@@ -580,8 +610,8 @@ void BundleAdjuster::Run() {
   for (auto &observation : point_projection_observations_) {
     const auto projection_type =
         observation.camera->GetValue().GetProjectionType();
-    Dispatch<AddProjectionError>(projection_type, observation, projection_loss,
-                                 &problem);
+    Dispatch<AddProjectionError>(projection_type, use_analytic_, observation,
+                                 projection_loss, &problem);
   }
 
   // Add rotation priors
@@ -924,7 +954,7 @@ void BundleAdjuster::ComputeReprojectionErrors() {
   for (auto &observation : point_projection_observations_) {
     const auto projection_type =
       observation.camera->GetValue().GetProjectionType();
-    Dispatch<ComputeResidualError>(projection_type, observation);
+    Dispatch<ComputeResidualError>(projection_type, use_analytic_, observation);
   }
 }
 

--- a/opensfm/src/bundle/src/projection_errors.h
+++ b/opensfm/src/bundle/src/projection_errors.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <ceres/sized_cost_function.h>
 #include <foundation/types.h>
 #include <geometry/camera_functions.h>
+#include <bundle/bundle_adjuster.h>
 
 template <class PointFunc> 
 struct BABearingError {
@@ -166,7 +168,7 @@ class ReprojectionError2DAnalytic : public ReprojectionError,
       Pose::ForwardDerivatives<double, true>(point, shot, &transformed[0],
                                              jacobian_pose.data());
       // Projection jacobian
-      constexpr int CameraSize = 9;
+      constexpr int CameraSize = C;
       const int StrideProj = PointSize + CameraSize;
       Eigen::Matrix<double, Size, StrideProj, Eigen::RowMajor> jacobian_proj;
       Dispatch<ProjectDerivativesFunction>(type_, transformed, camera,

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -7,12 +7,10 @@
 
 class ReprojectionError2DFixture : public ::testing::Test {
  public:
- typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
-  ReprojectionError2DFixture() {
-    observed << 0.5, 0.5;
-  }
+  typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
+  ReprojectionError2DFixture() { observed << 0.5, 0.5; }
 
-  void SetupADiff(int size, const double* camera, AScalar* camera_adiff){
+  void SetupADiff(int size, const double* camera, AScalar* camera_adiff) {
     const int total_size = size_point + size_rt + size;
     for (int i = 0; i < size_point; ++i) {
       point_adiff[i].value() = point[i];
@@ -24,25 +22,24 @@ class ReprojectionError2DFixture : public ::testing::Test {
     }
     for (int i = 0; i < size; ++i) {
       camera_adiff[i].value() = camera[i];
-      camera_adiff[i].derivatives() =
-          VecXd::Unit(total_size, size_point + size_rt + i);
+      camera_adiff[i].derivatives() = VecXd::Unit(total_size, size_point + size_rt + i);
     }
   }
 
   void CheckJacobians(int size, const double* jac_camera) {
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < size_residual; ++i) {
       for (int j = 0; j < size; ++j) {
         ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + size_rt + j),
                     jac_camera[i * size + j], 1e-15);
       }
     }
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < size_residual; ++i) {
       for (int j = 0; j < size_point; ++j) {
         ASSERT_NEAR(residual_adiff[i].derivatives()(j),
                     jac_point[i * size_point + j], 1e-15);
       }
     }
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < size_residual; ++i) {
       for (int j = 0; j < size_rt; ++j) {
         ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + j),
                     jac_rt[i * size_rt + j], 1e-15);
@@ -61,8 +58,7 @@ class ReprojectionError2DFixture : public ::testing::Test {
     autodiff(camera_adiff, rt_adiff, point_adiff, residual_adiff);
 
     // We test for analytic evaluation
-    double residuals[2];
-    double jac_camera[2 * size];
+    double jac_camera[size_residual * size];
     const double* params[] = {camera, rt, point};
     double* jacobians[] = {jac_camera, jac_rt, jac_point};
     ReprojectionError2DAnalytic<size> analytic(type, observed, scale);
@@ -72,6 +68,7 @@ class ReprojectionError2DFixture : public ::testing::Test {
     CheckJacobians(size, jac_camera);
   }
 
+  constexpr static int size_residual = 2;
   constexpr static int size_point = 3;
   constexpr static int size_rt = 6;
 
@@ -80,15 +77,14 @@ class ReprojectionError2DFixture : public ::testing::Test {
   const double point[size_point] = {1.0, 2.0, 3.0};
   const double rt[size_rt] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
 
-  AScalar residual_adiff[2];
+  AScalar residual_adiff[size_residual];
   AScalar point_adiff[size_point];
   AScalar rt_adiff[size_rt];
 
-  double residuals[2];
-  double jac_rt[2 * size_rt];
-  double jac_point[2 * size_point];
+  double residuals[size_residual];
+  double jac_rt[size_residual * size_rt];
+  double jac_point[size_residual * size_point];
 };
-
 
 TEST_F(ReprojectionError2DFixture, BrownAnalyticErrorEvaluatesOK) {
   constexpr int size = 9;
@@ -120,5 +116,69 @@ TEST_F(ReprojectionError2DFixture, DualAnalyticErrorEvaluatesOK) {
   // focal k1, k2
   const double camera[size] = {0.5, 0.3, 0.1, -0.03};
   RunTest<size>(ProjectionType::DUAL, &camera[0]);
+}
+
+class ReprojectionError3DFixture : public ::testing::Test {
+ public:
+ static constexpr int size = 3;
+
+ typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
+ ReprojectionError3DFixture() { observed << 0.5, 0.5; }
+
+ void SetupADiff() {
+   const int total_size = size_point + size_rt;
+   for (int i = 0; i < size_point; ++i) {
+     point_adiff[i].value() = point[i];
+     point_adiff[i].derivatives() = VecXd::Unit(total_size, i);
+   }
+   for (int i = 0; i < size_rt; ++i) {
+     rt_adiff[i].value() = rt[i];
+     rt_adiff[i].derivatives() = VecXd::Unit(total_size, size_point + i);
+   }
+  }
+
+  void CheckJacobians() {
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size_rt; ++j) {
+        ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + j),
+                    jac_rt[i * size_rt + j], 1e-14);
+      }
+    }
+  }
+
+  constexpr static int size_point = 3;
+  constexpr static int size_rt = 6;
+
+  Vec2d observed;
+  double scale{0.1};
+  const double point[size_point] = {1.0, 2.0, 3.0};
+  const double rt[size_rt] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+
+  AScalar residual_adiff[size];
+  AScalar point_adiff[size_point];
+  AScalar rt_adiff[size_rt];
+
+  double residuals[size];
+  double jac_rt[size * size_rt];
+  double jac_point[size * size_point];
+};
+
+TEST_F(ReprojectionError3DFixture, AnalyticErrorEvaluatesOK) {
+  // Autodiff-ed version will be used as reference/expected values
+    SetupADiff();
+    AScalar dummy_adiff;
+    ReprojectionError3D autodiff(ProjectionType::SPHERICAL, observed, scale);
+    autodiff(&dummy_adiff, rt_adiff, point_adiff, residual_adiff);
+
+    // We test for analytic evaluation
+    double dummy = 0.;
+    double dummy_jac[] = {0., 0., 0.};
+    const double* params[] = {&dummy, rt, point};
+    double* jacobians[] = {&dummy_jac[0], jac_rt, jac_point};
+    ReprojectionError3DAnalytic analytic(ProjectionType::SPHERICAL, observed, scale);
+    analytic.Evaluate(params, residuals, &jacobians[0]);
+
+    // Check
+    CheckJacobians();
 }
 

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -113,7 +113,7 @@ TEST_F(ReprojectionError2DFixture, FisheyeAnalyticErrorEvaluatesOK) {
 TEST_F(ReprojectionError2DFixture, DualAnalyticErrorEvaluatesOK) {
   constexpr int size = 4;
   
-  // focal k1, k2
+  // transtion, focal, k1, k2
   const double camera[size] = {0.5, 0.3, 0.1, -0.03};
   RunTest<size>(ProjectionType::DUAL, &camera[0]);
 }

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -139,6 +139,12 @@ class ReprojectionError3DFixture : public ::testing::Test {
 
   void CheckJacobians() {
     for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size_point; ++j) {
+        ASSERT_NEAR(residual_adiff[i].derivatives()(j),
+                    jac_point[i * size_point + j], 1e-14);
+      }
+    }
+    for (int i = 0; i < size; ++i) {
       for (int j = 0; j < size_rt; ++j) {
         ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + j),
                     jac_rt[i * size_rt + j], 1e-14);

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -1,0 +1,124 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+#include <bundle/src/projection_errors.h>
+
+class ReprojectionError2DFixture : public ::testing::Test {
+ public:
+ typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
+  ReprojectionError2DFixture() {
+    observed << 0.5, 0.5;
+  }
+
+  void SetupADiff(int size, const double* camera, AScalar* camera_adiff){
+    const int total_size = size_point + size_rt + size;
+    for (int i = 0; i < size_point; ++i) {
+      point_adiff[i].value() = point[i];
+      point_adiff[i].derivatives() = VecXd::Unit(total_size, i);
+    }
+    for (int i = 0; i < size_rt; ++i) {
+      rt_adiff[i].value() = rt[i];
+      rt_adiff[i].derivatives() = VecXd::Unit(total_size, size_point + i);
+    }
+    for (int i = 0; i < size; ++i) {
+      camera_adiff[i].value() = camera[i];
+      camera_adiff[i].derivatives() =
+          VecXd::Unit(total_size, size_point + size_rt + i);
+    }
+  }
+
+  void CheckJacobians(int size, const double* jac_camera) {
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < size; ++j) {
+        ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + size_rt + j),
+                    jac_camera[i * size + j], 1e-15);
+      }
+    }
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < size_point; ++j) {
+        ASSERT_NEAR(residual_adiff[i].derivatives()(j),
+                    jac_point[i * size_point + j], 1e-15);
+      }
+    }
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < size_rt; ++j) {
+        ASSERT_NEAR(residual_adiff[i].derivatives()(size_point + j),
+                    jac_rt[i * size_rt + j], 1e-15);
+      }
+    }
+  }
+
+  template <int N>
+  void RunTest(const ProjectionType& type, const double* camera) {
+    constexpr int size = N;
+
+    // Autodiff-ed version will be used as reference/expected values
+    AScalar camera_adiff[size];
+    SetupADiff(size, &camera[0], &camera_adiff[0]);
+    ReprojectionError2D autodiff(type, observed, scale);
+    autodiff(camera_adiff, rt_adiff, point_adiff, residual_adiff);
+
+    // We test for analytic evaluation
+    double residuals[2];
+    double jac_camera[2 * size];
+    const double* params[] = {camera, rt, point};
+    double* jacobians[] = {jac_camera, jac_rt, jac_point};
+    ReprojectionError2DAnalytic<size> analytic(type, observed, scale);
+    analytic.Evaluate(params, residuals, &jacobians[0]);
+
+    // Check
+    CheckJacobians(size, jac_camera);
+  }
+
+  constexpr static int size_point = 3;
+  constexpr static int size_rt = 6;
+
+  Vec2d observed;
+  double scale{0.1};
+  const double point[size_point] = {1.0, 2.0, 3.0};
+  const double rt[size_rt] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+
+  AScalar residual_adiff[2];
+  AScalar point_adiff[size_point];
+  AScalar rt_adiff[size_rt];
+
+  double residuals[2];
+  double jac_rt[2 * size_rt];
+  double jac_point[2 * size_point];
+};
+
+
+TEST_F(ReprojectionError2DFixture, BrownAnalyticErrorEvaluatesOK) {
+  constexpr int size = 9;
+  
+  // focal, ar, cx, cy, k1, k2, k3, p1, p2
+  const double camera[size] = {0.3, 1.0, 0.001, -0.02, 0.1, -0.03, 0.001, -0.005, 0.001};
+  RunTest<size>(ProjectionType::BROWN, &camera[0]);
+}
+
+TEST_F(ReprojectionError2DFixture, PerspectiveAnalyticErrorEvaluatesOK) {
+  constexpr int size = 3;
+  
+  // focal k1, k2
+  const double camera[size] = {0.3, 0.1, -0.03};
+  RunTest<size>(ProjectionType::PERSPECTIVE, &camera[0]);
+}
+
+TEST_F(ReprojectionError2DFixture, FisheyeAnalyticErrorEvaluatesOK) {
+  constexpr int size = 3;
+  
+  // focal k1, k2
+  const double camera[size] = {0.3, 0.1, -0.03};
+  RunTest<size>(ProjectionType::FISHEYE, &camera[0]);
+}
+
+TEST_F(ReprojectionError2DFixture, DualAnalyticErrorEvaluatesOK) {
+  constexpr int size = 4;
+  
+  // focal k1, k2
+  const double camera[size] = {0.5, 0.3, 0.1, -0.03};
+  RunTest<size>(ProjectionType::DUAL, &camera[0]);
+}
+

--- a/opensfm/src/foundation/numeric.h
+++ b/opensfm/src/foundation/numeric.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <Eigen/Dense>
+#include <foundation/types.h>
 
 #define SQUARE(x) ((x)*(x))
 
@@ -41,6 +42,11 @@ bool SolveAX0(const MAT& A, VEC* solution){
 
 
 Eigen::Matrix3d SkewMatrix(const Eigen::Vector3d& v);
+template <class V, class M>
+void SkewMatrixT(const V& v, M* matrix) {
+  (*matrix) << 0, -v(2), v(1), v(2), 0, -v(0), -v(1), v(0), 0;
+}
+
 Eigen::Matrix3d ClosestRotationMatrix(const Eigen::Matrix3d& matrix);
 
 std::array<double, 4> SolveQuartic(const std::array<double, 5>& coefficients);

--- a/opensfm/src/foundation/src/numeric.cc
+++ b/opensfm/src/foundation/src/numeric.cc
@@ -4,9 +4,7 @@
 
 Eigen::Matrix3d SkewMatrix(const Eigen::Vector3d& v){
   Eigen::Matrix3d m;
-  m <<    0, -v(2),  v(1),
-       v(2),     0, -v(0),
-      -v(1),  v(0),     0;
+  SkewMatrixT(v, &m);
   return m;
 }
 

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -557,15 +557,6 @@ struct Identity : CameraFunctor<2, 0, 2>{
   }
 };
 
-// template<class PROJ>
-// struct PoseAndProjectionDerivatives{
-//   template <class TYPE, class T>
-//   static void Apply(const T* point, const T* parameters, T* projected) {
-//     ComposeForwardDerivatives<T, PROJ, Pose>(point, parameters, projected,
-//                                              jacobian);
-//   }
-// };
-
 struct ProjectFunction {
   template <class TYPE, class T>
   static void Apply(const T* point, const T* parameters, T* projected) {
@@ -797,6 +788,7 @@ struct Pose : CameraFunctor<3, 6, 3> {
         std::swap(jacobian[i * 9 + j], jacobian[i * 9 + 3 + j]);
       }
     }
+    Forward(point, rt, transformed);
   }
 
  private:

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -3,6 +3,8 @@
 #include <foundation/newton_raphson.h>
 #include <foundation/types.h>
 
+#include <unsupported/Eigen/AutoDiff>
+
 #include <iostream>
 
 enum class ProjectionType { PERSPECTIVE, BROWN, FISHEYE, SPHERICAL, DUAL };
@@ -357,7 +359,6 @@ struct DistoBrown : CameraFunctor<2, 5, 2>{
     const auto& p2 = k[static_cast<int>(Disto::P2)];
     const auto& x = point[0];
     const auto& y = point[1];
-    const auto& z = point[2];
 
     const T x2 = x * x;
     const T x4 = x2 * x2;
@@ -556,6 +557,15 @@ struct Identity : CameraFunctor<2, 0, 2>{
   }
 };
 
+// template<class PROJ>
+// struct PoseAndProjectionDerivatives{
+//   template <class TYPE, class T>
+//   static void Apply(const T* point, const T* parameters, T* projected) {
+//     ComposeForwardDerivatives<T, PROJ, Pose>(point, parameters, projected,
+//                                              jacobian);
+//   }
+// };
+
 struct ProjectFunction {
   template <class TYPE, class T>
   static void Apply(const T* point, const T* parameters, T* projected) {
@@ -685,6 +695,150 @@ static void ComposeFunctions(const T* in, const T* parameters, T* out) {
   constexpr int Index = ComposeIndex<FUNC2, FUNCS...>();
   FUNC1::template Apply<T>(&tmp[0], parameters + Index, out);
 }
+
+struct Pose : CameraFunctor<3, 6, 3> {
+  /* Rotation and translation being stored as angle-axis | translation, apply
+   the transformation : x_world = R(t)*(x_camera - translation) by directly
+   applying the angle-axis rotation */
+  enum { Rx = 0, Ry = 1, Rz = 2, Tx = 3, Ty = 4, Tz = 5 };
+  template <class T>
+  static void Forward(const T* point, const T* rt, T* transformed) {
+    const T x = point[0] - rt[Tx];
+    const T y = point[1] - rt[Ty];
+    const T z = point[2] - rt[Tz];
+
+    const T a = -rt[Rx];
+    const T b = -rt[Ry];
+    const T c = -rt[Rz];
+
+    // Dot product of angle-axis and the point
+    const T cp_x = b * z - c * y;
+    const T cp_y = c * x - a * z;
+    const T cp_z = a * y - b * x;
+
+    const T theta2 = a * a + b * b + c * c;
+    // Regular angle-axis transformation
+    if (theta2 > T(std::numeric_limits<double>::epsilon())) {
+      const T theta = sqrt(theta2);
+      const T inv_theta = T(1.0) / theta;
+      const T cos_theta = cos(theta);
+      const T sin_theta = sin(theta) / theta;
+      const T dot_pt_p =
+          (a * x + b * y + c * z) * (T(1.0) - cos_theta) / theta2;
+      transformed[0] = x * cos_theta + sin_theta * cp_x + a * dot_pt_p;
+      transformed[1] = y * cos_theta + sin_theta * cp_y + b * dot_pt_p;
+      transformed[2] = z * cos_theta + sin_theta * cp_z + c * dot_pt_p;
+      // Apply taylor approximation for small angles
+    } else {
+      transformed[0] = x + cp_x;
+      transformed[1] = y + cp_y;
+      transformed[2] = z + cp_z;
+    }
+  }
+
+  template <class T, bool COMP_PARAM>
+  static void ForwardDerivatives(const T* point, const T* rt, T* transformed,
+                                 T* jacobian) {
+    // dx, dy, dz, drx, dry, drz, dtz, dty, dtz
+    constexpr int stride = Stride<COMP_PARAM>();
+    using Dual = Eigen::AutoDiffScalar<Vec3d>;
+
+    /* Get jacobian or R wrt. angle-axis using Dual */
+    Dual r_diff[InSize];
+    r_diff[0].value() = -rt[Rx];
+    r_diff[0].derivatives() = -Vec3d::Unit(Rx);
+    r_diff[1].value() = -rt[Ry];
+    r_diff[1].derivatives() = -Vec3d::Unit(Ry);
+    r_diff[2].value() = -rt[Rz];
+    r_diff[2].derivatives() = -Vec3d::Unit(Rz);
+
+    Eigen::Matrix<Dual, 3, 3, Eigen::RowMajor> rotation;
+    RotationToAngleAxis(&r_diff[0], rotation.data());
+
+    /* Storage is row-ordered : R00, R01, R02, R10, ... R22 */
+    Eigen::Matrix<T, 9, 3, Eigen::RowMajor> rotation_angleaxis;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          rotation_angleaxis(i * 3 + j, k) = rotation(i, j).derivatives()(k);
+        }
+      }
+    }
+
+    /* R.(x-t) derivatives are pretty straightfoward : dR00, dR01, ... dR22,
+     * dx, dy, dz, dtx, dty, dtz */
+    const T xyz[] = {point[0] - rt[Tx], point[1] - rt[Ty], point[2] - rt[Tz]};
+    Eigen::Matrix<T, 3, 15, Eigen::RowMajor> point_rotation =
+        Eigen::Matrix<T, 3, 15, Eigen::RowMajor>::Zero();
+    for (int i = 0; i < 3; ++i) {
+      // dRij
+      for (int j = 0; j < 3; ++j) {
+        point_rotation(i, i * 3 + j) = xyz[j];
+      }
+      // dx, dy, dz
+      for (int j = 0; j < 3; ++j) {
+        point_rotation(i, 9 + j) = rotation(i, j).value();
+      }
+      // dtx, dty, dtz
+      for (int j = 0; j < 3; ++j) {
+        point_rotation(i, 12 + j) = -point_rotation(i, 9 + j);
+      }
+    }
+
+    /* Compose d(R) / d(angle axis) with d(pose) / d(R | t | x) in order to get
+     * d(pose) / d(angle axis | t | x) */
+    ComposeDerivatives<T, 9, 3, 0, 3, 15, 6>(rotation_angleaxis, point_rotation,
+                                             jacobian);
+
+    /* Re-orde from angle-axis | x | t to x | angle-axis | t */
+    for (int i = 0; i < 3; ++i) {
+      // Swap dai and dxi
+      for (int j = 0; j < 3; ++j) {
+        std::swap(jacobian[i * 9 + j], jacobian[i * 9 + 3 + j]);
+      }
+    }
+  }
+
+ private:
+  template <class T>
+  static void RotationToAngleAxis(const T* angle_axis, T* rotation) {
+    /* From
+     * https://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/
+     */
+
+    const T theta2 = SquaredNorm(angle_axis) + angle_axis[2] * angle_axis[2];
+    const T theta = sqrt(theta2);
+    const T c = cos(theta);
+    const T s = sin(theta);
+    const T t = T(1.0) - c;
+
+    const T inv_theta2 = T(1.0) / theta2;
+    const T inv_theta = T(1.0) / theta;
+
+    const T xx = angle_axis[0] * angle_axis[0] * inv_theta2;
+    const T xy = angle_axis[0] * angle_axis[1] * inv_theta2;
+    const T xz = angle_axis[0] * angle_axis[2] * inv_theta2;
+    const T yy = angle_axis[1] * angle_axis[1] * inv_theta2;
+    const T yz = angle_axis[1] * angle_axis[2] * inv_theta2;
+    const T zz = angle_axis[2] * angle_axis[2] * inv_theta2;
+
+    const T xs = angle_axis[0] * inv_theta * s;
+    const T ys = angle_axis[1] * inv_theta * s;
+    const T zs = angle_axis[2] * inv_theta * s;
+
+    rotation[0] = t * xx + c;
+    rotation[1] = t * xy - zs;
+    rotation[2] = t * xz + ys;
+
+    rotation[3] = t * xy + zs;
+    rotation[4] = t * yy + c;
+    rotation[5] = t * yz - xs;
+
+    rotation[6] = t * xz - ys;
+    rotation[7] = t * yz + xs;
+    rotation[8] = t * zz + c;
+  }
+};
 
 /* Finally, here's the generic camera that implements the PROJ - > DISTO -> AFFINE pattern. */
 template <class PROJ, class DISTO, class AFF>

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -494,9 +494,6 @@ TEST_F(PoseFixture, EvaluatesCorrectly) {
   }
 }
 
-#include <chrono> 
-using namespace std::chrono; 
-
 TEST_F(PoseFixture, EvaluatesDerivativesCorrectly) {
   typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
 

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -9,9 +9,6 @@
 #include <ceres/jet.h>
 #include <ceres/rotation.h>
 
-#include <chrono> 
-using namespace std::chrono; 
-
 class CameraFixture : public ::testing::Test {
  public:
   CameraFixture() {

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -7,6 +7,7 @@
 
 #include <geometry/camera.h>
 #include <ceres/jet.h>
+#include <ceres/rotation.h>
 
 #include <chrono> 
 using namespace std::chrono; 
@@ -462,5 +463,71 @@ TEST_F(FunctionFixture, EvaluatesDerivativesCorrectly) {
       eval_adiff.data(), parameters_adiff.data(), &evaluated_addif);
   for(int i = 0; i < 7; ++i){
     ASSERT_NEAR(evaluated_addif.derivatives()(i), jacobian[i], 1e-20);
+  }
+}
+
+class PoseFixture : public ::testing::Test {
+ public:
+  const double point[3] = {1.0, 2.0, 3.0};
+  const double rt[6] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6};
+};
+
+TEST_F(PoseFixture, EvaluatesCorrectly) {
+  double transformed[3] = {0., 0., 0.};
+
+  /* Parameters order : angle_axis | pose_center */
+  Pose::Forward(point, rt, transformed);
+
+  /* Use Ceres as groundtruth */
+  const double pt[3] = {
+    point[0] - rt[Pose::Tx],
+    point[1] - rt[Pose::Ty],
+    point[2] - rt[Pose::Tz],
+  };
+  const double Rt[3] = {
+    -rt[Pose::Rx],
+    -rt[Pose::Ry],
+    -rt[Pose::Rz]
+  };
+  double expected[] = {1., 1., 1.};
+  ceres::AngleAxisRotatePoint(Rt, pt, expected);
+
+  for(int i = 0; i < 3; ++i){
+    ASSERT_NEAR(expected[i], transformed[i], 1e-15);
+  }
+}
+
+#include <chrono> 
+using namespace std::chrono; 
+
+TEST_F(PoseFixture, EvaluatesDerivativesCorrectly) {
+  typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
+
+  VecX<AScalar> point_adiff(3);
+  constexpr int size = 9;
+
+  /* Autodifferentaied as a reference */
+  for (int i = 0; i < 3; ++i) {
+    point_adiff(i).value() = point[i];
+    point_adiff(i).derivatives() = Eigen::VectorXd::Unit(size, i);
+  }
+  VecX<AScalar> rt_adiff(6);
+  for (int i = 0; i < 6; ++i) {
+    rt_adiff[i].value() = rt[i];
+    rt_adiff[i].derivatives() = Eigen::VectorXd::Unit(size, 3 + i);
+  }
+  VecX<AScalar> expected_adiff(3);
+  Pose::Forward(point_adiff.data(), rt_adiff.data(), expected_adiff.data());
+
+  /* Analytic version */
+  double transformed[] = {0., 0., 0.};
+  double jacobian[size * 3];
+  Pose::ForwardDerivatives<double, true>(&point[0], &rt[0], &transformed[0],
+                                         &jacobian[0]);
+
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < size; ++j) {
+      ASSERT_NEAR(expected_adiff(i).derivatives()(j), jacobian[i * size + j], 1e-15);
+    }
   }
 }


### PR DESCRIPTION
This PR aims at effectively plugging the analytic derivatives in the bundle adjustment code (see https://github.com/mapillary/OpenSfM/pull/610). To do so we had to :

 - Add a functor that compute worl-to-camera transformation along with its derivatives. Such derivatives are themselves implemented using `angle axis` (along with `Jet`) to `3x3` (analytic) and then chained.
 - Compose the above functor with the projection ones to get the full projection function.
 - Use the above in some cost function (both 2D and 3D-bearing)
 - Activate the instantiation of the above through some boolean, so it is de-activated for now and we can test it.
 - Added the corresponding unit test of all of the above to ensure no-regression wrt. to the auto-differentiated derivatives.