### PR TITLE
fix: pybing+CLANG

### DIFF
--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -553,7 +553,7 @@ def two_view_reconstruction(p1, p2, camera1, camera2,
 
     if inliers.sum() > 5:
         T = multiview.relative_pose_optimize_nonlinear(b1[inliers],
-                                                       b2[inliers], 
+                                                       b2[inliers],
                                                        t, R,
                                                        iterations)
         R = T[:, :3]
@@ -876,7 +876,7 @@ class TrackTriangulator:
             e, X = pygeometry.triangulate_bearings_midpoint(
                 os_t, bs_t, thresholds, np.radians(min_ray_angle_degrees))
 
-            if X is not None:
+            if e:
                 reprojected_bs = X-os
                 reprojected_bs /= np.linalg.norm(reprojected_bs, axis=1)[:, np.newaxis]
                 inliers = np.linalg.norm(reprojected_bs - bs, axis=1) < reproj_threshold
@@ -915,7 +915,7 @@ class TrackTriangulator:
             thresholds = len(os) * [reproj_threshold]
             e, X = pygeometry.triangulate_bearings_midpoint(
                 os, bs, thresholds, np.radians(min_ray_angle_degrees))
-            if X is not None:
+            if e:
                 point = types.Point()
                 point.id = track
                 point.coordinates = X.tolist()
@@ -937,7 +937,7 @@ class TrackTriangulator:
         if len(Rts) >= 2:
             e, X = pygeometry.triangulate_bearings_dlt(
                 Rts, bs, reproj_threshold, np.radians(min_ray_angle_degrees))
-            if X is not None:
+            if e:
                 point = types.Point()
                 point.id = track
                 point.coordinates = X.tolist()
@@ -1317,7 +1317,7 @@ def incremental_reconstruction(data, tracks_manager):
     chrono = Chronometer()
 
     images = tracks_manager.get_shot_ids()
-    
+
     if not data.reference_lla_exists():
         data.invent_reference_lla(images)
 

--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -9,27 +9,11 @@
 #include <string>
 #include <foundation/python_types.h>
 
-namespace geometry {
-
-enum {
-  TRIANGULATION_OK = 0,
-  TRIANGULATION_SMALL_ANGLE,
-  TRIANGULATION_BEHIND_CAMERA,
-  TRIANGULATION_BAD_REPROJECTION
-};
-
 double AngleBetweenVectors(const Eigen::Vector3d &u, const Eigen::Vector3d &v);
-
-py::list TriangulateReturn(int error, py::object value);
 
 Eigen::Vector4d TriangulateBearingsDLTSolve(
     const Eigen::Matrix<double, -1, 3> &bs,
     const std::vector< Eigen::Matrix<double, 3, 4> > &Rts);
-
-py::object TriangulateBearingsDLT(const std::vector<Eigen::Matrix<double, 3, 4>> &Rts,
-                                  const Eigen::Matrix<double, -1, 3> &bearings,
-                                  double threshold,
-                                  double min_angle);
 
 // Point minimizing the squared distance to all rays
 // Closed for solution from
@@ -59,6 +43,13 @@ Eigen::Matrix<T, 3, 1> TriangulateBearingsMidpointSolve(
   return (Eigen::Matrix<T, 3, 3>::Identity() + BBt * Cinv) * A / T(nviews) - Cinv * BBtA;
 }
 
+namespace geometry {
+
+std::pair<bool, Eigen::Vector3d> TriangulateBearingsDLT(
+    const std::vector<Eigen::Matrix<double, 3, 4>> &Rts,
+    const Eigen::Matrix<double, -1, 3> &bearings, double threshold,
+    double min_angle);
+
 template< class T >
 Eigen::Matrix<T, 3, 1> TriangulateTwoBearingsMidpointSolve(
     const Eigen::Matrix<T, 2, 3> &centers,
@@ -85,9 +76,9 @@ std::vector<Eigen::Vector3d> TriangulateTwoBearingsMidpointMany(
     const Eigen::Matrix3d& rotation,
     const Eigen::Vector3d& translation);
 
-py::object TriangulateBearingsMidpoint(const Eigen::Matrix<double, -1, 3> &centers,
-                                       const Eigen::Matrix<double, -1, 3> &bearings,
-                                       const std::vector<double> &threshold_list,
-                                       double min_angle);
+std::pair<bool, Eigen::Vector3d> TriangulateBearingsMidpoint(
+    const Eigen::Matrix<double, -1, 3> &centers,
+    const Eigen::Matrix<double, -1, 3> &bearings,
+    const std::vector<double> &threshold_list, double min_angle);
 
 }  // namespace geometry

--- a/opensfm/test/test_triangulation.py
+++ b/opensfm/test/test_triangulation.py
@@ -62,7 +62,7 @@ def test_triangulate_bearings_dlt():
     res, X = pygeometry.triangulate_bearings_dlt(
         [rt1, rt2], [b1, b2], max_reprojection, min_ray_angle)
     assert np.allclose(X, [0, 0, 1.0])
-    assert res == 0
+    assert res is True
 
 
 def test_triangulate_bearings_midpoint():
@@ -75,7 +75,7 @@ def test_triangulate_bearings_midpoint():
     res, X = pygeometry.triangulate_bearings_midpoint(
         [o1, o2], [b1, b2], 2 * [max_reprojection], min_ray_angle)
     assert np.allclose(X, [0, 0, 1.0])
-    assert res == 0
+    assert res is True
 
 
 def test_triangulate_two_bearings_midpoint():


### PR DESCRIPTION
This PR fixes runtime crash behaviour on when using Clang. By replacing `py::object` return types with proper `Eigen` + `STL` ones, we unify both return types in `geometry` as well as fixing the crashes.