### PR TITLE
Add additional parameters to the fisheye camera model

### DIFF
--- a/opensfm/commands/undistort.py
+++ b/opensfm/commands/undistort.py
@@ -211,7 +211,7 @@ def perspective_camera_from_perspective(distorted):
 
 
 def perspective_camera_from_brown(brown):
-    """Create a perspective camera froma a Brown camera."""
+    """Create a perspective camera from a Brown camera."""
     camera = pygeometry.Camera.create_perspective(
         brown.focal * (1 + brown.aspect_ratio) / 2.0, 0.0, 0.0)
     camera.id = brown.id
@@ -222,7 +222,8 @@ def perspective_camera_from_brown(brown):
 
 def perspective_camera_from_fisheye(fisheye):
     """Create a perspective camera from a fisheye."""
-    camera = pygeometry.Camera.create_perspective(fisheye.focal, 0.0, 0.0)
+    camera = pygeometry.Camera.create_perspective(
+        fisheye.focal * (1 + fisheye.aspect_ratio) / 2.0, 0.0, 0.0)
     camera.id = fisheye.id
     camera.width = fisheye.width
     camera.height = fisheye.height

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -100,8 +100,8 @@ radial_distortion_k1_sd: 0.01   # The standard deviation of the first radial dis
 radial_distortion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter
 radial_distortion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter
 radial_distortion_k4_sd: 0.01   # The standard deviation of the fourth radial distortion parameter
-radial_distortion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
-radial_distortion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
+tangential_distortion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
+tangential_distortion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
 bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlier : either fixed value (FIXED) or based on actual distribution (AUTO)
 bundle_outlier_auto_ratio: 3.0          # For AUTO filtering type, projections with larger reprojection than ratio-times-mean, are removed
 bundle_outlier_fixed_threshold: 0.006   # For FIXED filtering type, projections with larger reprojection error after bundle adjustment are removed

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -99,6 +99,7 @@ principal_point_sd: 0.01        # The standard deviation of the principal point 
 radial_distorsion_k1_sd: 0.01   # The standard deviation of the first radial distortion parameter
 radial_distorsion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter
 radial_distorsion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter
+radial_distorsion_k4_sd: 0.01   # The standard deviation of the fourth radial distortion parameter
 radial_distorsion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
 radial_distorsion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
 bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlier : either fixed value (FIXED) or based on actual distribution (AUTO)

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -96,12 +96,12 @@ loss_function_threshold: 1      # Threshold on the squared residuals.  Usually c
 reprojection_error_sd: 0.004    # The standard deviation of the reprojection error
 exif_focal_sd: 0.01             # The standard deviation of the exif focal length in log-scale
 principal_point_sd: 0.01        # The standard deviation of the principal point coordinates
-radial_distorsion_k1_sd: 0.01   # The standard deviation of the first radial distortion parameter
-radial_distorsion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter
-radial_distorsion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter
-radial_distorsion_k4_sd: 0.01   # The standard deviation of the fourth radial distortion parameter
-radial_distorsion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
-radial_distorsion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
+radial_distortion_k1_sd: 0.01   # The standard deviation of the first radial distortion parameter
+radial_distortion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter
+radial_distortion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter
+radial_distortion_k4_sd: 0.01   # The standard deviation of the fourth radial distortion parameter
+radial_distortion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
+radial_distortion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
 bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlier : either fixed value (FIXED) or based on actual distribution (AUTO)
 bundle_outlier_auto_ratio: 3.0          # For AUTO filtering type, projections with larger reprojection than ratio-times-mean, are removed
 bundle_outlier_fixed_threshold: 0.006   # For FIXED filtering type, projections with larger reprojection error after bundle adjustment are removed

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -43,7 +43,10 @@ def camera_from_json(key, obj):
              obj.get('p1', 0.0), obj.get('p2', 0.0)])
     elif pt == 'fisheye':
         camera = pygeometry.Camera.create_fisheye(
-            obj['focal'], obj.get('k1', 0.0), obj.get('k2', 0.0))
+            obj['focal_x'], obj['focal_y'] / obj['focal_x'],
+            [obj.get('c_x', 0.0), obj.get('c_y', 0.0)],
+            [obj.get('k1', 0.0), obj.get('k2', 0.0),
+             obj.get('k3', 0.0), obj.get('k4', 0.0)])
     elif pt == 'dual':
         camera = pygeometry.Camera.create_dual(obj.get('transition', 0.5), obj['focal'],
                                                obj.get('k1', 0.0), obj.get('k2', 0.0))
@@ -198,9 +201,14 @@ def camera_to_json(camera):
             'projection_type': camera.projection_type,
             'width': camera.width,
             'height': camera.height,
-            'focal': camera.focal,
+            'focal_x': camera.focal,
+            'focal_y': camera.focal*camera.aspect_ratio,
+            'c_x': camera.principal_point[0],
+            'c_y': camera.principal_point[1],
             'k1': camera.k1,
             'k2': camera.k2,
