### PR TITLE
Add OpenCV 4.3.x SIFT support

### DIFF
--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -18,6 +18,7 @@ BOW_PATH = os.path.join(abspath, 'data', 'bow')
 # Handle different OpenCV versions
 OPENCV5 = int(cv2.__version__.split('.')[0]) >= 5 #future proofing SIFT support test (see features.py)
 OPENCV4 = int(cv2.__version__.split('.')[0]) >= 4
+OPENCV43 = int(cv2.__version__.split('.')[0]) == 4 and int(cv2.__version__.split('.')[1])==3 # for SIFT support (see features.py)
 OPENCV44 = int(cv2.__version__.split('.')[0]) == 4 and int(cv2.__version__.split('.')[1]) >= 4 # for SIFT support (see features.py)
 OPENCV3 = int(cv2.__version__.split('.')[0]) >= 3
 

--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -92,7 +92,7 @@ def extract_features_sift(image, config):
         detector = cv2.SIFT_create(
             edgeThreshold=sift_edge_threshold,
             contrastThreshold=sift_peak_threshold)
-    elif context.OPENCV3:
+    elif context.OPENCV3 or context.OPENCV43:
         try:
             detector = cv2.xfeatures2d.SIFT_create(
                 edgeThreshold=sift_edge_threshold,
@@ -114,7 +114,7 @@ def extract_features_sift(image, config):
             detector = cv2.SIFT_create(
                 edgeThreshold=sift_edge_threshold,
                 contrastThreshold=sift_peak_threshold)
-        elif context.OPENCV3:
+        elif context.OPENCV3 or context.OPENCV43:
             detector = cv2.xfeatures2d.SIFT_create(
                 edgeThreshold=sift_edge_threshold,
                 contrastThreshold=sift_peak_threshold)


### PR DESCRIPTION
Add tests in context.py to determine version 4.3.x

Add code in features.py to utilise the SIFT calls cv2.xfeatures2d.SIFT_create() when using OpenCV 4.3.x