### PR TITLE
Update OpenMVS exporter to be compatible with latest version

### DIFF
--- a/opensfm/actions/export_openmvs.py
+++ b/opensfm/actions/export_openmvs.py
@@ -31,8 +31,8 @@ def export(reconstruction, tracks_manager, udata, export_only):
             w, h = camera.width, camera.height
             K = np.array(
                 [
-                    [camera.focal * max(w, h), 0, w / 2.0],
-                    [0, camera.focal * max(w, h), h / 2.0],
+                    [camera.focal * max(w, h), 0, (w - 1.0) / 2.0],
+                    [0, camera.focal * max(w, h), (h - 1.0) / 2.0],
                     [0, 0, 1],
                 ]
             )

--- a/opensfm/actions/export_openmvs.py
+++ b/opensfm/actions/export_openmvs.py
@@ -31,12 +31,12 @@ def export(reconstruction, tracks_manager, udata, export_only):
             w, h = camera.width, camera.height
             K = np.array(
                 [
-                    [camera.focal, 0, (w - 1.0) / 2 / max(w, h)],
-                    [0, camera.focal, (h - 1.0) / 2 / max(w, h)],
+                    [camera.focal * max(w, h), 0, w / 2.0],
+                    [0, camera.focal * max(w, h), h / 2.0],
                     [0, 0, 1],
                 ]
             )
-            exporter.add_camera(str(camera.id), K)
+            exporter.add_camera(str(camera.id), K, w, h)
 
     for shot in reconstruction.shots.values():
         if export_only is not None and shot.id not in export_only:

--- a/opensfm/pydense.pyi
+++ b/opensfm/pydense.pyi
@@ -88,7 +88,7 @@ class OpenMVSExporter:
     def __init__(self) -> None:
         ...
 
-    def add_camera(self, arg0: str, arg1: numpy.ndarray[float64]) -> None:
+    def add_camera(self, arg0: str, arg1: numpy.ndarray[float64], arg2: int, arg3: int) -> None:
         ...
 
     def add_point(self, arg0: numpy.ndarray[float64], arg1: list) -> None:

--- a/opensfm/src/dense/openmvs_exporter.h
+++ b/opensfm/src/dense/openmvs_exporter.h
@@ -6,10 +6,12 @@ namespace dense {
 
 class OpenMVSExporter {
  public:
-  void AddCamera(const std::string &camera_id, pyarray_d K) {
+  void AddCamera(const std::string &camera_id, pyarray_d K, uint32_t width, uint32_t height) {
     MVS::Interface::Platform platform;
     platform.name = camera_id;
     MVS::Interface::Platform::Camera camera;
+    camera.width = width;
+    camera.height = height;
     camera.K = cv::Matx33d(K.data());
     camera.R = cv::Matx33d::eye();
     camera.C = cv::Point3_<double>(0, 0, 0);


### PR DESCRIPTION
This PR updates the `export_openmvs` command to generate files compatible with the latest OpenMVS.

Note that these changes don't allow older version of OpenMVS to process the files exported with this PR, so this is a breaking change.