### PR TITLE
Add OpenCV 4.4.0 SIFT support

### DIFF
--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -16,6 +16,9 @@ BOW_PATH = os.path.join(abspath, 'data', 'bow')
 
 
 # Handle different OpenCV versions
+OPENCV5 = int(cv2.__version__.split('.')[0]) >= 5 #future proofing SIFT support test (see features.py)
+OPENCV4 = int(cv2.__version__.split('.')[0]) >= 4
+OPENCV44 = int(cv2.__version__.split('.')[0]) == 4 and int(cv2.__version__.split('.')[1] >= 4) # for SIFT support (see features.py)
 OPENCV3 = int(cv2.__version__.split('.')[0]) >= 3
 
 if hasattr(cv2, 'flann_Index'):

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -87,7 +87,12 @@ def _in_mask(point, width, height, mask):
 def extract_features_sift(image, config):
     sift_edge_threshold = config['sift_edge_threshold']
     sift_peak_threshold = float(config['sift_peak_threshold'])
-    if context.OPENCV3:
+    # SIFT support is in cv2 main from version 4.4.0
+    if context.OPENCV44 or context.OPENCV5:
+        detector = cv2.SIFT_create(
+            edgeThreshold=sift_edge_threshold,
+            contrastThreshold=sift_peak_threshold)
+    elif context.OPENCV3:
         try:
             detector = cv2.xfeatures2d.SIFT_create(
                 edgeThreshold=sift_edge_threshold,
@@ -104,7 +109,12 @@ def extract_features_sift(image, config):
     while True:
         logger.debug('Computing sift with threshold {0}'.format(sift_peak_threshold))
         t = time.time()
-        if context.OPENCV3:
+        # SIFT support is in cv2 main from version 4.4.0
+        if context.OPENCV44 or context.OPENCV5:
+            detector = cv2.SIFT_create(
+                edgeThreshold=sift_edge_threshold,
+                contrastThreshold=sift_peak_threshold)
+        elif context.OPENCV3:
             detector = cv2.xfeatures2d.SIFT_create(
                 edgeThreshold=sift_edge_threshold,
                 contrastThreshold=sift_peak_threshold)


### PR DESCRIPTION
* The SIFT code has moved from contrib to OpenCV's main repository from
  version 4.4.0. Ref:
  https://github.com/opencv/opencv/wiki/ChangeLog#version440
* Add tests in `context.py` to determine version 4.4.0 or later or 5.0.0
  or later to future proof things
* Add code in `features.py` to utilise the SIFT calls in their new
  location `cv2.SIFT_create()` when using OpenCV 4.4.0+

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>