### PR TITLE
Add --diagram_max_points flag to compute_statistics

### DIFF
--- a/opensfm/actions/compute_statistics.py
+++ b/opensfm/actions/compute_statistics.py
@@ -7,7 +7,7 @@ from opensfm import stats
 logger = logging.getLogger(__name__)
 
 
-def run_dataset(data):
+def run_dataset(data, diagram_max_points = -1):
     """Compute various staistics of a datasets and write them to 'stats' folder
 
     Args:
@@ -24,6 +24,10 @@ def run_dataset(data):
 
     stats.save_residual_grids(data, tracks_manager, reconstructions, output_path)
     stats.save_matchgraph(data, tracks_manager, reconstructions, output_path)
+    
+    if diagram_max_points > 0:
+        stats.decimate_points(reconstructions, diagram_max_points)
+        
     stats.save_heatmap(data, tracks_manager, reconstructions, output_path)
     stats.save_topview(data, tracks_manager, reconstructions, output_path)
 

--- a/opensfm/commands/compute_statistics.py
+++ b/opensfm/commands/compute_statistics.py
@@ -7,7 +7,12 @@ class Command(command.CommandBase):
     help = "Compute statistics and save them in the stats folder"
 
     def run_impl(self, dataset, args):
-        compute_statistics.run_dataset(dataset)
+        compute_statistics.run_dataset(dataset, args.diagram_max_points)
 
     def add_arguments_impl(self, parser):
-        pass
+        parser.add_argument(
+            "--diagram_max_points",
+            default=-1,
+            type=int,
+            help="Cap the number of points (by index-based decimation) for computing heatmap / topview diagrams. Default: %(default)s (use all available points)",
+        )

--- a/opensfm/stats.py
+++ b/opensfm/stats.py
@@ -4,6 +4,7 @@ import os
 import statistics
 from collections import defaultdict
 from functools import lru_cache
+import random
 
 import matplotlib.cm as cm
 import matplotlib.colors as colors
@@ -730,3 +731,19 @@ def save_residual_grids(data, tracks_manager, reconstructions, output_path):
             dpi=300,
             bbox_inches="tight",
         )
+
+def decimate_points(reconstructions, max_num_points):
+    """
+    Destructively decimate the points in a reconstruction
+    if they exceed max_num_points by removing points
+    at random
+    """
+    for rec in reconstructions:
+        if len(rec.points) > max_num_points:
+            all_points = rec.points
+            random_ids = list(all_points.keys())
+            random.shuffle(random_ids)
+            random_ids = set(random_ids[:len(all_points) - max_num_points])
+
+            for point_id in random_ids:
+                rec.remove_point(point_id)


### PR DESCRIPTION
Hello :hand: !

This PR adds an optional flag that allows a user to decimate the points used to compute the topview/heatmap diagrams in `compute_statistics`, which results in faster runtime.