### PR TITLE
More robust gps_to_decimal

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -29,7 +29,8 @@ def gps_to_decimal(values, reference):
     degrees = eval_frac(values[0])
     minutes = eval_frac(values[1])
     seconds = eval_frac(values[2])
-    return sign * (degrees + minutes / 60 + seconds / 3600)
+    if degrees is not None and minutes is not None and seconds is not None:
+        return sign * (degrees + minutes / 60 + seconds / 3600)
 
 
 def get_tag_as_float(tags, key, index=0):


### PR DESCRIPTION
This PR is a small improvement to `gps_to_decimal`, making it more robust to bad EXIF data.

`eval_frac` can return `None` if a valid tag is found, but has a denominator of `0`.

When this happens, gps_to_decimal fails. This check prevents that. 