+            'k3': camera.k3,
+            'k4': camera.k4,
         }
     elif camera.projection_type == 'dual':
         return {

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -152,8 +152,8 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
         config['principal_point_sd'],
         config['radial_distortion_k1_sd'],
         config['radial_distortion_k2_sd'],
-        config['radial_distortion_p1_sd'],
-        config['radial_distortion_p2_sd'],
+        config['tangential_distortion_p1_sd'],
+        config['tangential_distortion_p2_sd'],
         config['radial_distortion_k3_sd'],
         config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])
@@ -221,8 +221,8 @@ def bundle_single_view(graph, reconstruction, shot_id, camera_priors, config):
         config['principal_point_sd'],
         config['radial_distortion_k1_sd'],
         config['radial_distortion_k2_sd'],
-        config['radial_distortion_p1_sd'],
-        config['radial_distortion_p2_sd'],
+        config['tangential_distortion_p1_sd'],
+        config['tangential_distortion_p2_sd'],
         config['radial_distortion_k3_sd'],
         config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])
@@ -303,8 +303,8 @@ def bundle_local(graph, reconstruction, camera_priors, gcp, central_shot_id, con
         config['principal_point_sd'],
         config['radial_distortion_k1_sd'],
         config['radial_distortion_k2_sd'],
-        config['radial_distortion_p1_sd'],
-        config['radial_distortion_p2_sd'],
+        config['tangential_distortion_p1_sd'],
+        config['tangential_distortion_p2_sd'],
         config['radial_distortion_k3_sd'],
         config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -150,12 +150,12 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
     ba.set_internal_parameters_prior_sd(
         config['exif_focal_sd'],
         config['principal_point_sd'],
-        config['radial_distorsion_k1_sd'],
-        config['radial_distorsion_k2_sd'],
-        config['radial_distorsion_p1_sd'],
-        config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'],
-        config['radial_distorsion_k4_sd'])
+        config['radial_distortion_k1_sd'],
+        config['radial_distortion_k2_sd'],
+        config['radial_distortion_p1_sd'],
+        config['radial_distortion_p2_sd'],
+        config['radial_distortion_k3_sd'],
+        config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(config['bundle_max_iterations'])
     ba.set_linear_solver_type("SPARSE_SCHUR")
@@ -219,12 +219,12 @@ def bundle_single_view(graph, reconstruction, shot_id, camera_priors, config):
     ba.set_internal_parameters_prior_sd(
         config['exif_focal_sd'],
         config['principal_point_sd'],
-        config['radial_distorsion_k1_sd'],
-        config['radial_distorsion_k2_sd'],
-        config['radial_distorsion_p1_sd'],
-        config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'],
-        config['radial_distorsion_k4_sd'])
+        config['radial_distortion_k1_sd'],
+        config['radial_distortion_k2_sd'],
+        config['radial_distortion_p1_sd'],
+        config['radial_distortion_p2_sd'],
+        config['radial_distortion_k3_sd'],
+        config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(10)
     ba.set_linear_solver_type("DENSE_QR")
@@ -301,12 +301,12 @@ def bundle_local(graph, reconstruction, camera_priors, gcp, central_shot_id, con
     ba.set_internal_parameters_prior_sd(
         config['exif_focal_sd'],
         config['principal_point_sd'],
-        config['radial_distorsion_k1_sd'],
-        config['radial_distorsion_k2_sd'],
-        config['radial_distorsion_p1_sd'],
-        config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'],
-        config['radial_distorsion_k4_sd'])
+        config['radial_distortion_k1_sd'],
+        config['radial_distortion_k2_sd'],
+        config['radial_distortion_p1_sd'],
+        config['radial_distortion_p2_sd'],
+        config['radial_distortion_k3_sd'],
+        config['radial_distortion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(10)
     ba.set_linear_solver_type("DENSE_SCHUR")

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -154,7 +154,8 @@ def bundle(graph, reconstruction, camera_priors, gcp, config):
         config['radial_distorsion_k2_sd'],
         config['radial_distorsion_p1_sd'],
         config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'])
+        config['radial_distorsion_k3_sd'],
+        config['radial_distorsion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(config['bundle_max_iterations'])
     ba.set_linear_solver_type("SPARSE_SCHUR")
@@ -222,7 +223,8 @@ def bundle_single_view(graph, reconstruction, shot_id, camera_priors, config):
         config['radial_distorsion_k2_sd'],
         config['radial_distorsion_p1_sd'],
         config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'])
+        config['radial_distorsion_k3_sd'],
+        config['radial_distorsion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(10)
     ba.set_linear_solver_type("DENSE_QR")
@@ -303,7 +305,8 @@ def bundle_local(graph, reconstruction, camera_priors, gcp, central_shot_id, con
         config['radial_distorsion_k2_sd'],
         config['radial_distorsion_p1_sd'],
         config['radial_distorsion_p2_sd'],
-        config['radial_distorsion_k3_sd'])
+        config['radial_distorsion_k3_sd'],
+        config['radial_distorsion_k4_sd'])
     ba.set_num_threads(config['processes'])
     ba.set_max_num_iterations(10)
     ba.set_linear_solver_type("DENSE_SCHUR")

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -512,7 +512,8 @@ class BundleAdjuster {
       double k2_sd,
       double p1_sd,
       double p2_sd,
-      double k3_sd);
+      double k3_sd,
+      double k4_sd);
 
   void SetComputeCovariances(bool v);
   bool GetCovarianceEstimationValid();
@@ -587,6 +588,7 @@ class BundleAdjuster {
   double p1_sd_;
   double p2_sd_;
   double k3_sd_;
+  double k4_sd_;
 
   // minimization setup
   std::string point_projection_loss_name_;

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -16,6 +16,7 @@ BundleAdjuster::BundleAdjuster() {
   p1_sd_ = 1;
   p2_sd_ = 1;
   k3_sd_ = 1;
+  k4_sd_ = 1;
   compute_covariances_ = false;
   covariance_estimation_valid_ = false;
   compute_reprojection_errors_ = true;
@@ -338,7 +339,8 @@ void BundleAdjuster::SetInternalParametersPriorSD(
     double k2_sd,
     double p1_sd,
     double p2_sd,
-    double k3_sd) {
+    double k3_sd,
+    double k4_sd) {
   focal_prior_sd_ = focal_sd;
   c_prior_sd_ = c_sd;
   k1_sd_ = k1_sd;
@@ -346,6 +348,7 @@ void BundleAdjuster::SetInternalParametersPriorSD(
   p1_sd_ = p1_sd;
   p2_sd_ = p2_sd;
   k3_sd_ = k3_sd;
+  k4_sd_ = k4_sd;
   UpdateSigmas();
 }
 

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -97,16 +97,16 @@ TEST_F(ReprojectionError2DFixture, BrownAnalyticErrorEvaluatesOK) {
 TEST_F(ReprojectionError2DFixture, PerspectiveAnalyticErrorEvaluatesOK) {
   constexpr int size = 3;
   
-  // focal k1, k2
+  // focal, k1, k2
   const double camera[size] = {0.3, 0.1, -0.03};
   RunTest<size>(ProjectionType::PERSPECTIVE, &camera[0]);
 }
 
 TEST_F(ReprojectionError2DFixture, FisheyeAnalyticErrorEvaluatesOK) {
-  constexpr int size = 3;
+  constexpr int size = 8;
   
-  // focal k1, k2
-  const double camera[size] = {0.3, 0.1, -0.03};
+  // focal, ar, cx, cy, k1, k2, k3, k4
+  const double camera[size] = {0.3, 1.0, 0.001, -0.02, 0.1, -0.03, 0.001, -0.005};
   RunTest<size>(ProjectionType::FISHEYE, &camera[0]);
 }
 

--- a/opensfm/src/geometry/camera.h
+++ b/opensfm/src/geometry/camera.h
@@ -12,6 +12,7 @@ class Camera {
     K1,
     K2,
     K3,
+    K4,
     P1,
     P2,
     Focal,
@@ -32,7 +33,9 @@ class Camera {
   static Camera CreateBrownCamera(double focal, double aspect_ratio,
                                   const Vec2d& principal_point,
                                   const VecXd& distortion);
-  static Camera CreateFisheyeCamera(double focal, double k1, double k2);
+  static Camera CreateFisheyeCamera(double focal, double aspect_ratio,
+                                    const Vec2d& principal_point,
+                                    const VecXd& distortion);
   static Camera CreateDualCamera(double transition, double focal, double k1,
                                  double k2);
   static Camera CreateSphericalCamera();

--- a/opensfm/src/geometry/camera_functions.h
+++ b/opensfm/src/geometry/camera_functions.h
@@ -9,7 +9,7 @@
 #include <iostream>
 
 enum class ProjectionType { PERSPECTIVE, BROWN, FISHEYE, SPHERICAL, DUAL };
-enum class Disto { K1 = 0, K2 = 1, K3 = 2, P1 = 3, P2 = 4, COUNT = 5 };
+enum class Disto { K1 = 0, K2 = 1, K3 = 2, K4 = 3, P1 = 3, P2 = 4 }; // Brown model has P1 = 3, Fisheye has K4 = 3
 
 template <class T>
 inline T SquaredNorm(T* point){
@@ -415,6 +415,118 @@ struct Disto24 : CameraFunctor<2, 2, 2>{
   template <class T>
   static T DistortionDerivative(const T& r2, const T& k1, const T& k2) {
     return T(1.0) + r2 * T(2.0) * (k1 + T(2.0) * k2 * r2);
+  }
+};
+
+/* Parameters are : k1, k2, k3, k4 */
+struct DistoFisheye : CameraFunctor<2, 4, 2>{
+  template <class T>
+  static void Forward(const T* point, const T* k, T* distorted) {
+    const T r2 = SquaredNorm(point);
+    const auto distortion = Distortion(r2, k[static_cast<int>(Disto::K1)],
+                                       k[static_cast<int>(Disto::K2)],
+                                       k[static_cast<int>(Disto::K3)],
+                                       k[static_cast<int>(Disto::K4)]);
+    distorted[0] = point[0] * distortion;
+    distorted[1] = point[1] * distortion;
+  }
+
+  template <class T, bool COMP_PARAM>
+  static void ForwardDerivatives(const T* point, const T* k, T* distorted,
+                                 T* jacobian) {
+    // dx, dy, dk1, dk2, dk3, dk4
+    constexpr int stride = Stride<COMP_PARAM>();
+    const auto& k1 = k[static_cast<int>(Disto::K1)];
+    const auto& k2 = k[static_cast<int>(Disto::K2)];
+    const auto& k3 = k[static_cast<int>(Disto::K3)];
+    const auto& k4 = k[static_cast<int>(Disto::K4)];
+    const auto& x = point[0];
+    const auto& y = point[1];
+
+    const auto x2 = x * x;
+    const auto x4 = x2 * x2;
+    const auto y2 = y * y;
+    const auto y4 = y2 * y2;
+    const auto r2 = x2 + y2;
+
+    jacobian[0] = x * (T(2.0) * k1 * x + T(4.0) * k2 * x * r2 + T(6.0) * k3 * x * r2 * r2 + T(8.0) * k4 * x * r2 * r2 * r2) +
+                  k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2 + k4 * r2 * r2 * r2 * r2 + T(1.0);
+    jacobian[1] = x * (T(2.0) * k1 * y + T(4.0) * k2 * y * r2 + T(6.0) * k3 * y * r2 * r2 + T(8.0) * k4 * y * r2 * r2 * r2);
+    jacobian[stride] = y * (T(2.0) * k1 * x + T(4.0) * k2 * x * r2 + T(6.0) * k3 * x * r2 * r2 + T(8.0) * k4 * x * r2 * r2 * r2);
+    jacobian[stride + 1] = y * (T(2.0) * k1 * y + T(4.0) * k2 * y * r2 + T(6.0) * k3 * y * r2 * r2 + T(8.0) * k4 * y * r2 * r2 * r2) +
+                           k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2 + k4 * r2 * r2 * r2 * r2 + T(1.0);
+
+    if (COMP_PARAM) {
+      jacobian[2] = x * r2;
+      jacobian[3] = x * r2 * r2;
+      jacobian[4] = x * r2 * r2 * r2;
+      jacobian[5] = x * r2 * r2 * r2 * r2;
+      jacobian[stride + 2] = y * r2;
+      jacobian[stride + 3] = y * r2 * r2;
+      jacobian[stride + 4] = y * r2 * r2 * r2;
+      jacobian[stride + 5] = y * r2 * r2 * r2 * r2;
+    }
+
+    Forward(point, k, distorted);
+  }
+
+  template <class T>
+  static void Backward(const T* point, const T* k, T* undistorted) {
+    /* Beware if you use Backward together with autodiff. You'll need to remove
+     * the line below, otherwise, derivatives won't be propagated */
+    const T rd = sqrt(SquaredNorm(point));
+    if (rd < T(std::numeric_limits<double>::epsilon())) {
+      undistorted[0] = point[0];
+      undistorted[1] = point[1];
+    }
+
+    // Compute undistorted radius
+    DistoEval<T> eval_function{rd, k[static_cast<int>(Disto::K1)],
+                               k[static_cast<int>(Disto::K2)],
+                               k[static_cast<int>(Disto::K3)],
+                               k[static_cast<int>(Disto::K4)]};
+    const auto ru_refined =
+        NewtonRaphson<DistoEval<T>, 1, 1, ManualDiff<DistoEval<T>, 1, 1>>(
+            eval_function, rd, iterations);
+
+    // Compute distortion factor from undistorted radius
+    const T r2 = ru_refined * ru_refined;
+    const auto distortion = Distortion(r2, k[static_cast<int>(Disto::K1)],
+                                       k[static_cast<int>(Disto::K2)],
+                                       k[static_cast<int>(Disto::K3)],
+                                       k[static_cast<int>(Disto::K4)]);
+
+    // Unapply undistortion
+    undistorted[0] = point[0] / distortion;
+    undistorted[1] = point[1] / distortion;
+  }
+
+  static constexpr int iterations = 10;
+  template <class T>
+  struct DistoEval {
+    const T& rd;
+    const T& k1;
+    const T& k2;
+    const T& k3;
+    const T& k4;
+    T operator()(const T& x) const {
+      const auto r2 = x * x;
+      return x * DistoFisheye::Distortion(r2, k1, k2, k3, k4) - rd;
+    }
+    T derivative(const T& x) const {
+      const auto r2 = x * x;
+      return DistoFisheye::DistortionDerivative(r2, k1, k2, k3, k4);
+    }
+  };
+
+  template <class T>
+  static inline T Distortion(const T& r2, const T& k1, const T& k2, const T& k3, const T& k4) {
+    return T(1.0) + r2 * (k1 + r2 * (k2 + r2 * (k3 + r2 * k4)));
+  }
+
+  template <class T>
+  static T DistortionDerivative(const T& r2, const T& k1, const T& k2, const T& k3, const T& k4) {
+    return T(1.0) + r2 * (T(3.0) * k1 + r2 * (T(5.0) * k2 + r2 * (T(7.0) * k3 + r2 * T(9.0) * k4)));
   }
 };
 
@@ -901,6 +1013,7 @@ template <class T> struct FunctorTraits { static constexpr int Size = 0;};
 template <> struct FunctorTraits<SphericalProjection> { static constexpr int Size = 0;};
 template <> struct FunctorTraits<DualProjection> { static constexpr int Size = 1;};
 template <> struct FunctorTraits<Disto24> { static constexpr int Size = 2;};
+template <> struct FunctorTraits<DistoFisheye> { static constexpr int Size = 4;};
 template <> struct FunctorTraits<DistoBrown> {static constexpr int Size = 5;};
 template <> struct FunctorTraits<UniformScale> {static constexpr int Size = 1;};
 template <> struct FunctorTraits<Affine> { static constexpr int Size = 4;};
@@ -967,7 +1080,7 @@ struct ProjectGeneric : CameraFunctor<3, SizeTraits<PROJ, DISTO, AFF>::Size, 2> 
 
 using PerspectiveCamera = ProjectGeneric<PerspectiveProjection, Disto24, UniformScale>;
 using BrownCamera = ProjectGeneric<PerspectiveProjection, DistoBrown, Affine>;
-using FisheyeCamera = ProjectGeneric<FisheyeProjection, Disto24, UniformScale>;
+using FisheyeCamera = ProjectGeneric<FisheyeProjection, DistoFisheye, Affine>;
 using DualCamera = ProjectGeneric<DualProjection, Disto24, UniformScale>;
 using SphericalCamera = ProjectGeneric<SphericalProjection, Identity, Identity>;
 

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -121,6 +121,7 @@ PYBIND11_MODULE(pygeometry, m) {
     .def_property_readonly("k1",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::K1);})
     .def_property_readonly("k2",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::K2);})
     .def_property_readonly("k3",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::K3);})
+    .def_property_readonly("k4",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::K4);})
     .def_property_readonly("p1",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::P1);})
     .def_property_readonly("p2",[](const Camera& c) {return c.GetParameterValue(Camera::Parameters::P2);})
     .def(py::pickle(
@@ -156,9 +157,14 @@ PYBIND11_MODULE(pygeometry, m) {
               break;
             }
             case ProjectionType::FISHEYE:{
+              Vec2d principal_point = Vec2d::Zero();
+              principal_point << values.at(Camera::Parameters::Cx), values.at(Camera::Parameters::Cy);
+              VecXd distortion(4);
+              distortion << values.at(Camera::Parameters::K1), values.at(Camera::Parameters::K2),
+                            values.at(Camera::Parameters::K3), values.at(Camera::Parameters::K4);
               camera = Camera::CreateFisheyeCamera(values.at(Camera::Parameters::Focal),
-                                                    values.at(Camera::Parameters::K1),
-                                                    values.at(Camera::Parameters::K2));
+                                                   values.at(Camera::Parameters::AspectRatio),
+                                                   principal_point, distortion);
               break;
             }
             case ProjectionType::DUAL:{

--- a/opensfm/src/geometry/src/camera.cc
+++ b/opensfm/src/geometry/src/camera.cc
@@ -30,18 +30,25 @@ Camera Camera::CreateBrownCamera(double focal, double aspect_ratio,
                    Camera::Parameters::Cy};
   camera.values_.resize(9);
   camera.values_ << distortion[0], distortion[1], distortion[2], distortion[3],
-      distortion[4], focal, aspect_ratio, principal_point[0],
-      principal_point[1];
+      distortion[4], focal, aspect_ratio, principal_point[0], principal_point[1];
   return camera;
 };
 
-Camera Camera::CreateFisheyeCamera(double focal, double k1, double k2) {
+Camera Camera::CreateFisheyeCamera(double focal, double aspect_ratio,
+                                   const Eigen::Vector2d& principal_point,
+                                   const Eigen::VectorXd& distortion) {
   Camera camera;
+  if (distortion.size() != 4) {
+    throw std::runtime_error("Invalid distortion coefficients size");
+  }
   camera.type_ = ProjectionType::FISHEYE;
-  camera.types_ = {Camera::Parameters::K1, Camera::Parameters::K2,
-                   Camera::Parameters::Focal};
-  camera.values_.resize(3);
-  camera.values_ << k1, k2, focal;
+  camera.types_ = {Camera::Parameters::K1,          Camera::Parameters::K2,
+                   Camera::Parameters::K3,          Camera::Parameters::K4,
+                   Camera::Parameters::Focal,       Camera::Parameters::AspectRatio,
+                   Camera::Parameters::Cx,          Camera::Parameters::Cy};
+  camera.values_.resize(8);
+  camera.values_ << distortion[0], distortion[1], distortion[2], distortion[3],
+      focal, aspect_ratio, principal_point[0], principal_point[1];
   return camera;
 };
 
@@ -78,7 +85,6 @@ Camera::GetParametersMap() const {
   std::map<Camera::Parameters, double, Camera::CompParameters> params_map;
   for(int i = 0; i < values_.size(); ++i){
     params_map[types_[i]] = values_[i];
-
   }
   return params_map;
 }

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -22,13 +22,13 @@ class CameraFixture : public ::testing::Test {
       pixels.row(i) << x, y;
     }
 
-    distortion.resize(5);
-    distortion << -0.1, 0.03, 0.001, 0.001, 0.002;
+    distortion.resize(2);
+    distortion << -0.1, 0.03;
+    distortion_brown.resize(5);
+    distortion_brown << -0.1, 0.03, 0.001, 0.001, 0.002;
+    distortion_fisheye.resize(4);
+    distortion_fisheye << -0.1, 0.03, 0.001, 0.005;
     principal_point << 0.1, -0.05;
-
-    new_distortion.resize(5);
-    new_distortion << 1, 1, 1, 1, 1;
-    new_principal_point << 0.02, -0.01;
 
     for (int i = 0; i < 3; ++i) {
       point_adiff[i].value() = point[i] = (i + 1) / 10.0;
@@ -92,9 +92,9 @@ class CameraFixture : public ::testing::Test {
   int pixel_height{3000};
 
   Eigen::VectorXd distortion;
-  Eigen::VectorXd new_distortion;
+  Eigen::VectorXd distortion_brown;
+  Eigen::VectorXd distortion_fisheye;
   Eigen::Vector2d principal_point;
-  Eigen::Vector2d new_principal_point;
 
   double point[3];
   typedef Eigen::AutoDiffScalar<Eigen::VectorXd> AScalar;
@@ -112,13 +112,13 @@ TEST_F(CameraFixture, PerspectiveIsConsistent){
 }
 
 TEST_F(CameraFixture, BrownIsConsistent){
-  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion);
+  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion_brown);
   const auto projected = camera.ProjectMany(camera.BearingsMany(pixels));
   ASSERT_LT(ComputeError(projected), 2e-7);
 }
 
 TEST_F(CameraFixture, FisheyeIsConsistent){
-  Camera camera = Camera::CreateFisheyeCamera(focal, distortion[0], distortion[1]);
+  Camera camera = Camera::CreateFisheyeCamera(focal, 1.0, principal_point, distortion_fisheye);
   const auto projected = camera.ProjectMany(camera.BearingsMany(pixels));
   ASSERT_LT(ComputeError(projected), 2e-7);
 }
@@ -153,16 +153,17 @@ TEST_F(CameraFixture, PerspectiveReturnCorrectTypes){
 }
 
 TEST_F(CameraFixture, FisheyeReturnCorrectTypes) {
-  Camera camera = Camera::CreatePerspectiveCamera(focal, distortion[0], distortion[1]);
+  Camera camera = Camera::CreateFisheyeCamera(focal, 1.0, principal_point, distortion_fisheye);
   const auto types = camera.GetParametersTypes();
   const auto expected = std::vector<Camera::Parameters>(
-      {Camera::Parameters::K1, Camera::Parameters::K2,
-       Camera::Parameters::Focal});
+      {Camera::Parameters::K1, Camera::Parameters::K2, Camera::Parameters::K3,
+       Camera::Parameters::K4, Camera::Parameters::Focal, Camera::Parameters::AspectRatio,
+       Camera::Parameters::Cx, Camera::Parameters::Cy});
   ASSERT_THAT(expected, ::testing::ContainerEq(types));
 }
 
 TEST_F(CameraFixture, BrownReturnCorrectTypes){
-  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion);
+  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion_brown);
   const auto types = camera.GetParametersTypes();
 
   const auto expected = std::vector<Camera::Parameters>(
@@ -192,20 +193,20 @@ TEST_F(CameraFixture, PerspectiveReturnCorrectValues){
 }
 
 TEST_F(CameraFixture, FisheyeReturnCorrectValues) {
-  Camera camera = Camera::CreatePerspectiveCamera(focal, distortion[0], distortion[1]);
+  Camera camera = Camera::CreateFisheyeCamera(focal, 1.0, principal_point, distortion_fisheye);
   const auto values = camera.GetParametersValues();
 
-  Eigen::VectorXd expected(3);
-  expected << distortion[0], distortion[1], focal;
+  Eigen::VectorXd expected(8);
+  expected << distortion_fisheye, focal, 1.0, principal_point;
   ASSERT_EQ(expected, values);
 }
 
 TEST_F(CameraFixture, BrownReturnCorrectValues){
-  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion);
+  Camera camera = Camera::CreateBrownCamera(focal, 1.0, principal_point, distortion_brown);
   const auto values = camera.GetParametersValues();
 
   Eigen::VectorXd expected(9);
-  expected << distortion, focal, 1.0, principal_point;
+  expected << distortion_brown, focal, 1.0, principal_point;
   ASSERT_EQ(expected, values);
 }
 
@@ -261,7 +262,7 @@ TEST_F(CameraFixture, PerspectiveReturnCorrectKScaled){
 }
 
 TEST_F(CameraFixture, BrownReturnCorrectK){
-  Camera camera = Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion);
+  Camera camera = Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion_brown);
 
   Eigen::Matrix3d expected = Eigen::Matrix3d::Identity();
   expected(0, 0) = focal;
