### PR TITLE
Bugfix for PR658 - features.py descriptor undefined

### DIFF
--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -92,6 +92,7 @@ def extract_features_sift(image, config):
         detector = cv2.SIFT_create(
             edgeThreshold=sift_edge_threshold,
             contrastThreshold=sift_peak_threshold)
+        descriptor = detector
     elif context.OPENCV3:
         try:
             detector = cv2.xfeatures2d.SIFT_create(


### PR DESCRIPTION
I made a mistake in `features.py` in PR #658. The new code does not
correctly assign `descriptor` in the new OpenCV 4.4.0 Sift code-path so
we die horribly with a backtrace informing that `descriptor` is used
before it is assigned.

* Ensure `descriptor` is assigned in the new OpenCV 4.4.0 Sift codepath

Signed-off-by: Daniel Llewellyn <daniel@snapcraft.ninja>