### PR TITLE
refactor: use python 3 lru_cache instead of repoze.lru

### DIFF
--- a/opensfm/feature_loading.py
+++ b/opensfm/feature_loading.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
+from functools import lru_cache
 
 import numpy as np
-from repoze.lru import LRUCache
 
 from opensfm import features as ft
 
@@ -15,82 +10,56 @@ logger = logging.getLogger(__name__)
 
 
 class FeatureLoader(object):
-    def __init__(self):
-        self.points_cache = LRUCache(1000)
-        self.colors_cache = LRUCache(1000)
-        self.features_cache = LRUCache(200)
-        self.words_cache = LRUCache(200)
-        self.masks_cache = LRUCache(1000)
-        self.index_cache = LRUCache(200)
-        self.masked_index_cache = LRUCache(200)
-
     def clear_cache(self):
-        self.points_cache.clear()
-        self.colors_cache.clear()
-        self.features_cache.clear()
-        self.words_cache.clear()
-        self.masks_cache.clear()
+        self.load_mask.cache_clear()
+        self.load_points_colors.cache_clear()
+        self._load_points_features_colors_unmasked.cache_clear()
+        self._load_points_features_colors_masked.cache_clear()
+        self.load_features_index.cache_clear()
+        self.load_words.cache_clear
 
-    def load_mask(self, data, image, points=None):
-        masks = self.masks_cache.get(image)
-        if masks is None:
-            if points is None:
-                points, _ = self.load_points_colors(data, image, masked=False)
-            if points is None:
-                return None
-            masks = data.load_features_mask(image, points[:, :2])
-            self.masks_cache.put(image, masks)
-        return masks
+    @lru_cache(1000)
+    def load_mask(self, data, image):
+        points, _, _ = self._load_points_features_colors_unmasked(data, image)
+        if points is None:
+            return None
+        return data.load_features_mask(image, points[:, :2])
 
-    def load_points_colors(self, data, image, masked=False):
-        points = self.points_cache.get(image)
-        colors = self.colors_cache.get(image)
-        if points is None or colors is None:
-            points, _, colors = self._load_features_nocache(data, image)
-            self.points_cache.put(image, points)
-            self.colors_cache.put(image, colors)
-        if masked:
-            mask = self.load_mask(data, image, points)
-            if mask is not None:
-                points = points[mask]
-                colors = colors[mask]
+    @lru_cache(1000)
+    def load_points_colors(self, data, image):
+        points, _, colors = self._load_features_nocache(data, image)
         return points, colors
 
-    def load_points_features_colors(self, data, image, masked=False):
-        points = self.points_cache.get(image)
-        features = self.features_cache.get(image)
-        colors = self.colors_cache.get(image)
-        if points is None or features is None or colors is None:
-            points, features, colors = self._load_features_nocache(data, image)
-            self.points_cache.put(image, points)
-            self.features_cache.put(image, features)
-            self.colors_cache.put(image, colors)
+    def load_points_features_colors(self, data, image, masked):
         if masked:
-            mask = self.load_mask(data, image, points)
-            if mask is not None:
-                points = points[mask]
-                features = features[mask]
-                colors = colors[mask]
+            return self._load_points_features_colors_masked(data, image)
+        else:
+            return self._load_points_features_colors_unmasked(data, image)
+
+    @lru_cache(20)
+    def _load_points_features_colors_unmasked(self, data, image):
+        points, features, colors = self._load_features_nocache(data, image)
         return points, features, colors
 
-    def load_features_index(self, data, image, masked=False):
-        cache = self.masked_index_cache if masked else self.index_cache
-        cached = cache.get(image)
-        if cached is None:
-            _, features, _ = self.load_points_features_colors(data, image,
-                                                              masked)
-            index = ft.build_flann_index(features, data.config)
-            cache.put(image, (features, index))
-        else:
-            features, index = cached
-        return index
+    @lru_cache(200)
+    def _load_points_features_colors_masked(self, data, image):
+        points, features, colors = self._load_points_features_colors_unmasked(data, image)
+        mask = self.load_mask(data, image)
+        if mask is not None:
+            points = points[mask]
+            features = features[mask]
+            colors = colors[mask]
+        return points, features, colors
 
+    @lru_cache(200)
+    def load_features_index(self, data, image, masked):
+        _, features, _ = self.load_points_features_colors(data, image, masked)
+        return features, ft.build_flann_index(features, data.config)
+
+    @lru_cache(200)
     def load_words(self, data, image, masked):
-        words = self.words_cache.get(image)
-        if words is None:
-            words = data.load_words(image)
-            self.words_cache.put(image, words)
-        if masked and words is not None:
+        words = data.load_words(image)
+        if masked:
             mask = self.load_mask(data, image)
             if mask is not None:
                 words = words[mask]

--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -7,7 +7,7 @@ import scipy.spatial as spatial
 
 from collections import namedtuple
 from networkx.algorithms import bipartite