@@ -272,7 +273,7 @@ TEST_F(CameraFixture, BrownReturnCorrectK){
 }
 
 TEST_F(CameraFixture, BrownReturnCorrectKScaled){
-  Camera camera = Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion);
+  Camera camera = Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion_brown);
 
   Eigen::Matrix3d expected = Eigen::Matrix3d::Identity();
   const auto normalizer = std::max(pixel_width, pixel_height);
@@ -296,19 +297,19 @@ TEST_F(CameraFixture, ComputePerspectiveAnalyticalDerivatives){
 }
 
 TEST_F(CameraFixture, ComputeFisheyeAnalyticalDerivatives){
-  const Camera camera = Camera::CreateFisheyeCamera(focal, -0.1, 0.01);
-  
+  const Camera camera = Camera::CreateFisheyeCamera(focal, new_ar, principal_point, distortion_fisheye);
+
   const VecXd camera_params = camera.GetParametersValues();
   const int size_params = 3 + camera_params.size();
 
-  Eigen::Matrix<double, 2, 6, Eigen::RowMajor> jacobian;
+  Eigen::Matrix<double, 2, 11, Eigen::RowMajor> jacobian;
   RunJacobianEval(camera, ProjectionType::FISHEYE, &jacobian);
   CheckJacobian(jacobian, size_params);
 }
 
 TEST_F(CameraFixture, ComputeBrownAnalyticalDerivatives){
   const Camera camera =
-      Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion);
+      Camera::CreateBrownCamera(focal, new_ar, principal_point, distortion_brown);
 
   const VecXd camera_params = camera.GetParametersValues();
   const int size_params = 3 + camera_params.size();

