### PR TITLE
[fix] Add omp includes and libs to CMakeLists.txt

### DIFF
--- a/opensfm/src/foundation/CMakeLists.txt
+++ b/opensfm/src/foundation/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(foundation
   PUBLIC
     pybind11
     ${OpenCV_LIBS}
+    ${OpenMP_libomp_LIBRARY}
   PRIVATE
     ${GFLAGS_LIBRARY}
     ${GLOG_LIBRARY}
@@ -20,6 +21,7 @@ target_include_directories(foundation
     ${EIGEN_INCLUDE_DIRS}
     ${PYTHON_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}
+    ${OpenMP_CXX_INCLUDE_DIR}
 )
 
 if (OPENSFM_BUILD_TESTS)

--- a/opensfm/src/sfm/CMakeLists.txt
+++ b/opensfm/src/sfm/CMakeLists.txt
@@ -11,7 +11,12 @@ target_link_libraries(sfm
   PRIVATE
     foundation
 )
-target_include_directories(sfm PUBLIC ${EIGEN_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
+target_include_directories(sfm
+    PUBLIC
+        ${EIGEN_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}
+    PRIVATE
+        ${OpenMP_CXX_INCLUDE_DIR})
 
 if (OPENSFM_BUILD_TESTS)
     set(SFM_TEST_FILES

--- a/opensfm/src/sfm/CMakeLists.txt
+++ b/opensfm/src/sfm/CMakeLists.txt
@@ -11,12 +11,7 @@ target_link_libraries(sfm
   PRIVATE
     foundation
 )
-target_include_directories(sfm
-    PUBLIC
-        ${EIGEN_INCLUDE_DIRS}
-        ${CMAKE_SOURCE_DIR}
-    PRIVATE
-        ${OpenMP_CXX_INCLUDE_DIR})
+target_include_directories(sfm PUBLIC ${EIGEN_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
 
 if (OPENSFM_BUILD_TESTS)
     set(SFM_TEST_FILES

--- a/opensfm/src/third_party/akaze/CMakeLists.txt
+++ b/opensfm/src/third_party/akaze/CMakeLists.txt
@@ -10,10 +10,10 @@ set(AKAZE_SRCS
     lib/utils.cpp
 )
 add_library(akaze ${AKAZE_SRCS})
-target_link_libraries(akaze ${OpenCV_LIBS} ${OpenMP_libomp_LIBRARY})
+target_link_libraries(akaze ${OpenCV_LIBS})
 target_include_directories(akaze
   PUBLIC
     ${CMAKE_SOURCE_DIR}/third_party/akaze/lib
-    ${OpenMP_CXX_INCLUDE_DIR}
   PRIVATE
-    ${OpenCV_INCLUDE_DIRS})
+    ${OpenCV_INCLUDE_DIRS}
+    ${OpenMP_CXX_INCLUDE_DIR})

--- a/opensfm/src/third_party/akaze/CMakeLists.txt
+++ b/opensfm/src/third_party/akaze/CMakeLists.txt
@@ -10,10 +10,10 @@ set(AKAZE_SRCS
     lib/utils.cpp
 )
 add_library(akaze ${AKAZE_SRCS})
-target_link_libraries(akaze ${OpenCV_LIBS})
+target_link_libraries(akaze ${OpenCV_LIBS} ${OpenMP_libomp_LIBRARY})
 target_include_directories(akaze
-  PUBLIC 
+  PUBLIC
     ${CMAKE_SOURCE_DIR}/third_party/akaze/lib
+    ${OpenMP_CXX_INCLUDE_DIR}
   PRIVATE
-    ${OpenCV_INCLUDE_DIRS}
-)
+    ${OpenCV_INCLUDE_DIRS})

--- a/opensfm/src/third_party/vlfeat/CMakeLists.txt
+++ b/opensfm/src/third_party/vlfeat/CMakeLists.txt
@@ -1,3 +1,6 @@
 file(GLOB VLFEAT_SRCS vl/*.c vl/*.h)
 add_library(vl ${VLFEAT_SRCS})
-target_include_directories(vl PRIVATE ${CMAKE_SOURCE_DIR}/third_party/vlfeat)
+target_include_directories(vl
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/third_party/vlfeat
+    ${OpenMP_CXX_INCLUDE_DIR})


### PR DESCRIPTION
To compile on some system, it is required to explicitly add the `Open MP` includes and libraries in the `CMakeLists.txt`.
This solves compilation errors such as:
```
fatal error: 'omp.h' file not found 
#include <omp.h>
```