### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_install:
   - docker build -t mapillary/opensfm .
 script:
-  - docker run mapillary/opensfm /bin/sh -c "py.test"
+  - docker run mapillary/opensfm /bin/sh -c "PYTHONPATH=. py.test"
   - docker run mapillary/opensfm /bin/sh -c "cd cmake_build && ctest"
 
 notifications:


### PR DESCRIPTION
Since we removed the `__init__.py` file from the `opensfm/test` folder, pytests were not running in travis. The reason was that pytest could not find the opensfm package. It is not clear why removing the `__init__.py` affected that. In any case, setting up the `PYTHONPATH` before calling pytest solves the issue.