### PR TITLE
Add Phantom4 Pro camera sensor width

### DIFF
--- a/opensfm/data/sensor_data.json
+++ b/opensfm/data/sensor_data.json
@@ -709,6 +709,7 @@
     "DJI FC330": 6.25,
     "DJI FC220": 6.17,
     "DJI FC2103": 6.07,
+    "DJI FC6310": 13.2,
     "Epson L-500V": 5.75,
     "Epson PhotoPC 3000 Zoom": 7.11,
     "Epson PhotoPC 3100 Zoom": 7.11,


### PR DESCRIPTION
Adds missing entries for Phantom4 Pro drone cameras.