### PR TITLE
Regression fix: allow build without tests

### DIFF
--- a/opensfm/src/bundle/CMakeLists.txt
+++ b/opensfm/src/bundle/CMakeLists.txt
@@ -23,16 +23,18 @@ if (SUITESPARSE_FOUND)
 endif()
 target_include_directories(bundle PRIVATE ${CERES_INCLUDE_DIR} ${CMAKE_SOURCE_DIR})
 
-set(BUNDLE_TEST_FILES
-    test/reprojection_errors_test.cc
-)
-add_executable(bundle_test ${BUNDLE_TEST_FILES})
-target_include_directories(bundle_test PRIVATE ${CMAKE_SOURCE_DIR} ${EIGEN_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS})
-target_link_libraries(bundle_test
-                      PUBLIC
-                      bundle
-                      ${TEST_MAIN})
-add_test(bundle_test bundle_test)
+if (OPENSFM_BUILD_TESTS)
+    set(BUNDLE_TEST_FILES
+        test/reprojection_errors_test.cc
+    )
+    add_executable(bundle_test ${BUNDLE_TEST_FILES})
+    target_include_directories(bundle_test PRIVATE ${CMAKE_SOURCE_DIR} ${EIGEN_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS})
+    target_link_libraries(bundle_test
+                        PUBLIC
+                        bundle
+                        ${TEST_MAIN})
+    add_test(bundle_test bundle_test)
+endif()
 
 pybind11_add_module(pybundle python/pybind.cc)
 target_link_libraries(pybundle PRIVATE

--- a/opensfm/src/dense/CMakeLists.txt
+++ b/opensfm/src/dense/CMakeLists.txt
@@ -7,17 +7,19 @@ add_library(dense ${DENSE_FILES})
 target_link_libraries(dense PRIVATE foundation)
 target_include_directories(dense PRIVATE ${CMAKE_SOURCE_DIR})
 
-set(DENSE_TEST_FILES
-    test/depthmap_test.cc
-)
-add_executable(dense_test ${DENSE_TEST_FILES})
-target_include_directories(dense_test PRIVATE ${CMAKE_SOURCE_DIR} ${GTEST_INCLUDE_DIRS})
-target_link_libraries(dense_test
-                      PUBLIC
-                      dense
-                      ${TEST_MAIN}
-                      ${OpenCV_LIBS})
-add_test(dense_test dense_test)
+if (OPENSFM_BUILD_TESTS)
+    set(DENSE_TEST_FILES
+        test/depthmap_test.cc
+    )
+    add_executable(dense_test ${DENSE_TEST_FILES})
+    target_include_directories(dense_test PRIVATE ${CMAKE_SOURCE_DIR} ${GTEST_INCLUDE_DIRS})
+    target_link_libraries(dense_test
+                        PUBLIC
+                        dense
+                        ${TEST_MAIN}
+                        ${OpenCV_LIBS})
+    add_test(dense_test dense_test)
+endif()
 
 pybind11_add_module(pydense python/pybind.cc)
 target_include_directories(pydense PRIVATE ${GLOG_INCLUDE_DIR})

--- a/opensfm/src/foundation/CMakeLists.txt
+++ b/opensfm/src/foundation/CMakeLists.txt
@@ -24,13 +24,15 @@ target_include_directories(foundation
     ${CMAKE_SOURCE_DIR}
 )
 
-set(FOUNDATION_TEST_FILES
-    test/newton_raphson_test.cc
-)
-add_executable(foundation_test ${FOUNDATION_TEST_FILES})
-target_include_directories(foundation_test PRIVATE ${CMAKE_SOURCE_DIR} ${GMOCK_INCLUDE_DIRS})
-target_link_libraries(foundation_test
-                      PUBLIC
-                      foundation
-                      ${TEST_MAIN})
-add_test(foundation_test foundation_test)
+if (OPENSFM_BUILD_TESTS)
+    set(FOUNDATION_TEST_FILES
+        test/newton_raphson_test.cc
+    )
+    add_executable(foundation_test ${FOUNDATION_TEST_FILES})
+    target_include_directories(foundation_test PRIVATE ${CMAKE_SOURCE_DIR} ${GMOCK_INCLUDE_DIRS})
+    target_link_libraries(foundation_test
+                          PUBLIC
+                          foundation
+                          ${TEST_MAIN})
+    add_test(foundation_test foundation_test)
+endif()

--- a/opensfm/src/geometry/CMakeLists.txt
+++ b/opensfm/src/geometry/CMakeLists.txt
@@ -20,16 +20,18 @@ target_link_libraries(geometry
 )
 target_include_directories(geometry PUBLIC ${CMAKE_SOURCE_DIR} ${CERES_INCLUDE_DIR})
 
-set(GEOMETRY_TEST_FILES
-    test/camera_test.cc
-)
-add_executable(geometry_test ${GEOMETRY_TEST_FILES})
-target_include_directories(geometry_test PRIVATE ${CMAKE_SOURCE_DIR} ${EIGEN_INCLUDE_DIRS})
-target_link_libraries(geometry_test
-                      PUBLIC
-                      geometry
-                      ${TEST_MAIN})
-add_test(geometry_test geometry_test)
+if (OPENSFM_BUILD_TESTS)
+    set(GEOMETRY_TEST_FILES
+        test/camera_test.cc
+    )
+    add_executable(geometry_test ${GEOMETRY_TEST_FILES})
+    target_include_directories(geometry_test PRIVATE ${CMAKE_SOURCE_DIR} ${EIGEN_INCLUDE_DIRS})
+    target_link_libraries(geometry_test
+                        PUBLIC
+                        geometry
+                        ${TEST_MAIN})
+    add_test(geometry_test geometry_test)
+endif()
 
 pybind11_add_module(pygeometry python/pybind.cc)
 target_link_libraries(pygeometry

--- a/opensfm/src/map/CMakeLists.txt
+++ b/opensfm/src/map/CMakeLists.txt
@@ -30,18 +30,20 @@ target_link_libraries(pymap
     geometry
 )
 
-set(MAP_TEST_FILES
-  test/map_test.cc
-)
+if (OPENSFM_BUILD_TESTS)
+    set(MAP_TEST_FILES
+    test/map_test.cc
+    )
 
-add_executable(map_test ${MAP_TEST_FILES})
-target_include_directories(map_test PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(map_test
-                      PUBLIC
-                      geometry
-                      map
-                      ${TEST_MAIN})
-add_test(map_test map_test)
+    add_executable(map_test ${MAP_TEST_FILES})
+    target_include_directories(map_test PRIVATE ${CMAKE_SOURCE_DIR})
+    target_link_libraries(map_test
+                        PUBLIC
+                        geometry
+                        map
+                        ${TEST_MAIN})
+    add_test(map_test map_test)
+endif()
 
 set_target_properties(pymap PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${opensfm_SOURCE_DIR}/.."

--- a/opensfm/src/map/CMakeLists.txt
+++ b/opensfm/src/map/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(pymap
 
 if (OPENSFM_BUILD_TESTS)
     set(MAP_TEST_FILES
-    test/map_test.cc
+        test/map_test.cc
     )
 
     add_executable(map_test ${MAP_TEST_FILES})

--- a/opensfm/src/sfm/CMakeLists.txt
+++ b/opensfm/src/sfm/CMakeLists.txt
@@ -13,16 +13,18 @@ target_link_libraries(sfm
 )
 target_include_directories(sfm PUBLIC ${EIGEN_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
 
-set(SFM_TEST_FILES
-    test/tracks_manager_test.cc
-)
-add_executable(sfm_test ${SFM_TEST_FILES})
-target_include_directories(sfm_test PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(sfm_test
-                      PUBLIC
-                      sfm
-                      ${TEST_MAIN})
-add_test(sfm_test sfm_test)
+if (OPENSFM_BUILD_TESTS)
+    set(SFM_TEST_FILES
+        test/tracks_manager_test.cc
+    )
+    add_executable(sfm_test ${SFM_TEST_FILES})
+    target_include_directories(sfm_test PRIVATE ${CMAKE_SOURCE_DIR})
+    target_link_libraries(sfm_test
+                        PUBLIC
+                        sfm
+                        ${TEST_MAIN})
+    add_test(sfm_test sfm_test)
+endif()
 
 pybind11_add_module(pysfm python/pybind.cc)
 target_include_directories(pysfm PRIVATE ${GLOG_INCLUDE_DIR})


### PR DESCRIPTION
Hello :hand:

I'm so excited for all the new changes in OpenSfM! 

While building it with `-DOPENSFM_BUILD_TESTS=OFF` I noticed that tests were being built anyway (it slows down build time, requires a few extra dependencies).

This PR makes building tests conditional (I think this is a regression since it was working OK with previous releases).

Hope this can be useful for others.