### PR TITLE
Fixed pickle error, deprecation warning

### DIFF
--- a/opensfm/large/metadataset.py
+++ b/opensfm/large/metadataset.py
@@ -112,10 +112,10 @@ class MetaDataSet():
         filepath = self._clusters_with_neighbors_path()
         np.savez_compressed(
             filepath,
-            clusters=clusters)
+            clusters=np.array(clusters, dtype=object))
 
     def load_clusters_with_neighbors(self):
-        c = np.load(self._clusters_with_neighbors_path())
+        c = np.load(self._clusters_with_neighbors_path(), allow_pickle=True)
         return c['clusters']
 
     def save_cluster_with_neighbors_geojson(self, geojson):


### PR DESCRIPTION
Hey :hand:,

When running OpenSfM I noticed that an update to numpy started throwing an error and a deprecation warning while running the create_submodels command:

```
/usr/bin/env python3 /code/SuperBuild/src/opensfm/bin/opensfm create_submodels "/datasets/code/opensfm"
/usr/local/lib/python3.6/dist-packages/numpy/core/_asarray.py:136: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  return array(a, dtype, copy=False, order=order, subok=True)
Traceback (most recent call last):
  File "/code/SuperBuild/src/opensfm/bin/opensfm", line 34, in <module>
    command.run(args)
  File "/code/SuperBuild/src/opensfm/opensfm/commands/create_submodels.py", line 34, in run
    self._save_cluster_neighbors_geojson(meta_data)
  File "/code/SuperBuild/src/opensfm/opensfm/commands/create_submodels.py", line 124, in _save_cluster_neighbors_geojson
    clusters = meta_data.load_clusters_with_neighbors()
  File "/code/SuperBuild/src/opensfm/opensfm/large/metadataset.py", line 119, in load_clusters_with_neighbors
    return c['clusters']
  File "/usr/local/lib/python3.6/dist-packages/numpy/lib/npyio.py", line 255, in __getitem__
    pickle_kwargs=self.pickle_kwargs)
  File "/usr/local/lib/python3.6/dist-packages/numpy/lib/format.py", line 727, in read_array
    raise ValueError("Object arrays cannot be loaded when "
ValueError: Object arrays cannot be loaded when allow_pickle=False
```

This PR fixes both. It's safe to use `allow_pickle` here because OpenSfM is the program generating the file (we don't download it from an external source).

Please let me know if changes are needed :pray: 
