### PR TITLE
Handle int values in GPSAltitude EXIFs

### DIFF
--- a/opensfm/exif.py
+++ b/opensfm/exif.py
@@ -327,11 +327,19 @@ class EXIF:
         if self.has_dji_altitude():
             altitude = self.extract_dji_altitude()
         elif "GPS GPSAltitude" in self.tags:
-            altitude = eval_frac(self.tags["GPS GPSAltitude"].values[0])
+            alt_value = self.tags["GPS GPSAltitude"].values[0]
+            if isinstance(alt_value, exifread.utils.Ratio):
+                altitude = eval_frac(alt_value)
+            elif isinstance(alt_value, int):
+                altitude = float(alt_value)
+            else:
+                altitude = None
+            
             # Check if GPSAltitudeRef is equal to 1, which means GPSAltitude should be negative, reference: http://www.exif.org/Exif2-2.PDF#page=53
             if (
                 "GPS GPSAltitudeRef" in self.tags
                 and self.tags["GPS GPSAltitudeRef"].values[0] == 1
+                and altitude is not None
             ):
                 altitude = -altitude
         else:


### PR DESCRIPTION
Hello :hand:

Certain cameras write the `GPSAltitude` tag using `int` values instead of fractions. This causes the extract_metadata command to fail with these images. (Sample image attached)

![DSC00907_RG+N](https://user-images.githubusercontent.com/1951843/114558611-db859b00-9c38-11eb-9786-68a7e348a414.JPG)

This PR specifically checks for such case and handles it by using the int value (after casting).