### PR TITLE
Expose flann index algorithm

### DIFF
--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -43,8 +43,10 @@ matcher_type: FLANN           # FLANN, BRUTEFORCE, or WORDS
 symmetric_matching: yes       # Match symmetricly or one-way
 
 # Params for FLANN matching
+flann_algorithm: KMEANS      # Algorithm type (KMEANS, KDTREE)
 flann_branching: 8           # See OpenCV doc
 flann_iterations: 10          # See OpenCV doc
+flann_tree: 8                # See OpenCV doc
 flann_checks: 20             # Smaller -> Faster (but might lose good matches)
 
 # Params for BoW matching

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -299,13 +299,21 @@ def build_flann_index(features, config):
     FLANN_INDEX_LSH             = 6
 
     if features.dtype.type is np.float32:
-        FLANN_INDEX_METHOD = FLANN_INDEX_KMEANS
+        algorithm_type = config['flann_algorithm'].upper()
+        if algorithm_type == 'KMEANS':
+            FLANN_INDEX_METHOD = FLANN_INDEX_KMEANS
+        elif algorithm_type == 'KDTREE':
+            FLANN_INDEX_METHOD = FLANN_INDEX_KDTREE
+        else:
+            raise ValueError('Unknown flann algorithm type '
+                             'must be KMEANS, KDTREE')
     else:
         FLANN_INDEX_METHOD = FLANN_INDEX_LSH
 
     flann_params = dict(algorithm=FLANN_INDEX_METHOD,
                         branching=config['flann_branching'],
-                        iterations=config['flann_iterations'])
+                        iterations=config['flann_iterations'],
+                        tree=config['flann_tree'])
 
     return context.flann_Index(features, flann_params)
 


### PR DESCRIPTION
Hey ✋ all,

I've exposed the flann index algorithm choice (KDTREE and KMEANS) in the config file. This has several possible uses:
 - Choosing KDTREE can make it faster to build the index, which on some datasets seem to decrease overall runtime.
 - KMEANS in certain postprocessed datasets can crash; this is really rare, but I've found at least one dataset that has certain trouble images (images that have a large section where no features can be found, eg. any image with a large black patch, either due to corruption, thresholding or for masking reasons).

This PR leaves the default as KMEANS, so the default logic of the program is unchanged.

Hope this can be useful to others.

(Paper with runtime/accuracy comparisons of the two algorithms: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.160.1721&rep=rep1&type=pdf)
