### PR TITLE
Fix alignment constraints function, syntax warning

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -237,10 +237,10 @@ def align_reconstructions(reconstruction_shots,
                           camera_constraint_type='soft_camera_constraint'):
     ra = pybundle.ReconstructionAlignment()
 
-    if camera_constraint_type is 'soft_camera_constraint':
+    if camera_constraint_type == 'soft_camera_constraint':
         add_camera_constraints_soft(ra, reconstruction_shots,
                                     reconstruction_name)
-    if camera_constraint_type is 'hard_camera_constraint':
+    if camera_constraint_type == 'hard_camera_constraint':
         add_camera_constraints_hard(ra, reconstruction_shots,
                                     reconstruction_name, True)
     if use_points_constraints:

--- a/opensfm/src/map/src/ba_helpers.cc
+++ b/opensfm/src/map/src/ba_helpers.cc
@@ -523,6 +523,7 @@ void BAHelpers::AlignmentConstraints(
       const auto& shot = shot_p.second;
       Xp.row(idx) = shot.shot_measurements_.gps_position_.Value();
       X.row(idx) = shot.GetPose().GetOrigin();
+      ++idx;
     }
   }
 }


### PR DESCRIPTION
Hey all :wave: 

I found a bug in `BAHelpers::AlignmentConstraints`. The `idx` variable is never incremented in the second for loop, causing the function to improperly populate the matrix. This in turn can affect the alignment of the reconstruction (I found at least one verified dataset that is improperly aligned without this fix).

I also fixed a warning concerning the use of `is` for comparison between strings. It's actually equivalent, but newer versions of Python complain about it.

```
$ python3 --version
Python 3.8.5
$ echo '"a" is "b"' | python3
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

