### PR TITLE
build error

### DIFF
--- a/opensfm/src/geometry/CMakeLists.txt
+++ b/opensfm/src/geometry/CMakeLists.txt
@@ -5,7 +5,7 @@ set(GEOMETRY_FILES
     covariance.h
     pose.h
     camera.h
-    camera_functions.h
+    functions.h
     relative_pose.h
     triangulation.h
     src/camera.cc


### PR DESCRIPTION
When I run the ```python3 setup.py build``` command I get this error:

```
CMake Error at geometry/CMakeLists.txt:18 (add_library):
  Cannot find source file:

    camera_functions.h

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx


CMake Error at geometry/CMakeLists.txt:18 (add_library):
  No SOURCES given to target: geometry
```

The file does not exist and it was renamed to functions.h but wasn't updated in the CMakeList.txt, so I updated the CMakeList to the correct way.