--- a/opensfm/synthetic_data/synthetic_scene.py
+++ b/opensfm/synthetic_data/synthetic_scene.py
@@ -19,8 +19,7 @@ def get_camera(type, id, focal, k1, k2):
     camera = None
     if type == 'perspective':
         camera = pygeometry.Camera.create_perspective(focal, k1, k2)
-    if type == 'fisheye':
-        camera = pygeometry.Camera.create_fisheye(focal, k1, k2)
+
     camera.id = id
 
     camera.height = 1600

--- a/opensfm/test/test_types.py
+++ b/opensfm/test/test_types.py
@@ -98,6 +98,15 @@ def test_perspective_camera_projection():
         assert np.allclose(pixel, projected)
 
 
+def test_brown_camera_projection():
+    """Test brown projection--backprojection loop."""
+    for camera in _get_brown_perspective_camera():
+        pixel = [0.1, 0.2]
+        bearing = camera.pixel_bearing(pixel)
+        projected = camera.project(bearing)
+        assert np.allclose(pixel, projected)
+
+
 def test_fisheye_camera_projection():
     """Test fisheye projection--backprojection loop."""
     if not context.OPENCV3:
@@ -250,11 +259,18 @@ def _get_fisheye_camera():
     camera = types.FisheyeCamera()
     camera.width = 800
     camera.height = 600
