### PR TITLE
OpenSfM viewer upgrade to MapillaryJS 4.0.0-beta.2

### DIFF
--- a/viewer/node_modules.sh
+++ b/viewer/node_modules.sh
@@ -39,7 +39,7 @@ curl -fS "$UNPKG/$GLM_V/$PKG" \
 
 # mapillary-js
 MJS_PKG="mapillary-js"
-MJS_V="$MJS_PKG@4.0.0-beta.0"
+MJS_V="$MJS_PKG@4.0.0-beta.2"
 MJS_DIST="dist"
 MJS_JS="mapillary.module.js"
 MJS_CSS="mapillary.css"

--- a/viewer/src/controller/DatController.js
+++ b/viewer/src/controller/DatController.js
@@ -3,7 +3,11 @@
  */
 
 import {GUI} from '../../node_modules/dat.gui/build/dat.gui.module.js';
-import {SpatialDataComponent as SDC} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+import {
+  CameraControls,
+  CameraVisualizationMode,
+  OriginalPositionMode,
+} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {ListController} from './ListController.js';
 
 export const FolderName = Object.freeze({
@@ -54,10 +58,20 @@ export class DatController {
       .onChange(v => this._onChange(name, v));
   }
 
+  _addCameraControlsOption(folder) {
+    const cc = CameraControls;
+    const ccs = [cc[cc.Earth], cc[cc.Street]];
+    folder
+      .add(this._config, 'cameraControls', ccs)
+      .listen()
+      .onChange(c => this._onChange('cameraControls', cc[c]));
+  }
+
   _addCameraVizualizationOption(folder) {
-    const cvm = SDC.CameraVisualizationMode;
+    const cvm = CameraVisualizationMode;
     const cvms = [
-      cvm[cvm.Default],
+      cvm[cvm.Hidden],
+      cvm[cvm.Homogeneous],
       cvm[cvm.Cluster],
       cvm[cvm.ConnectedComponent],
       cvm[cvm.Sequence],
@@ -76,7 +90,7 @@ export class DatController {
   }
 
   _addPositionVisualizationOption(folder) {
-    const opm = SDC.OriginalPositionMode;
+    const opm = OriginalPositionMode;
     const opms = [opm[opm.Hidden], opm[opm.Flat], opm[opm.Altitude]];
     folder
       .add(this._config, 'originalPositionMode', opms)
@@ -113,13 +127,12 @@ export class DatController {
     folder.open();
     this._addBooleanOption('pointsVisible', folder);
     this._addNumericOption('pointSize', folder);
-    this._addBooleanOption('camerasVisible', folder);
-    this._addNumericOption('cameraSize', folder);
     this._addCameraVizualizationOption(folder);
+    this._addNumericOption('cameraSize', folder);
     this._addPositionVisualizationOption(folder);
+    this._addCameraControlsOption(folder);
     this._addBooleanOption('tilesVisible', folder);
     this._addBooleanOption('imagesVisible', folder);
-    this._addBooleanOption('earthControls', folder);
     return folder;
   }
 
@@ -139,13 +152,8 @@ export class DatController {
         type = types[name];
         emitter.fire(type, {type, visible});
         break;
-      case 'earthControls':
-        const active = value;
-        type = types[name];
-        emitter.fire(type, {active, type});
-        break;
+      case 'cameraControls':
       case 'originalPositionMode':
-        mode = value;
       case 'cameraVisualizationMode':
         mode = value;
         type = types[name];

--- a/viewer/src/controller/OptionController.js
+++ b/viewer/src/controller/OptionController.js
@@ -2,26 +2,31 @@
  * @format
  */
 
-import {SpatialDataComponent as SDC} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+import {
+  CameraControls,
+  CameraVisualizationMode,
+  OriginalPositionMode,
+} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {EventEmitter} from '../util/EventEmitter.js';
 import {DatController} from './DatController.js';
 import {KeyController} from './KeyController.js';
 
 export class OptionController {
   constructor(options) {
-    const cvm = SDC.CameraVisualizationMode;
-    const opm = SDC.OriginalPositionMode;
+    const cc = CameraControls;
+    const cvm = CameraVisualizationMode;
+    const opm = OriginalPositionMode;
     const config = Object.assign({}, options, {
+      cameraControls: cc[options.cameraControls],
       cameraVisualizationMode: cvm[options.cameraVisualizationMode],
       originalPositionMode: opm[options.originalPositionMode],
     });
     const eventTypes = {
+      cameraControls: 'cameracontrols',
       cameraSize: 'camerasize',
-      camerasVisible: 'camerasvisible',
       cameraVisualizationMode: 'cameravisualizationmode',
       commandsVisible: 'commandsvisible',
       datToggle: 'dattoggle',
-      earthControls: 'earthcontrols',
       imagesVisible: 'imagesvisible',
       infoSize: 'infosize',
       originalPositionMode: 'originalpositionmode',

--- a/viewer/src/provider/DataConverter.js
+++ b/viewer/src/provider/DataConverter.js
@@ -2,7 +2,7 @@
  * @format
  */
 
-import {Geo} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+import {enuToGeodetic} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {imageEntToUniqueID} from '../util/ids.js';
 import * as math from './math.js';
 
@@ -12,48 +12,11 @@ export class DataConverter {
   }
 
   cluster(cluster, clusterId, reference) {
-    const cameras = {};
-    for (const cameraId in cluster.cameras) {
-      if (!cluster.cameras.hasOwnProperty(cameraId)) {
-        continue;
-      }
-
-      const camera = cluster.cameras[cameraId];
-      const camera_type = this._mapProjectionType(camera.projection_type);
-      const camera_parameters = [camera.focal, camera.k1, camera.k2];
-      cameras[cameraId] = {
-        camera_parameters,
-        camera_type,
-      };
-    }
-
-    const points = !!cluster.points ? cluster.points : {};
-    const shots = {};
-    for (const shotId in cluster.shots) {
-      if (!cluster.shots.hasOwnProperty(shotId)) {
-        continue;
-      }
-      const shot = cluster.shots[shotId];
-      const cameraId = shot.camera;
-      const rotation = shot.rotation;
-      const translation = shot.translation;
-      // Invent unique id
-      const uniqueId = imageEntToUniqueID({
-        cluster: {id: clusterId},
-        id: shotId,
-      });
-      shots[uniqueId] = {
-        cameraId,
-        rotation,
-        translation,
-      };
-    }
+    const points = cluster.points ?? {};
     return {
-      cameras,
       id: clusterId,
       points,
       reference,
-      shots,
     };
   }
 
@@ -149,8 +112,7 @@ export class DataConverter {
     const cluster = {id: clusterId, url: clusterId};
     const computed_rotation = shot.rotation;
     const height = camera.height;
-    const merge_cc = shot.merge_cc;
-    const merge_version = 1;
+    const merge_id = shot.merge_cc.toString();
     const exif_orientation = shot.orientation;
     const quality_score = 1;
     const width = camera.width;
@@ -178,8 +140,7 @@ export class DataConverter {
       geometry,
       height,
       id: uniqueId,
-      merge_cc,
-      merge_version,
+      merge_id,
       mesh,
       organization,
       exif_orientation,
@@ -208,7 +169,7 @@ export class DataConverter {
   }
 
   _enuToGeodetic(enu, reference) {
-    return Geo.enuToGeodetic(
+    return enuToGeodetic(
       enu[0],
       enu[1],
       enu[2],

--- a/viewer/src/provider/OpensfmDataProvider.js
+++ b/viewer/src/provider/OpensfmDataProvider.js
@@ -2,7 +2,11 @@
  * @format
  */
 
-import {API} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+import {
+  fetchArrayBuffer,
+  DataProviderBase,
+  S2GeometryProvider,
+} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {isReconstructionData} from '../util/types.js';
 import {DataConverter} from './DataConverter.js';
 
@@ -12,9 +16,9 @@ function* generator(items, map) {
   }
 }
 
-export class OpensfmDataProvider extends API.DataProviderBase {
+export class OpensfmDataProvider extends DataProviderBase {
   constructor(options, geometry) {
-    super(geometry ?? new API.S2GeometryProvider(15));
+    super(geometry ?? new S2GeometryProvider(15));
     this._convert = new DataConverter(options);
     this._inventedImageBuffer = null;
     this._rawData = {};
@@ -127,7 +131,7 @@ export class OpensfmDataProvider extends API.DataProviderBase {
     });
   }
 
-  getClusterReconstruction(clusterId) {
+  getCluster(clusterId) {
     return this._getDataLoadedPromise().then(
       () => this._data.clusters[clusterId],
     );
@@ -150,7 +154,7 @@ export class OpensfmDataProvider extends API.DataProviderBase {
       return this._getInventedImageBuffer();
     }
 
-    return API.fetchArrayBuffer(url, cancellation);
+    return fetchArrayBuffer(url, cancellation);
   }
 
   getMesh(url) {

--- a/viewer/styles/opensfm.css
+++ b/viewer/styles/opensfm.css
@@ -15,7 +15,7 @@ body,
 .opensfm-file-background {
     position: absolute;
     top: 0;
-    background-color: #ffffff60;
+    background-color: #000000c0;
 }
 
 .opensfm-file-exit-button {
@@ -232,7 +232,7 @@ input[type='file'] {
 }
 
 .opensfm-info-text {
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
     color: #eee;
     display: block;
     margin: 2px;


### PR DESCRIPTION
Summary:
## Handle breaking MJS changes

- Flat export
- Cameras visible removed - use camera controls API
- `merge_version` removed
- Image `mergeCc` prop renamed to `mergeId`
- Use camera control API instead of spatial config bool
- Cluster contract rename and removal of unused props
- Spatial data component renamed to spatial
- Image plane component renamed to image
- Filter expression properly typed

Differential Revision: D27989090