-from repoze.lru import lru_cache
+from functools import lru_cache
 
 from opensfm import align
 from opensfm import context

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -142,13 +142,10 @@ def match_unwrap_args(args):
     im1, candidates, ctx = args
 
     im1_matches = {}
-    p1, f1, _ = feature_loader.instance.load_points_features_colors(ctx.data, im1)
     camera1 = ctx.cameras[ctx.exifs[im1]['camera']]
 
     for im2 in candidates:
-        p2, f2, _ = feature_loader.instance.load_points_features_colors(ctx.data, im2)
         camera2 = ctx.cameras[ctx.exifs[im2]['camera']]
-
         im1_matches[im2] = match(im1, im2, camera1, camera2, ctx.data)
 
     num_matches = sum(1 for m in im1_matches.values() if len(m) > 0)
@@ -185,10 +182,10 @@ def match(im1, im2, camera1, camera2, data):
         else:
             matches = match_words(f1, w1, f2, w2, config)
     elif matcher_type == 'FLANN':
-        i1 = feature_loader.instance.load_features_index(data, im1, masked=True)
+        fi1, i1 = feature_loader.instance.load_features_index(data, im1, masked=True)
         if symmetric_matching:
-            i2 = feature_loader.instance.load_features_index(data, im2, masked=True)
-            matches = match_flann_symmetric(f1, i1, f2, i2, config)
+            fi2, i2 = feature_loader.instance.load_features_index(data, im2, masked=True)
+            matches = match_flann_symmetric(fi1, i1, fi2, i2, config)
         else:
             matches = match_flann(i1, f2, config)
     elif matcher_type == 'BRUTEFORCE':

--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -392,17 +392,11 @@ def vlad_histograms(images, data):
 
         Returns a dictionary of VLAD vectors for the images.
     """
-    if len(images) == 0:
-        return {}
-
-    words = vlad.instance.load_words(data)
     vlads = {}
     for im in images:
-        _, features, _ = feature_loader.instance.load_points_features_colors(
-            data, im, masked=True)
-        if features is not None:
-            vlads[im] = vlad.instance.vlad_histogram(im, features, words)
-
+        im_vlad = vlad.instance.vlad_histogram(data, im)
+        if im_vlad is not None:
+            vlads[im] = im_vlad
     return vlads
 
 

--- a/opensfm/test/test_matching.py
+++ b/opensfm/test/test_matching.py
@@ -64,7 +64,7 @@ def test_match_using_words():
     for i, j in matches:
         assert i == j
 
-        
+
 def test_unfilter_matches():
     matches = np.array([])
     m1 = np.array([], dtype=bool)

--- a/opensfm/vlad.py
+++ b/opensfm/vlad.py
@@ -1,8 +1,9 @@
+from functools import lru_cache
+
 import numpy as np
 
-from repoze.lru import LRUCache
-
 from opensfm import bow
+from opensfm import feature_loader
 
 
 def unnormalized_vlad(features, centers):
@@ -52,23 +53,20 @@ def vlad_distances(image, other_images, histograms):
 
 
 class VladCache(object):
-    def __init__(self):
-        self.word_cache = LRUCache(1)
-        self.vlad_cache = LRUCache(1000)
-
+    @lru_cache(1)
     def load_words(self, data):
-        words = self.word_cache.get('words')
-        if words is None:
-            words, _ = bow.load_vlad_words_and_frequencies(data.config)
-            self.word_cache.put('words', words)
+        words, _ = bow.load_vlad_words_and_frequencies(data.config)
         return words
 
-    def vlad_histogram(self, image, features, words):
-        vlad = self.vlad_cache.get(image)
-        if vlad is None:
-            vlad = unnormalized_vlad(features, words)
-            vlad = signed_square_root_normalize(vlad)
-            self.vlad_cache.put(image, vlad)
+    @lru_cache(1000)
+    def vlad_histogram(self, data, image):
+        words = self.load_words(data)
+        _, features, _ = feature_loader.instance.load_points_features_colors(
+            data, image, masked=True)
+        if features is None:
+            return None
+        vlad = unnormalized_vlad(features, words)
+        vlad = signed_square_root_normalize(vlad)
         return vlad
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pyproj>=1.9.5.1
 pytest==3.0.7
 python-dateutil==2.6.0
 pyyaml==5.1
-repoze.lru==0.7
 scipy
 six
 xmltodict==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setuptools.setup(
     #     'pytest>=3.0.7',
     #     'python-dateutil>=2.6.0',
     #     'PyYAML>=3.12',
-    #     'repoze.lru>=0.7',
     #     'scipy',
     #     'six',
     #     'xmltodict>=0.10.2',


### PR DESCRIPTION
Now that we are python 3 only, we can use python's owns lru cache instead of repoze.lru.
Python's lru cache comes only as a decorator. So a bit of refactoring was needed to make use of it.

We lose the ability to cache points and colors independently when we load points, features and color.

We now cache the masked features also, since those are the ones we load most of the time. So we avoid having to mask the features each time we get them from cache.