### PR TITLE
Fix invalid lla keys

### DIFF
--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -420,9 +420,9 @@ class DataSet(object):
 
         if not wlat and not wlon:
             for gcp in self.load_ground_control_points_impl(None):
-                lat += gcp.lla[0]
-                lon += gcp.lla[1]
-                alt += gcp.lla[2]
+                lat += gcp.lla['latitude']
+                lon += gcp.lla['longitude']
+                alt += gcp.lla['altitude']
                 wlat += 1
                 wlon += 1
                 walt += 1

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -422,10 +422,12 @@ class DataSet(object):
             for gcp in self.load_ground_control_points_impl(None):
                 lat += gcp.lla['latitude']
                 lon += gcp.lla['longitude']
-                alt += gcp.lla['altitude']
                 wlat += 1
                 wlon += 1
-                walt += 1
+
+                if gcp.has_altitude:
+                    alt += gcp.lla['altitude']
+                    walt += 1
 
         if wlat: lat /= wlat
         if wlon: lon /= wlon


### PR DESCRIPTION
Hey all :hand: !

While processing a dataset that has no embedded GPS info, but has a GCP file, the program crashes during `match_features` with a `KeyError` exception, due to the fact that the GCP objects have named properties (they are not arrays): https://github.com/mapillary/OpenSfM/blob/master/opensfm/io.py#L394

Furthermore not all GCPs have an altitude value (it can be nan), so it should be checked against that possibility.

Let me know if changes are required!