-    camera.focal = 0.6
+    camera.focal_x = 0.6
+    camera.focal_y = 0.7
+    camera.c_x = 0.1
+    camera.c_y = -0.05
     camera.k1 = -0.1
     camera.k2 = 0.01
+    camera.k3 = 0.0002
+    camera.k4 = 0.0005
     camera_cpp = pygeometry.Camera.create_fisheye(
-        camera.focal, camera.k1, camera.k2)
+        camera.focal_x, camera.focal_y / camera.focal_x,
+        [camera.c_x, camera.c_y],
+        [camera.k1, camera.k2, camera.k3, camera.k4])
     return camera, camera_cpp
 
 

--- a/opensfm/types.py
+++ b/opensfm/types.py
@@ -450,8 +450,11 @@ class FisheyeCamera(Camera):
         theta2 = theta**2
         theta_d = theta * (1.0 + theta2 * (self.k1 + theta2 * (self.k2 + theta2 * (self.k3 + theta2 * self.k4))))
 
-        x_p = theta_d / r * a
-        y_p = theta_d / r * b
+        inv_r = 1.0 / r if r > 1e-8 else 1.0
+        cdist = theta_d * inv_r if r > 1e-8 else 1.0
+
+        x_p = cdist * a
+        y_p = cdist * b
 
         return np.array([self.focal_x * x_p + self.c_x,
                          self.focal_y * y_p + self.c_y])

