### PR TITLE
Export num views option with export_ply

### DIFF
--- a/opensfm/actions/export_ply.py
+++ b/opensfm/actions/export_ply.py
@@ -6,22 +6,25 @@ from opensfm import io
 from opensfm.dense import depthmap_to_ply, scale_down_image
 
 
-def run_dataset(data, no_cameras, no_points, depthmaps):
+def run_dataset(data, no_cameras, no_points, depthmaps, point_num_views):
     """Export reconstruction to PLY format
 
     Args:
         no_cameras: do not save camera positions
         no_points: do not save points
         depthmaps: export per-image depthmaps as pointclouds
+        point_num_views: Export the number of views associated with each point
 
     """
 
     reconstructions = data.load_reconstruction()
+    tracks_manager = data.load_tracks_manager()
     no_cameras = no_cameras
     no_points = no_points
+    point_num_views = point_num_views
 
     if reconstructions:
-        data.save_ply(reconstructions[0], None, no_cameras, no_points)
+        data.save_ply(reconstructions[0], tracks_manager, None, no_cameras, no_points, point_num_views)
 
     if depthmaps and reconstructions:
         udata = dataset.UndistortedDataSet(data)

--- a/opensfm/commands/export_ply.py
+++ b/opensfm/commands/export_ply.py
@@ -8,7 +8,7 @@ class Command(command.CommandBase):
     help = "Export reconstruction to PLY format"
 
     def run_impl(self, dataset, args):
-        export_ply.run_dataset(dataset, args.no_cameras, args.no_points, args.depthmaps)
+        export_ply.run_dataset(dataset, args.no_cameras, args.no_points, args.depthmaps, args.point_num_views)
 
     def add_arguments_impl(self, parser):
         parser.add_argument(
@@ -25,4 +25,10 @@ class Command(command.CommandBase):
             action="store_true",
             default=False,
             help="Export per-image depthmaps as pointclouds",
+        )
+        parser.add_argument(
+            "--point-num-views",
+            action="store_true",
+            default=False,
+            help="Export the number of observations associated with each point"
         )

--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -560,10 +560,10 @@ class DataSet(object):
         return os.path.join(self.data_path, filename or "reconstruction.ply")
 
     def save_ply(
-        self, reconstruction, filename=None, no_cameras=False, no_points=False
+        self, reconstruction, tracks_manager, filename=None, no_cameras=False, no_points=False, point_num_views=False
     ):
         """Save a reconstruction in PLY format."""
-        ply = io.reconstruction_to_ply(reconstruction, no_cameras, no_points)
+        ply = io.reconstruction_to_ply(reconstruction, tracks_manager, no_cameras, no_points, point_num_views)
         with io.open_wt(self._ply_file(filename)) as fout:
             fout.write(ply)
 

--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -1059,7 +1059,7 @@ def import_bundler(
 # PLY
 
 
-def ply_header(count_vertices, with_normals=False):
+def ply_header(count_vertices, with_normals=False, point_num_views=False):
     if with_normals:
         header = [
             "ply",
@@ -1074,7 +1074,6 @@ def ply_header(count_vertices, with_normals=False):
             "property uchar diffuse_red",
             "property uchar diffuse_green",
             "property uchar diffuse_blue",
-            "end_header",
         ]
     else:
         header = [
@@ -1087,13 +1086,18 @@ def ply_header(count_vertices, with_normals=False):
             "property uchar diffuse_red",
             "property uchar diffuse_green",
             "property uchar diffuse_blue",
-            "end_header",
         ]
+    
+    if point_num_views:
+        header += ["property uchar views"]
+    
+    header += ["end_header"]
+
     return header
 
 
-def points_to_ply_string(vertices):
-    header = ply_header(len(vertices))
+def points_to_ply_string(vertices, point_num_views=False):
+    header = ply_header(len(vertices), point_num_views=point_num_views)
     return "\n".join(header + vertices + [""])
 
 
@@ -1122,7 +1126,7 @@ def ply_to_points(filename):
     return np.array(points), np.array(normals), np.array(colors)
 
 
-def reconstruction_to_ply(reconstruction, no_cameras=False, no_points=False):
+def reconstruction_to_ply(reconstruction, tracks_manager=None, no_cameras=False, no_points=False, point_num_views=False):
     """Export reconstruction points as a PLY string."""
     vertices = []
 
@@ -1132,6 +1136,13 @@ def reconstruction_to_ply(reconstruction, no_cameras=False, no_points=False):
             s = "{} {} {} {} {} {}".format(
                 p[0], p[1], p[2], int(c[0]), int(c[1]), int(c[2])
             )
+
+            if point_num_views and tracks_manager:
+                obs_count = point.number_of_observations()
+                if not obs_count:
+                    obs_count = len(tracks_manager.get_track_observations(point.id))
+                s += " {}".format(obs_count)
+
             vertices.append(s)
 
     if not no_cameras:
@@ -1145,5 +1156,7 @@ def reconstruction_to_ply(reconstruction, no_cameras=False, no_points=False):
                     s = "{} {} {} {} {} {}".format(
                         p[0], p[1], p[2], int(c[0]), int(c[1]), int(c[2])
                     )
+                    if point_num_views:
+                        s += " 0"
                     vertices.append(s)
-    return points_to_ply_string(vertices)
+    return points_to_ply_string(vertices, point_num_views)


### PR DESCRIPTION
Hello :hand:

This PR proposes the addition of a new `--point-num-views` parameter to the `export_ply` command to output a new `views` containing the number of views that each point is visible from.

This lets a user generate "coverage" maps using a tool such as PDAL to identify areas that might be missing overlap.

![image](https://user-images.githubusercontent.com/1951843/104733606-f1a0bf80-570c-11eb-9c7d-a9b4a178bfe5.png)

Hope it can be useful to others.