### PR TITLE
Change PyYaml to avoid vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy
 Pillow>=8.1.1
 pyproj>=1.9.5.1
 pytest==3.0.7
-python-dateutil==2.6.0
+python-dateutil>=2.7
 pyyaml==5.4
 scipy
 Sphinx==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Pillow>=8.1.1
 pyproj>=1.9.5.1
 pytest==3.0.7
 python-dateutil==2.6.0
-pyyaml==5.1
+pyyaml==5.4
 scipy
 Sphinx==3.4.3
 six


### PR DESCRIPTION
This PR changes the PyYaml version to address this [vulnerability](https://github.com/advisories/GHSA-8q59-q68h-6hv4) in the PyYaml versions <5.4.
It was also necessary to change the version of `python-datetime`.
All the test pass: https://github.com/mapillary/OpenSfM/runs/2200491648?check_suite_focus=true