--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -223,9 +223,9 @@
                 float r = sqrt(a * a + b * b);
                 float theta = atan(r);
                 float theta2 = theta * theta;
-                float theta_d = theta * (1.0 + theta2 * (k1 + theta2 * (k2 + theta2 * (k3 + theta2 * k4)));
-                float x_p = theta_d / r * a
-                float y_p = theta_d / r * b
+                float theta_d = theta * (1.0 + theta2 * (k1 + theta2 * (k2 + theta2 * (k3 + theta2 * k4))));
+                float x_p = theta_d / r * a;
+                float y_p = theta_d / r * b;
 
                 float u = focal_x * x_p + c_x;
                 float v = focal_y * y_p + c_y;
@@ -768,6 +768,22 @@
                             type: 'f',
                             value: cam.focal
                         },
+                        focal_x: {
+                            type: 'f',
+                            value: cam.focal_x
+                        },
+                        focal_y: {
+                            type: 'f',
+                            value: cam.focal_y
+                        },
+                        c_x: {
+                            type: 'f',
+                            value: cam.c_x
+                        },
+                        c_y: {
+                            type: 'f',
+                            value: cam.c_y
+                        },
                         k1: {
                             type: 'f',
                             value: cam.k1
@@ -775,6 +791,14 @@
                         k2: {
                             type: 'f',
                             value: cam.k2
+                        },
+                        k3: {
+                            type: 'f',
+                            value: cam.k3
+                        },
+                        k4: {
+                            type: 'f',
+                            value: cam.k4
                         },
                         scale_x: {
                             type: 'f',
@@ -1080,8 +1104,14 @@
                             imagePlaneOld.material.uniforms.projectorTex.value = imagePlane.material.uniforms.projectorTex.value;
                             imagePlaneOld.material.uniforms.projectorMat.value = imagePlane.material.uniforms.projectorMat.value;
                             imagePlane.material.uniforms.focal.value = imagePlane.material.uniforms.focal.value;
+                            imagePlane.material.uniforms.focal_x.value = imagePlane.material.uniforms.focal_x.value;
+                            imagePlane.material.uniforms.focal_y.value = imagePlane.material.uniforms.focal_y.value;
+                            imagePlane.material.uniforms.c_x.value = imagePlane.material.uniforms.c_x.value;
+                            imagePlane.material.uniforms.c_y.value = imagePlane.material.uniforms.c_y.value;
                             imagePlane.material.uniforms.k1.value = imagePlane.material.uniforms.k1.value;
                             imagePlane.material.uniforms.k2.value = imagePlane.material.uniforms.k2.value;
+                            imagePlane.material.uniforms.k3.value = imagePlane.material.uniforms.k3.value;
+                            imagePlane.material.uniforms.k4.value = imagePlane.material.uniforms.k4.value;
                             imagePlane.material.uniforms.scale_x.value = imagePlane.material.uniforms.scale_x.value;
                             imagePlane.material.uniforms.scale_y.value = imagePlane.material.uniforms.scale_y.value;
                             imagePlaneOld.material.vertexShader = imagePlane.material.vertexShader;

--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -224,11 +224,13 @@
                 float theta = atan(r);
                 float theta2 = theta * theta;
                 float theta_d = theta * (1.0 + theta2 * (k1 + theta2 * (k2 + theta2 * (k3 + theta2 * k4))));
-                float x_p = theta_d / r * a;
-                float y_p = theta_d / r * b;
+                float inv_r = r > 1e-8 ? 1.0 / r : 1.0;
+                float cdist = r > 1e-8 ? theta_d * inv_r : 1.0;
+                float x_p = cdist * a;
+                float y_p = cdist * b;
 
-                float u = focal_x * x_p + c_x;
-                float v = focal_y * y_p + c_y;
+                float u = scale_x * focal_x * x_p + c_x + 0.5;
+                float v = -scale_y * focal_y * y_p + c_y + 0.5;
 
                 vec4 baseColor = texture2D(projectorTex, vec2(u, v));
                 baseColor.a = opacity;

--- a/viewer/reconstruction.html
+++ b/viewer/reconstruction.html
@@ -200,9 +200,14 @@
             varying vec4 vRstq;
             uniform sampler2D projectorTex;
             uniform float opacity;
-            uniform float focal;
+            uniform float focal_x;
+            uniform float focal_y;
+            uniform float c_x;
+            uniform float c_y;
             uniform float k1;
             uniform float k2;
+            uniform float k3;
+            uniform float k4;
             uniform float scale_x;
             uniform float scale_y;
 
@@ -212,14 +217,18 @@
                 float y = vRstq.y;
                 float z = vRstq.z;
 
-                float l = sqrt(x * x + y * y);
-                float theta = atan(l, z);
-                float theta2 = theta * theta;
-                float theta_d = theta * (1.0 + theta2 * (k1 + theta2 * k2));
-                float s = focal * theta_d / l;
+                float a = x / z;
+                float b = y / z;
 
-                float u = scale_x * s * x + 0.5;
-                float v = -scale_y * s * y + 0.5;
+                float r = sqrt(a * a + b * b);
+                float theta = atan(r);
+                float theta2 = theta * theta;
+                float theta_d = theta * (1.0 + theta2 * (k1 + theta2 * (k2 + theta2 * (k3 + theta2 * k4)));
+                float x_p = theta_d / r * a
+                float y_p = theta_d / r * b
+
+                float u = focal_x * x_p + c_x;
+                float v = focal_y * y_p + c_y;
 
                 vec4 baseColor = texture2D(projectorTex, vec2(u, v));
                 baseColor.a = opacity;


### PR DESCRIPTION
This pr adds the following parameters to the fisheye camera model:
* aspect ratio
* principal point cx and cy,
* k3 and k4 radial distortion parameters.