### PR TITLE
Make shot measurements optional without using None

### DIFF
--- a/annotation_gui_gcp/imageSugestion.py
+++ b/annotation_gui_gcp/imageSugestion.py
@@ -14,13 +14,14 @@ def get_most_common_seqs(path):
     seq_dict_most_common = [[] for i in range(2)]
     for recons in reconstructions:
         for shot in recons.shots.values():
-            if not seq_dict.get(shot.metadata.skey, 0):
-                seq_dict[shot.metadata.skey] = []
-            seq_dict[shot.metadata.skey].append(shot)
+            skey = shot.metadata.sequence_key.value
+            if not seq_dict.get(skey, 0):
+                seq_dict[skey] = []
+            seq_dict[skey].append(shot)
     seq_dict_count = sorted(seq_dict, key=lambda k: len(seq_dict[k]),
                             reverse=True)  # two sequences with the most number of images
     for idx, key in enumerate(seq_dict_count[:2]):
-        seq_dict_most_common[idx] = sorted(seq_dict[key], key=lambda x: x.metadata.capture_time)
+        seq_dict_most_common[idx] = sorted(seq_dict[key], key=lambda x: x.metadata.capture_time.value)
         seq_dict_most_common[idx] = [shot.id for shot in seq_dict_most_common[idx]]
 
     return seq_dict_most_common
@@ -35,6 +36,6 @@ def get_all_images(path):
     data = dataset.DataSet(path)
     reconstructions = data.load_reconstruction()
     shots = sorted([shot for reconstruction in reconstructions for shot in reconstruction.shots.values()],
-                   key=lambda x: (x.metadata.skey, x.metadata.capture_time))
+                   key=lambda x: (x.metadata.sequence_key.value, x.metadata.capture_time.value))
     seqs = [[shot.id for shot in shots] for i in range(2)]
     return seqs

--- a/opensfm/align.py
+++ b/opensfm/align.py
@@ -81,7 +81,7 @@ def alignment_constraints(config, reconstruction, gcp):
     if config['bundle_use_gps']:
         for shot in reconstruction.shots.values():
             X.append(shot.pose.get_origin())
-            Xp.append(shot.metadata.gps_position)
+            Xp.append(shot.metadata.gps_position.value)
 
     return X, Xp
 
@@ -212,7 +212,7 @@ def estimate_ground_plane(reconstruction, config):
     for shot in reconstruction.shots.values():
         R = shot.pose.get_rotation_matrix()
         x, y, z = get_horizontal_and_vertical_directions(
-            R, shot.metadata.orientation)
+            R, shot.metadata.orientation.value)
         if orientation_type == 'no_roll':
             onplane.append(x)
             verticals.append(-y)

--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -116,8 +116,8 @@ def add_camera_constraints_soft(ra, reconstruction_shots, reconstruction_name):
                 ra.add_shot(shot_name, R[0], R[1], R[2],
                             t[0], t[1], t[2], False)
 
-                gps = shot.metadata.gps_position
-                gps_sd = shot.metadata.gps_dop
+                gps = shot.metadata.gps_position.value
+                gps_sd = shot.metadata.gps_accuracy.value
 
                 ra.add_absolute_position_constraint(
                         shot_name, gps[0], gps[1], gps[2], gps_sd)
@@ -152,8 +152,8 @@ def add_camera_constraints_hard(ra, reconstruction_shots,
             ra.add_shot(shot_name, R[0], R[1], R[2],
                         t[0], t[1], t[2], True)
 
-            gps = shot.metadata.gps_position
-            gps_sd = shot.metadata.gps_dop
+            gps = shot.metadata.gps_position.value
+            gps_sd = shot.metadata.gps_accuracy.value
             ra.add_relative_absolute_position_constraint(
                 rec_name, shot_name, gps[0], gps[1], gps[2], gps_sd)
 

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -119,9 +119,9 @@ def bundle(reconstruction, camera_priors, gcp, config):
 
     if config['bundle_use_gps']:
         for shot in reconstruction.shots.values():
-            g = shot.metadata.gps_position
+            g = shot.metadata.gps_position.value
             ba.add_position_prior(shot.id, g[0], g[1], g[2],
-                                  shot.metadata.gps_dop)
+                                  shot.metadata.gps_accuracy.value)
 
     if config['bundle_use_gcp'] and gcp:
         _add_gcp_to_bundle(ba, gcp, reconstruction.shots)
@@ -200,9 +200,9 @@ def bundle_single_view(reconstruction, shot_id, camera_priors, config):
             shot_id, track_id, point[0], point[1], obs.scale)
 
     if config['bundle_use_gps']:
-        g = shot.metadata.gps_position
+        g = shot.metadata.gps_position.value
         ba.add_position_prior(shot_id, g[0], g[1], g[2],
-                              shot.metadata.gps_dop)
+                              shot.metadata.gps_accuracy.value)
 
     ba.set_point_projection_loss_function(config['loss_function'],
                                           config['loss_function_threshold'])
@@ -280,9 +280,9 @@ def bundle_local(reconstruction, camera_priors, gcp, central_shot_id, config):
     if config['bundle_use_gps']:
         for shot_id in interior:
             shot = reconstruction.shots[shot_id]
-            g = shot.metadata.gps_position
+            g = shot.metadata.gps_position.value
             ba.add_position_prior(shot.id, g[0], g[1], g[2],
-                                  shot.metadata.gps_dop)
+                                  shot.metadata.gps_accuracy.value)
 
     if config['bundle_use_gcp'] and gcp:
         _add_gcp_to_bundle(ba, gcp, reconstruction.shots)

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -14,6 +14,19 @@
 
 namespace py = pybind11;
 // PYBIND11_MAKE_OPAQUE(std::unordered_map<std::string, map::TestShot>)
+
+template <typename T>
+void DeclareShotMeasurement(py::module &m, const std::string &type_name) {
+  using SM = map::ShotMeasurement<T>;
+  std::string class_name = std::string("ShotMeasurement") + type_name;
+
+  py::class_<SM>(m, class_name.c_str())
+      .def(py::init<>())
+      .def_property_readonly("has_value", &SM::HasValue)
+      .def_property("value", &SM::Value, &SM::SetValue)
+      .def("reset", &SM::Reset);
+}
+
 PYBIND11_MODULE(pymap, m) {
   py::class_<map::Pose>(m, "Pose")
       .def(py::init())
@@ -277,29 +290,34 @@ PYBIND11_MODULE(pymap, m) {
   py::class_<map::SLAMLandmarkData>(m, "SlamLandmarkData")
       .def("get_observed_ratio", &map::SLAMLandmarkData::GetObservedRatio);
 
+  DeclareShotMeasurement<int>(m, "Int");
+  DeclareShotMeasurement<double>(m, "Double");
+  DeclareShotMeasurement<Vec3d>(m, "Vec3d");
+  DeclareShotMeasurement<std::string>(m, "String");
+
   py::class_<map::ShotMeasurements>(m, "ShotMeasurements")
-      .def_readwrite("gps_dop", &map::ShotMeasurements::gps_dop_)
+      .def_readwrite("gps_accuracy", &map::ShotMeasurements::gps_accuracy_)
       .def_readwrite("gps_position", &map::ShotMeasurements::gps_position_)
       .def_readwrite("orientation", &map::ShotMeasurements::orientation_)
       .def_readwrite("capture_time", &map::ShotMeasurements::capture_time_)
       .def_readwrite("accelerometer", &map::ShotMeasurements::accelerometer_)
-      .def_readwrite("compass", &map::ShotMeasurements::compass_)
-      .def_readwrite("skey", &map::ShotMeasurements::skey_)
+      .def_readwrite("compass_angle", &map::ShotMeasurements::compass_angle_)
+      .def_readwrite("sequence_key", &map::ShotMeasurements::sequence_key_)
       .def(py::pickle(
           [](const map::ShotMeasurements &s) {
-            return py::make_tuple(s.gps_dop_, s.gps_position_, s.orientation_,
-                                  s.capture_time_, s.accelerometer_, s.compass_,
-                                  s.skey_);
+            return py::make_tuple(s.gps_accuracy_, s.gps_position_, s.orientation_,
+                                  s.capture_time_, s.accelerometer_, s.compass_angle_,
+                                  s.sequence_key_);
           },
           [](py::tuple s) {
             map::ShotMeasurements sm;
-            sm.gps_dop_ = s[0].cast<decltype(sm.gps_dop_)>();
+            sm.gps_accuracy_ = s[0].cast<decltype(sm.gps_accuracy_)>();
             sm.gps_position_ = s[1].cast<decltype(sm.gps_position_)>();
             sm.orientation_ = s[2].cast<decltype(sm.orientation_)>();
             sm.capture_time_ = s[3].cast<decltype(sm.capture_time_)>();
             sm.accelerometer_ = s[4].cast<decltype(sm.accelerometer_)>();
-            sm.compass_ = s[5].cast<decltype(sm.compass_)>();
-            sm.skey_ = s[6].cast<decltype(sm.skey_)>();
+            sm.compass_angle_ = s[5].cast<decltype(sm.compass_angle_)>();
+            sm.sequence_key_ = s[6].cast<decltype(sm.sequence_key_)>();
             return sm;
           }));
 

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -178,6 +178,7 @@ PYBIND11_MODULE(pymap, m) {
                     py::return_value_policy::reference_internal)
       .def_readwrite("mesh", &map::Shot::mesh)
       .def_readwrite("covariance", &map::Shot::covariance)
+      .def_readwrite("merge_cc", &map::Shot::merge_cc)
       .def("get_observation", &map::Shot::GetObservation,
            py::return_value_policy::reference_internal)
       .def("get_keypoints", &map::Shot::GetKeyPoints,

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -158,6 +158,7 @@ PYBIND11_MODULE(pymap, m) {
       .def_readonly("slam_data", &map::Shot::slam_data_,
                     py::return_value_policy::reference_internal)
       .def_readwrite("mesh", &map::Shot::mesh)
+      .def_readwrite("covariance", &map::Shot::covariance)
       .def("get_observation", &map::Shot::GetObservation,
            py::return_value_policy::reference_internal)
       .def("get_keypoints", &map::Shot::GetKeyPoints,

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -24,7 +24,13 @@ void DeclareShotMeasurement(py::module &m, const std::string &type_name) {
       .def(py::init<>())
       .def_property_readonly("has_value", &SM::HasValue)
       .def_property("value", &SM::Value, &SM::SetValue)
-      .def("reset", &SM::Reset);
+      .def("reset", &SM::Reset)
+      .def(py::pickle([](const SM &sm) { return py::make_tuple(sm.Value()); },
+                      [](py::tuple p) {
+                        SM sm;
+                        sm.SetValue(p[0].cast<T>());
+                        return sm;
+                      }));
 }
 
 PYBIND11_MODULE(pymap, m) {

--- a/opensfm/src/map/shot.h
+++ b/opensfm/src/map/shot.h
@@ -36,16 +36,32 @@ struct ShotMesh {
   Eigen::MatrixXd faces_;
 };
 
+template <typename T>
+class ShotMeasurement {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  bool HasValue() const { return has_value_; }
+  T Value() const { return value_; }
+  void SetValue(const T& v) {
+    value_ = v;
+    has_value_ = true;
+  }
+  void Reset() { has_value_ = false; }
+
+ private:
+  bool has_value_{false};
+  T value_;
+};
+
 struct ShotMeasurements {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  double capture_time_;
-  // TODO: Correct data types for compass,....
-  double compass_;
-  double accelerometer_;
-  double gps_dop_{0};
-  Vec3d gps_position_;
-  int orientation_;
-  std::string skey_;
+  ShotMeasurement<double> capture_time_;
+  ShotMeasurement<Vec3d> gps_position_;
+  ShotMeasurement<double> gps_accuracy_;
+  ShotMeasurement<double> compass_angle_;
+  ShotMeasurement<Vec3d> accelerometer_;
+  ShotMeasurement<int> orientation_;
+  ShotMeasurement<std::string> sequence_key_;
 };
 
 class Shot {

--- a/opensfm/src/map/shot.h
+++ b/opensfm/src/map/shot.h
@@ -227,6 +227,7 @@ class Shot {
   ShotMeasurements shot_measurements_;  // metadata
   ShotMesh mesh;
   MatXd covariance;
+  long int merge_cc;
 
  private:
   Pose pose_;

--- a/opensfm/src/map/shot.h
+++ b/opensfm/src/map/shot.h
@@ -210,6 +210,7 @@ class Shot {
   const Camera* const shot_camera_;
   ShotMeasurements shot_measurements_;  // metadata
   ShotMesh mesh;
+  MatXd covariance;
 
  private:
   Pose pose_;

--- a/opensfm/src/map/src/shot.cc
+++ b/opensfm/src/map/src/shot.cc
@@ -4,15 +4,25 @@
 #include <numeric>
 namespace map
 {
-Shot::Shot(const ShotId& shot_id, const Camera* const shot_camera, const Pose& pose):
-            id_(shot_id), shot_camera_(shot_camera), slam_data_(this), pose_(pose)
-{
-}
-Shot::Shot(const ShotId& shot_id, std::unique_ptr<Camera> shot_camera, const Pose& pose):
-            id_(shot_id), shot_camera_(shot_camera.get()), slam_data_(this), pose_(pose)
-{
+
+Shot::Shot(const ShotId& shot_id, const Camera* const shot_camera,
+           const Pose& pose)
+    : id_(shot_id),
+      shot_camera_(shot_camera),
+      slam_data_(this),
+      pose_(pose),
+      merge_cc(0) {}
+
+Shot::Shot(const ShotId& shot_id, std::unique_ptr<Camera> shot_camera,
+           const Pose& pose)
+    : id_(shot_id),
+      shot_camera_(shot_camera.get()),
+      slam_data_(this),
+      pose_(pose),
+      merge_cc(0) {
   own_camera_ = std::move(shot_camera);
 }
+
 size_t
 Shot::ComputeNumValidLandmarks(const int min_obs_thr) const
 {

--- a/opensfm/synthetic_data/synthetic_metrics.py
+++ b/opensfm/synthetic_data/synthetic_metrics.py
@@ -23,7 +23,7 @@ def completeness_errors(reference, candidate):
 def gps_errors(candidate):
     errors = []
     for shot in candidate.shots.values():
-        pose1 = shot.metadata.gps_position
+        pose1 = shot.metadata.gps_position.value
         pose2 = shot.pose.get_origin()
         errors.append(pose1-pose2)
     return np.array(errors)

--- a/opensfm/test/test_types.py
+++ b/opensfm/test/test_types.py
@@ -1,8 +1,9 @@
 import numpy as np
 
 from opensfm import context
-from opensfm import types
 from opensfm import pygeometry
+from opensfm import pymap
+from opensfm import types
 
 """
 Trying to imitate the following structure
@@ -54,6 +55,9 @@ def test_reconstruction_class_initialization():
     metadata.gps_position = [1.0815875281451939,
                              -0.96510451436708888,
                              1.2042133903991235]
+    metadata.accelerometer = [0.1, 0.9, 0.0]
+    metadata.compass = {"angle": 270.0, "accuracy": 15.0}
+    metadata.skey = 'a_sequence_key'
 
     # Instantiate shots
     pose0 = types.Pose([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
@@ -250,4 +254,10 @@ def _get_spherical_camera():
     camera_cpp = pygeometry.Camera.create_spherical()
     return camera, camera_cpp
 
-test_reconstruction_class_initialization()
+
+def test_shot_measurement():
+    m = pymap.ShotMeasurementInt()
+    assert not m.has_value
+    m.value = 4
+    assert m.has_value
+    assert m.value == 4

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -154,6 +154,22 @@ class ShotMetadata(object):
         self.capture_time = None
         self.skey = None
 
+    def add_to_map_shot(self, shot: pymap.Shot):
+        if self.orientation is not None:
+            shot.shot_measurement.orientation.value = self.orientation
+        if self.gps_dop is not None:
+            shot.shot_measurement.gps_accuracy.value = self.gps_dop
+        if self.gps_position is not None:
+            shot.shot_measurement.gps_position.value = self.gps_position
+        if self.accelerometer is not None:
+            shot.shot_measurement.accelerometer.value = self.accelerometer
+        if self.compass is not None:
+            shot.shot_measurement.compass_angle.value = self.compass["angle"]
+        if self.capture_time is not None:
+            shot.shot_measurement.capture_time.value = self.capture_time
+        if self.skey is not None:
+            shot.shot_measurement.sequence_key.value = self.skey
+
 
 class ShotMesh(object):
     """Triangular mesh of points visible in a shot
@@ -895,12 +911,10 @@ class Reconstruction(object):
                 shot.pose.rotation, shot.pose.translation)
         map_shot = self.map.create_shot(shot.id, shot.camera.id, pose)
         if shot.metadata is not None:
-            if shot.metadata.gps_dop is not None:
-                map_shot.shot_measurement.gps_dop = shot.metadata.gps_dop
-            if shot.metadata.gps_position is not None:
-                map_shot.shot_measurement.gps_position = shot.metadata.gps_position
-            if shot.metadata.orientation is not None:
-                map_shot.shot_measurement.orientation = shot.metadata.orientation
+            try:  # Ugly handling of both pymap.Shot and types.Shot
+                map_shot.metadata = shot.metadata
+            except TypeError:
+                shot.metadata.add_to_map_shot(map_shot)
 
     def get_shot(self, id):
         """Return a shot by id.


### PR DESCRIPTION
The `types.ShotMetadata` class used `None` as a sentinel value for missing metadata. Doing so in c++/pybind gets complicated. Instead, we explicitly add a `has_value` property to each member.

Also, we take the opportunity to rename some old, wrong names such as `gps_dop` which is actually storing the GPS accuracy in meters and not the GPS DOP.

There are some ugly parts to handle both `types.Shot` and `pymap.Shot` objects. Those should go away when removing `types.Shot`