### PR TITLE
refactor: use threading

### DIFF
--- a/opensfm/commands/__init__.py
+++ b/opensfm/commands/__init__.py
@@ -18,6 +18,7 @@ from . import (
     reconstruct,
     undistort,
 )
+from .command_runner import command_runner
 
 
 opensfm_commands = [

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -31,36 +31,6 @@ else:
     logger.warning("Unable to find flann Index")
     flann_Index = None
 
-# Either use default (loky )or multiprocessing if loky doesn't work
-backend_parallel = None
-
-
-def get_parallel_backend():
-    default_parallel_backend = "loky"
-    global backend_parallel
-    if not backend_parallel:
-        try:
-            logger.info(
-                "********* Loky back-end testing, please ignore errors below. *********"
-            )
-            backend_parallel = default_parallel_backend
-            sys.stdout = sys.stderr = open(os.devnull, "w")
-            Parallel(backend=default_parallel_backend, n_jobs=2)(
-                delayed(str)(i ** 2) for i in range(10)
-            )
-        except (
-            externals.loky.process_executor.TerminatedWorkerError,
-            ModuleNotFoundError,
-        ):
-            backend_parallel = "multiprocessing"
-        sys.stdout = sys.__stdout__
-        sys.stderr = sys.__stderr__
-        logger.info(
-            "************* Loky back-end test done ************************************"
-        )
-        logger.info("Using {} as parallel backend.".format(backend_parallel))
-    return backend_parallel
-
 
 # Parallel processes
 def parallel_map(func, args, num_proc, max_batch_size=1):
@@ -73,7 +43,7 @@ def parallel_map(func, args, num_proc, max_batch_size=1):
     if num_proc <= 1:
         res = list(map(func, args))
     else:
-        with parallel_backend(get_parallel_backend(), n_jobs=num_proc):
+        with parallel_backend("threading", n_jobs=num_proc):
             batch_size = max(1, int(len(args) / (num_proc * 2)))
             batch_size = (
                 min(batch_size, max_batch_size) if max_batch_size else batch_size

--- a/opensfm/src/bundle/python/pybind.cc
+++ b/opensfm/src/bundle/python/pybind.cc
@@ -6,15 +6,11 @@
 #include <bundle/reconstruction_alignment.h>
 #include <foundation/python_types.h>
 
-void BundleAdjusterRun(BundleAdjuster *bundle_adjuster) {
-  py::gil_scoped_release release;
-  bundle_adjuster->Run();
-}
 
 PYBIND11_MODULE(pybundle, m) {
   py::class_<BundleAdjuster>(m, "BundleAdjuster")
       .def(py::init())
-      .def("run", &BundleAdjusterRun)
+      .def("run", &BundleAdjuster::Run, py::call_guard<py::gil_scoped_release>())
       .def("set_point_projection_loss_function",
            &BundleAdjuster::SetPointProjectionLossFunction)
       .def("set_relative_motion_loss_function",

--- a/opensfm/src/dense/depthmap_bind.h
+++ b/opensfm/src/dense/depthmap_bind.h
@@ -26,26 +26,29 @@ class DepthmapEstimatorWrapper {
   void SetMinPatchSD(float sd) { de_.SetMinPatchSD(sd); }
 
   py::object ComputePatchMatch() {
-    py::gil_scoped_release release;
-
     DepthmapEstimatorResult result;
-    de_.ComputePatchMatch(&result);
+    {
+      py::gil_scoped_release release;
+      de_.ComputePatchMatch(&result);
+    }
     return ComputeReturnValues(result);
   }
 
   py::object ComputePatchMatchSample() {
-    py::gil_scoped_release release;
-
     DepthmapEstimatorResult result;
-    de_.ComputePatchMatchSample(&result);
+    {
+      py::gil_scoped_release release;
+      de_.ComputePatchMatchSample(&result);
+    }
     return ComputeReturnValues(result);
   }
 
   py::object ComputeBruteForce() {
-    py::gil_scoped_release release;
-
     DepthmapEstimatorResult result;
-    de_.ComputeBruteForce(&result);
+    {
+      py::gil_scoped_release release;
+      de_.ComputeBruteForce(&result);
+    }
     return ComputeReturnValues(result);
   }
 
@@ -78,10 +81,11 @@ class DepthmapCleanerWrapper {
   }
 
   py::object Clean() {
-    py::gil_scoped_release release;
-
     cv::Mat depth;
-    dc_.Clean(&depth);
+    {
+      py::gil_scoped_release release;
+      dc_.Clean(&depth);
+    }
     return py_array_from_data(depth.ptr<float>(0), depth.rows, depth.cols);
   }
 
@@ -102,15 +106,16 @@ class DepthmapPrunerWrapper {
   }
 
   py::object Prune() {
-    py::gil_scoped_release release;
-
     std::vector<float> points;
     std::vector<float> normals;
     std::vector<unsigned char> colors;
     std::vector<unsigned char> labels;
     std::vector<unsigned char> detections;
 
-    dp_.Prune(&points, &normals, &colors, &labels, &detections);
+    {
+      py::gil_scoped_release release;
+      dp_.Prune(&points, &normals, &colors, &labels, &detections);
+    }
 
     py::list retn;
     int n = int(points.size()) / 3;

--- a/opensfm/src/dense/src/depthmap.cc
+++ b/opensfm/src/dense/src/depthmap.cc
@@ -10,11 +10,11 @@ bool IsInsideImage(const cv::Mat &image, int i, int j) {
 
 template <typename T>
 float LinearInterpolation(const cv::Mat &image, float y, float x) {
-  if (x < 0.0f || x >= image.cols - 1 || y < 0.0f || y >= image.rows - 1) {
-    return 0.0f;
-  }
   int ix = int(x);
   int iy = int(y);
+  if (ix < 0.0f || ix >= image.cols - 1 || iy < 0.0f || iy >= image.rows - 1) {
+    return 0.0f;
+  }
   float dx = x - ix;
   float dy = y - iy;
   float im00 = image.at<T>(iy, ix);

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -11,6 +11,15 @@
 
 namespace py = pybind11;
 
+std::pair<MatXf, MatXf>
+RunComputeCameraMapping(const Camera& from,
+                        const Camera& to,
+                        int width, int height){
+  py::gil_scoped_release release;
+  return ComputeCameraMapping(from, to, width, height);
+}
+
+
 PYBIND11_MODULE(pygeometry, m) {
   py::enum_<ProjectionType>(m, "ProjectionType")
       .value("PERSPECTIVE", ProjectionType::PERSPECTIVE)
@@ -251,7 +260,7 @@ PYBIND11_MODULE(pygeometry, m) {
            py::return_value_policy::copy)
       .def("__deepcopy__", [](const Camera& c, const py::dict& d) { return c; },
            py::return_value_policy::copy);
-  m.def("compute_camera_mapping", ComputeCameraMapping);
+  m.def("compute_camera_mapping", RunComputeCameraMapping);
 
   m.def("triangulate_bearings_dlt", geometry::TriangulateBearingsDLT);
   m.def("triangulate_bearings_midpoint", geometry::TriangulateBearingsMidpoint);

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -11,14 +11,6 @@
 
 namespace py = pybind11;
 
-std::pair<MatXf, MatXf>
-RunComputeCameraMapping(const Camera& from,
-                        const Camera& to,
-                        int width, int height){
-  py::gil_scoped_release release;
-  return ComputeCameraMapping(from, to, width, height);
-}
-
 
 PYBIND11_MODULE(pygeometry, m) {
   py::enum_<ProjectionType>(m, "ProjectionType")
@@ -260,8 +252,7 @@ PYBIND11_MODULE(pygeometry, m) {
            py::return_value_policy::copy)
       .def("__deepcopy__", [](const Camera& c, const py::dict& d) { return c; },
            py::return_value_policy::copy);
-  m.def("compute_camera_mapping", RunComputeCameraMapping);
-
+  m.def("compute_camera_mapping", ComputeCameraMapping, py::call_guard<py::gil_scoped_release>());
   m.def("triangulate_bearings_dlt", geometry::TriangulateBearingsDLT);
   m.def("triangulate_bearings_midpoint", geometry::TriangulateBearingsMidpoint);
   m.def("triangulate_two_bearings_midpoint",


### PR DESCRIPTION
This PR aims at making OpenSfM uses `joblib`'s `threading` instead of `multiprocessing`/`loky` : due to GIL release in OpenSfM C++ part and as well in OpenCV, critical code can run concurrently.

We narrow a bit the GIL release sections as some crash could be observed, and also release GIL when computing camera bearings map for undistortion.

We also fix the `command_runner` import broken at db32545f6d6359bb170382ba2d61a6be52247941