### PR TITLE
Fixed export_geocoords

### DIFF
--- a/opensfm/actions/export_geocoords.py
+++ b/opensfm/actions/export_geocoords.py
@@ -114,7 +114,7 @@ def _transform_reconstruction(reconstruction, transformation):
     for shot in reconstruction.shots.values():
         R = shot.pose.get_rotation_matrix()
         shot.pose.set_rotation_matrix(np.dot(R, A1))
-        shot.pose.translation = list(np.dot(A, shot.pose.get_origin()) + b)
+        shot.pose.set_origin(np.dot(A, shot.pose.get_origin()) + b)
 
     for point in reconstruction.points.values():
         point.coordinates = list(np.dot(A, point.coordinates) + b)

--- a/opensfm/actions/export_geocoords.py
+++ b/opensfm/actions/export_geocoords.py
@@ -110,13 +110,12 @@ def _transform_reconstruction(reconstruction, transformation):
     """Apply a transformation to a reconstruction in-place."""
     A, b = transformation[:3, :3], transformation[:3, 3]
     A1 = np.linalg.inv(A)
-    b1 = -np.dot(A1, b)
 
     for shot in reconstruction.shots.values():
         R = shot.pose.get_rotation_matrix()
         t = shot.pose.translation
         shot.pose.set_rotation_matrix(np.dot(R, A1))
-        shot.pose.translation = list(np.dot(R, b1) + t)
+        shot.pose.translation = list(np.dot(A, shot.pose.get_origin()) + b)
 
     for point in reconstruction.points.values():
         point.coordinates = list(np.dot(A, point.coordinates) + b)

--- a/opensfm/actions/export_geocoords.py
+++ b/opensfm/actions/export_geocoords.py
@@ -113,7 +113,6 @@ def _transform_reconstruction(reconstruction, transformation):
 
     for shot in reconstruction.shots.values():
         R = shot.pose.get_rotation_matrix()
-        t = shot.pose.translation
         shot.pose.set_rotation_matrix(np.dot(R, A1))
         shot.pose.translation = list(np.dot(A, shot.pose.get_origin()) + b)
 


### PR DESCRIPTION
Hey all :hand: 

Today while running the `export_geocoords --reconstruction` command (to export the reconstruction.json in a geographic CRS) I noticed that the camera's translation had some erroneous values after the transformation.

This PR fixes the issue by using the same computation used in `_transform_image_positions` (which is correct) and applies it to `_transform_reconstruction`.