### PR TITLE
feat: upgrade opensfm viewer to mapillary-js v4.0.0-beta.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ launch.json
 eval
 
 # Viewer
-viewer/node_modules
+node_modules
 
 # Ignore the data folder, but not the berlin example.
 data/*

--- a/viewer/node_modules.sh
+++ b/viewer/node_modules.sh
@@ -39,7 +39,7 @@ curl -fS "$UNPKG/$GLM_V/$PKG" \
 
 # mapillary-js
 MJS_PKG="mapillary-js"
-MJS_V="$MJS_PKG@4.0.0-beta.2"
+MJS_V="$MJS_PKG@4.0.0-beta.4"
 MJS_DIST="dist"
 MJS_JS="mapillary.module.js"
 MJS_CSS="mapillary.css"
@@ -52,3 +52,23 @@ curl -fS --create-dirs "$UNPKG/$MJS_IN/$MJS_CSS" \
     -o "$MJS_OUT/$MJS_CSS" || exit 1
 curl -fS "$UNPKG/$MJS_V/$PKG" \
     -o "$NODE_MODULES/$MJS_PKG/$PKG" || exit 1
+
+# three
+THR_PKG="three"
+THR_V="$THR_PKG@0.125.2"
+THR_DIST="build"
+THR_JS="three.module.js"
+
+THR_IN="$THR_V/$THR_DIST"
+THR_OUT="$NODE_MODULES/$THR_PKG/$THR_DIST"
+curl -fS --create-dirs "$UNPKG/$THR_IN/$THR_JS" \
+    -o "$THR_OUT/$THR_JS" || exit 1
+curl -fS "$UNPKG/$THR_V/$PKG" \
+    -o "$NODE_MODULES/$THR_PKG/$PKG" || exit 1
+
+THR_EXM="examples/jsm"
+THR_EXM_JS="controls/OrbitControls.js"
+THR_EXM_IN="$THR_V/$THR_EXM"
+THR_EXM_OUT="$NODE_MODULES/$THR_PKG/$THR_EXM"
+curl -fS --create-dirs "$UNPKG/$THR_EXM_IN/$THR_EXM_JS" \
+    -o "$THR_EXM_OUT/$THR_EXM_JS" || exit 1

--- a/viewer/src/control/StatsControl.js
+++ b/viewer/src/control/StatsControl.js
@@ -1,0 +1,92 @@
+/**
+ * @format
+ */
+
+export class StatsControl {
+  constructor(options) {
+    const container = this._createContainer();
+    this._container = container;
+    this._provider = options.provider;
+    this._shotCount = 0;
+    this._pointCount = 0;
+    this._total = this._createText(
+      this._makeContent('Total', this._shotCount, this._pointCount),
+    );
+    this._container.appendChild(this._total);
+    this._visible = false;
+    if (options.visible) {
+      this.show();
+    }
+  }
+
+  get container() {
+    return this._container;
+  }
+
+  addRawData(rawData) {
+    for (const data of Object.values(rawData)) {
+      const id = data.id;
+      const url = data.url;
+      const cluster = data.cluster;
+      const shotCount = Object.keys(cluster.shots).length;
+      const pointCount = Object.keys(cluster.points).length;
+      const content = this._makeContent(id, shotCount, pointCount, url);
+      this.addStatRow(content);
+
+      this._shotCount += shotCount;
+      this._pointCount += pointCount;
+    }
+
+    this._total.textContent = this._makeContent(
+      'Total',
+      this._shotCount,
+      this._pointCount,
+    );
+  }
+
+  addStatRow(content) {
+    const stat = this._createText(content);
+    stat.classList.add('opensfm-info-text-stat');
+    this._container.appendChild(stat);
+  }
+
+  hide() {
+    if (!this._visible) {
+      return;
+    }
+    this._container.classList.add('opensfm-hidden');
+    this._visible = false;
+  }
+
+  show() {
+    if (this._visible) {
+      return;
+    }
+    this._container.classList.remove('opensfm-hidden');
+    this._visible = true;
+  }
+
+  _createContainer() {
+    const header = document.createElement('span');
+    header.classList.add('opensfm-info-text', 'opensfm-info-text-header');
+    header.textContent = 'Stats';
+
+    const container = document.createElement('div');
+    container.classList.add('opensfm-control-container', 'opensfm-hidden');
+    container.appendChild(header);
+    return container;
+  }
+
+  _createText(content) {
+    const document = window.document;
+    const element = document.createElement('span');
+    element.classList.add('opensfm-info-text');
+    element.textContent = content;
+    return element;
+  }
+
+  _makeContent(prefix, shotCount, pointCount, suffix) {
+    const append = suffix ? ` (${suffix})` : '';
+    return `${prefix}: ${shotCount} images, ${pointCount} points${append}`;
+  }
+}

--- a/viewer/src/controller/DatController.js
+++ b/viewer/src/controller/DatController.js
@@ -4,11 +4,11 @@
 
 import {GUI} from '../../node_modules/dat.gui/build/dat.gui.module.js';
 import {
-  CameraControls,
   CameraVisualizationMode,
   OriginalPositionMode,
 } from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {ListController} from './ListController.js';
+import {CameraControlMode} from '../ui/modes.js';
 
 export const FolderName = Object.freeze({
   INFO: 'info',
@@ -58,13 +58,13 @@ export class DatController {
       .onChange(v => this._onChange(name, v));
   }
 
-  _addCameraControlsOption(folder) {
-    const cc = CameraControls;
-    const ccs = [cc[cc.Earth], cc[cc.Street]];
+  _addCameraControlOption(folder) {
+    const ccm = CameraControlMode;
+    const ccms = [ccm.ORBIT, ccm.STREET, ccm.EARTH];
     folder
-      .add(this._config, 'cameraControls', ccs)
+      .add(this._config, 'cameraControlMode', ccms)
       .listen()
-      .onChange(c => this._onChange('cameraControls', cc[c]));
+      .onChange(m => this._onChange('cameraControlMode', m));
   }
 
   _addCameraVizualizationOption(folder) {
@@ -103,6 +103,7 @@ export class DatController {
     folder.open();
     this._addBooleanOption('commandsVisible', folder);
     this._addBooleanOption('thumbnailVisible', folder);
+    this._addBooleanOption('statsVisible', folder);
     this._addNumericOption('infoSize', folder);
     return folder;
   }
@@ -116,7 +117,7 @@ export class DatController {
   _createReconstructionsController(gui) {
     const emitter = this._emitter;
     const eventType = this._eventTypes.reconstructionsSelected;
-    const folder = gui.addFolder('Reconstructions');
+    const folder = gui.addFolder('Clusters');
     folder.open();
     const controller = new ListController({emitter, eventType, folder});
     return controller;
@@ -130,9 +131,10 @@ export class DatController {
     this._addCameraVizualizationOption(folder);
     this._addNumericOption('cameraSize', folder);
     this._addPositionVisualizationOption(folder);
-    this._addCameraControlsOption(folder);
-    this._addBooleanOption('tilesVisible', folder);
+    this._addCameraControlOption(folder);
+    this._addBooleanOption('cellsVisible', folder);
     this._addBooleanOption('imagesVisible', folder);
+    this._addBooleanOption('axesVisible', folder);
     return folder;
   }
 
@@ -142,17 +144,18 @@ export class DatController {
     let mode = null;
     let type = null;
     switch (name) {
-      case 'camerasVisible':
+      case 'axesVisible':
+      case 'cellsVisible':
       case 'commandsVisible':
       case 'imagesVisible':
       case 'pointsVisible':
+      case 'statsVisible':
       case 'thumbnailVisible':
-      case 'tilesVisible':
         const visible = value;
         type = types[name];
         emitter.fire(type, {type, visible});
         break;
-      case 'cameraControls':
+      case 'cameraControlMode':
       case 'originalPositionMode':
       case 'cameraVisualizationMode':
         mode = value;

--- a/viewer/src/controller/KeyController.js
+++ b/viewer/src/controller/KeyController.js
@@ -3,10 +3,10 @@
  */
 
 import {
-  CameraControls,
   CameraVisualizationMode,
   OriginalPositionMode,
 } from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+import {CameraControlMode} from '../ui/modes.js';
 
 export class KeyController {
   constructor(options) {
@@ -18,17 +18,19 @@ export class KeyController {
     const increase = 1.1;
     this._commands = {
       // visibility
+      c: {value: 'axesVisible'},
+      d: {value: 'cellsVisible'},
       e: {value: 'commandsVisible'},
-      f: {value: 'pointsVisible'},
-      d: {value: 'tilesVisible'},
       r: {value: 'imagesVisible'},
+      f: {value: 'pointsVisible'},
+      t: {value: 'statsVisible'},
       v: {value: 'thumbnailVisible'},
       // activity
       l: {value: 'datToggle'},
       // mode
       '1': {value: 'cameraVisualizationMode'},
       '2': {value: 'originalPositionMode'},
-      '3': {value: 'cameraControls'},
+      '3': {value: 'cameraControlMode'},
       // size
       q: {value: 'pointSize', coeff: decrease},
       w: {value: 'pointSize', coeff: increase},
@@ -79,6 +81,7 @@ export class KeyController {
         case 'e':
         case 'f':
         case 'r':
+        case 't':
         case 'v':
           const visible = this._toggle(command.value);
           emitter.fire(type, {type, visible});
@@ -96,8 +99,8 @@ export class KeyController {
           emitter.fire(type, {type, mode: opm});
           break;
         case '3':
-          const cc = this._rotateCc();
-          emitter.fire(type, {type, mode: cc});
+          const ccm = this._rotateCcm();
+          emitter.fire(type, {type, mode: ccm});
           break;
         case 'a':
         case 'q':
@@ -125,19 +128,21 @@ export class KeyController {
     return key in this._commands || key in this._customCommands;
   }
 
-  _rotateCc() {
-    const cc = CameraControls;
-    const earth = cc.Earth;
-    const street = cc.Street;
+  _rotateCcm() {
+    const ccm = CameraControlMode;
+    const orbit = ccm.ORBIT;
+    const earth = ccm.EARTH;
+    const street = ccm.STREET;
 
     const modeRotation = {};
+    modeRotation[orbit] = earth;
     modeRotation[earth] = street;
-    modeRotation[street] = earth;
+    modeRotation[street] = orbit;
 
     const config = this._config;
-    const mode = cc[config.cameraControls];
-    config.cameraControls = cc[modeRotation[mode]];
-    return cc[config.cameraControls];
+    const mode = config.cameraControlMode;
+    config.cameraControlMode = modeRotation[mode];
+    return config.cameraControlMode;
   }
 
   _rotateCvm() {

--- a/viewer/src/controller/OptionController.js
+++ b/viewer/src/controller/OptionController.js
@@ -3,28 +3,27 @@
  */
 
 import {
-  CameraControls,
   CameraVisualizationMode,
   OriginalPositionMode,
 } from '../../node_modules/mapillary-js/dist/mapillary.module.js';
 import {EventEmitter} from '../util/EventEmitter.js';
-import {DatController} from './DatController.js';
+import {DatController, FolderName} from './DatController.js';
 import {KeyController} from './KeyController.js';
 
 export class OptionController {
   constructor(options) {
-    const cc = CameraControls;
     const cvm = CameraVisualizationMode;
     const opm = OriginalPositionMode;
     const config = Object.assign({}, options, {
-      cameraControls: cc[options.cameraControls],
       cameraVisualizationMode: cvm[options.cameraVisualizationMode],
       originalPositionMode: opm[options.originalPositionMode],
     });
     const eventTypes = {
-      cameraControls: 'cameracontrols',
+      axesVisible: 'axesvisible',
+      cameraControlMode: 'cameracontrolmode',
       cameraSize: 'camerasize',
       cameraVisualizationMode: 'cameravisualizationmode',
+      cellsVisible: 'cellsvisible',
       commandsVisible: 'commandsvisible',
       datToggle: 'dattoggle',
       imagesVisible: 'imagesvisible',
@@ -34,7 +33,7 @@ export class OptionController {
       pointsVisible: 'pointsvisible',
       reconstructionsSelected: 'reconstructionsselected',
       thumbnailVisible: 'thumbnailvisible',
-      tilesVisible: 'tilesvisible',
+      statsVisible: 'statsvisible',
     };
     const emitter = new EventEmitter();
     const internalOptions = {config, emitter, eventTypes};
@@ -42,6 +41,7 @@ export class OptionController {
     this._keyController = new KeyController(internalOptions);
     this._emitter = emitter;
     this._config = config;
+    this._eventTypes = eventTypes;
   }
 
   get config() {

--- a/viewer/src/opensfm.js
+++ b/viewer/src/opensfm.js
@@ -22,6 +22,7 @@ export {OpensfmViewer} from './ui/OpensfmViewer.js';
 
 export {CancelledError} from './util/Error.js';
 export {EventEmitter} from './util/EventEmitter.js';
+export * from './util/coords.js';
 export * from './util/ids.js';
 export * from './util/params.js';
 export * from './util/types.js';

--- a/viewer/src/provider/DataConverter.js
+++ b/viewer/src/provider/DataConverter.js
@@ -13,6 +13,14 @@ export class DataConverter {
 
   cluster(cluster, clusterId, reference) {
     const points = cluster.points ?? {};
+    const normalize = 1 / 255;
+    for (const point of Object.values(points)) {
+      const color = point.color;
+      color[0] *= normalize;
+      color[1] *= normalize;
+      color[2] *= normalize;
+    }
+
     return {
       id: clusterId,
       points,
@@ -112,7 +120,7 @@ export class DataConverter {
     const cluster = {id: clusterId, url: clusterId};
     const computed_rotation = shot.rotation;
     const height = camera.height;
-    const merge_id = shot.merge_cc.toString();
+    const merge_id = shot.merge_cc == null ? null : shot.merge_cc.toString();
     const exif_orientation = shot.orientation;
     const quality_score = 1;
     const width = camera.width;

--- a/viewer/src/renderer/AxesRenderer.js
+++ b/viewer/src/renderer/AxesRenderer.js
@@ -1,0 +1,146 @@
+/**
+ * @format
+ */
+
+import {
+  AmbientLight,
+  ConeGeometry,
+  CylinderGeometry,
+  DirectionalLight,
+  Euler,
+  Matrix4,
+  Mesh,
+  MeshPhongMaterial,
+  Object3D,
+  Scene,
+  SphereGeometry,
+} from '../../node_modules/three/build/three.module.js';
+
+export class AxesRenderer {
+  constructor() {
+    this._scene = new Scene();
+    this._scene.add(this._createAxes());
+    this._scene.add(new AmbientLight(0xffffff, 0.5));
+    const lightNE = new DirectionalLight(0xffffff, 0.4);
+    lightNE.position.set(1, 1, 1);
+    const lightSW = new DirectionalLight(0xffffff, 0.1);
+    lightSW.position.set(-1, -1, 1);
+    this._scene.add(lightNE, lightSW);
+  }
+
+  get scene() {
+    return this._scene;
+  }
+
+  onAdd(viewer, camera, reference) {
+    /* noop */
+  }
+
+  onReference(reference) {
+    /* noop */
+  }
+
+  onRemove() {
+    /* noop */
+  }
+
+  _createAxes() {
+    const axisLength = 10;
+    const coneLength = axisLength / 5;
+    const coneRadius = axisLength / 15;
+    const options = {
+      coneLength,
+      coneRadius,
+      cylinderLength: axisLength - coneLength,
+      cylinderRadius: 3e-1 * coneRadius,
+    };
+
+    const east = this._createAxis(
+      Object.assign({}, options, {
+        color: 0xff0000,
+        euler: [0, 0, -Math.PI / 2],
+      }),
+    );
+    const north = this._createAxis(
+      Object.assign({}, options, {
+        color: 0x00ff00,
+        euler: [0, 0, 0],
+      }),
+    );
+    const up = this._createAxis(
+      Object.assign({}, options, {
+        color: 0x0088ff,
+        euler: [Math.PI / 2, 0, 0],
+      }),
+    );
+
+    const sphereSegments = 12;
+    const origin = new Mesh(
+      new SphereGeometry(
+        options.cylinderRadius,
+        sphereSegments,
+        sphereSegments,
+      ),
+      new MeshPhongMaterial({
+        color: 0xffffff,
+        flatShading: true,
+      }),
+    );
+
+    const axes = new Object3D();
+    axes.add(east, north, up, origin);
+
+    return axes;
+  }
+
+  _createAxis(options) {
+    const color = options.color;
+    const euler = options.euler;
+    const coneLength = options.coneLength;
+    const coneRadius = options.coneRadius;
+    const cylinderLength = options.cylinderLength;
+    const cylinderRadius = options.cylinderRadius;
+
+    const rotation = new Matrix4().multiply(
+      new Matrix4().makeRotationFromEuler(new Euler().fromArray(euler)),
+    );
+    const material = new MeshPhongMaterial({
+      color,
+      flatShading: true,
+    });
+
+    const cylinderSegments = 12;
+    const cylinder = new Mesh(
+      new CylinderGeometry(
+        cylinderRadius,
+        cylinderRadius,
+        cylinderLength,
+        cylinderSegments,
+      ),
+      material.clone(),
+    );
+    cylinder.applyMatrix4(
+      rotation
+        .clone()
+        .multiply(new Matrix4().makeTranslation(0, cylinderLength / 2, 0)),
+    );
+
+    const coneSegments = 12;
+    const cone = new Mesh(
+      new ConeGeometry(coneRadius, coneLength, coneSegments),
+      material.clone(),
+    );
+    cone.applyMatrix4(
+      rotation
+        .clone()
+        .multiply(
+          new Matrix4().makeTranslation(0, cylinderLength + coneLength / 2, 0),
+        ),
+    );
+
+    const axis = new Object3D();
+    axis.add(cylinder, cone);
+
+    return axis;
+  }
+}

--- a/viewer/src/renderer/CustomRenderer.js
+++ b/viewer/src/renderer/CustomRenderer.js
@@ -1,0 +1,93 @@
+/**
+ * @format
+ */
+
+import {
+  Camera,
+  WebGLRenderer,
+} from '../../node_modules/three/build/three.module.js';
+import {EventEmitter} from '../util/EventEmitter.js';
+
+export class CustomRenderer extends EventEmitter {
+  constructor(viewer) {
+    super();
+
+    this._id = 'opensfm-renderer';
+    this._camera = new Camera();
+    this._camera.matrixAutoUpdate = false;
+    this._viewer = viewer;
+    this._reference = null;
+
+    this._children = [];
+  }
+
+  get added() {
+    return !!this._reference;
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  get reference() {
+    return this._reference;
+  }
+
+  add(renderer) {
+    if (this._children.indexOf(renderer) >= 0) {
+      throw new Error(`Renderer already added`);
+    }
+    this._children.push(renderer);
+    if (this.added) {
+      renderer.onAdd(this._viewer, this._camera, this._reference);
+    }
+  }
+
+  remove(renderer) {
+    const index = this._children.indexOf(renderer);
+    if (index > -1) {
+      this._children.splice(index, 1);
+      renderer.onRemove();
+    }
+  }
+
+  onAdd(viewer, reference, context) {
+    this._reference = reference;
+    const canvas = viewer.getCanvas();
+    const renderer = new WebGLRenderer({canvas, context});
+    renderer.autoClear = false;
+    this._renderer = renderer;
+    for (const child of this._children) {
+      child.onAdd(this.viewer, this._camera, this._reference);
+    }
+    this.fire('add', {target: this});
+  }
+
+  onReferenceChanged(viewer, reference) {
+    this._reference = reference;
+    for (const child of this._children) {
+      child.onReference(this._reference);
+    }
+    this.fire('reference', {target: this});
+  }
+
+  onRemove(viewer, context) {
+    for (const child of this._children) {
+      child.onRemove();
+    }
+  }
+
+  render(context, viewMatrix, projectionMatrix) {
+    const camera = this._camera;
+    camera.matrix.fromArray(viewMatrix).invert();
+    camera.updateMatrixWorld(true);
+    camera.projectionMatrix.fromArray(projectionMatrix);
+    camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+
+    const renderer = this._renderer;
+    renderer.resetState();
+    for (const child of this._children) {
+      renderer.render(child.scene, camera);
+    }
+  }
+}

--- a/viewer/src/renderer/EarthRenderer.js
+++ b/viewer/src/renderer/EarthRenderer.js
@@ -1,0 +1,174 @@
+/**
+ * @format
+ */
+
+import {
+  BufferGeometry,
+  DoubleSide,
+  Float32BufferAttribute,
+  Mesh,
+  Raycaster,
+  Scene,
+  ShaderMaterial,
+  Vector2,
+  Vector3,
+} from '../../node_modules/three/build/three.module.js';
+import {pixelToViewport} from '../util/coords.js';
+
+const frag = `
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform float uLineWidth;
+uniform float uTileSize;
+uniform vec2 uMouse;
+uniform bool uMouseIntersecting;
+uniform float uRadius;
+
+varying vec4 vWorldCoords;
+
+void main()	{
+    vec4 fragColor = vec4(0.0, 0.0, 0.0, 0.0);
+
+    float mouseDist = distance(vWorldCoords.xy, uMouse);
+    bool showIndicator =
+        uMouseIntersecting &&
+        mouseDist < uRadius;
+
+    if (showIndicator) {
+        float discAlpha = (uRadius - mouseDist) / uRadius;
+        discAlpha = smoothstep(0.0, 1.0, discAlpha);
+
+        vec2 pos = vWorldCoords.xy / uTileSize;
+        vec2 f = abs(pos - floor(pos + vec2(0.5, 0.5)));
+        vec2 df = fwidth(pos) * uLineWidth;
+        vec2 g = smoothstep(-df, df, f);
+        float grid = 1.0 - clamp(g.x * g.y, 0.0, 1.0);
+        fragColor.rgb = mix(fragColor.rgb, vec3(1.0, 1.0, 1.0), grid);
+        fragColor.a = discAlpha;
+    }
+
+    gl_FragColor = fragColor;
+}
+`;
+
+const vert = `
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec4 vWorldCoords;
+
+void main() {
+    vWorldCoords = vec4(position, 1.0);
+    gl_Position = projectionMatrix * viewMatrix * vec4(position, 1.0);
+}
+`;
+
+const SIZE = 10000;
+
+export class EarthRenderer {
+  constructor() {
+    this._earth = this._makeEarth();
+    this._scene = new Scene();
+    this._scene.add(this._earth);
+
+    this._camera = null;
+    this._raycaster = new Raycaster();
+    this._origin = new Vector3();
+    this._direction = new Vector3();
+  }
+
+  get active() {
+    return !!this._camera;
+  }
+
+  get scene() {
+    return this._scene;
+  }
+
+  intersect(event) {
+    if (!this.active) {
+      throw new Error('Cannot intersect when inactive');
+    }
+
+    const camera = this._camera;
+    const raycaster = this._raycaster;
+    const origin = this._origin;
+    const direction = this._direction;
+    const uniforms = this._earth.material.uniforms;
+
+    const viewport = pixelToViewport(event.pixelPoint, this._container);
+    origin.setFromMatrixPosition(camera.matrixWorld);
+    direction
+      .set(viewport[0], viewport[1], 0.5)
+      .applyMatrix4(camera.projectionMatrixInverse)
+      .applyMatrix4(camera.matrixWorld)
+      .sub(origin)
+      .normalize();
+    raycaster.set(origin, direction);
+
+    const intersections = raycaster.intersectObject(this._earth);
+    if (intersections.length) {
+      const intersection = intersections[0];
+      uniforms.uMouseIntersecting.value = true;
+      uniforms.uMouse.value.x = intersection.point.x;
+      uniforms.uMouse.value.y = intersection.point.y;
+    } else {
+      uniforms.uMouseIntersecting.value = false;
+      uniforms.uMouse.value.x = 0;
+      uniforms.uMouse.value.y = 0;
+    }
+  }
+
+  onAdd(viewer, camera, reference) {
+    this._container = viewer.getContainer();
+    this._camera = camera;
+  }
+
+  onReference(reference) {
+    /* noop */
+  }
+
+  onRemove() {
+    this._camera = null;
+  }
+
+  _makeEarth() {
+    const size = SIZE;
+    const quad = [
+      size / 2,
+      size / 2,
+      -2,
+      size / 2,
+      -size / 2,
+      -2,
+      -size / 2,
+      -size / 2,
+      -2,
+      -size / 2,
+      size / 2,
+      -2,
+    ];
+    const indices = [0, 1, 2, 2, 3, 0];
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute(quad, 3));
+    geometry.setIndex(indices);
+    const uniforms = {
+      uLineWidth: {value: 2},
+      uMouse: {value: new Vector2()},
+      uMouseIntersecting: {value: false},
+      uRadius: {value: 10},
+      uTileSize: {value: 3},
+    };
+    const material = new ShaderMaterial({
+      fragmentShader: frag,
+      vertexShader: vert,
+      side: DoubleSide,
+      uniforms,
+      transparent: true,
+    });
+    return new Mesh(geometry, material);
+  }
+}

--- a/viewer/src/ui/FileLoader.js
+++ b/viewer/src/ui/FileLoader.js
@@ -38,7 +38,7 @@ export class FileLoader {
           data,
           name: file.name,
           type: null,
-          url: `local/${file.name}`,
+          url: `file:${file.name}`,
         })),
       );
     }

--- a/viewer/src/ui/OrbitCameraControls.js
+++ b/viewer/src/ui/OrbitCameraControls.js
@@ -1,0 +1,139 @@
+/**
+ * @format
+ */
+
+import {
+  Matrix4,
+  PerspectiveCamera,
+  Vector3,
+} from '../../node_modules/three/build/three.module.js';
+import {OrbitControls} from '../../node_modules/three/examples/jsm/controls/OrbitControls.js';
+
+const DAMPING_FACTOR = 0.1;
+const FOV = 90;
+const MAX_DISTANCE = 5000;
+const MIN_DISTANCE = 1;
+
+export class OrbitCameraControls {
+  constructor() {
+    this._controls = null;
+    this._reference = null;
+    this._projectionMatrixCallback = null;
+    this._viewMatrixCallback = null;
+    this._viewMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  }
+
+  onActivate(viewer, viewMatrix, projectionMatrix, reference) {
+    this._reference = reference;
+
+    const container = viewer.getContainer();
+    const aspect = this._calcAspect(container);
+    const camera = new PerspectiveCamera(FOV, aspect, 0.1, 10000);
+    camera.up.set(0, 0, 1);
+
+    const matrixWorld = new Matrix4().fromArray(viewMatrix).invert();
+    const me = matrixWorld.elements;
+    const eye = new Vector3(me[12], me[13], me[14]);
+    camera.position.copy(eye);
+
+    // Set target to 10 meters distance in front of eye on activation
+    const forward = new Vector3(-me[8], -me[9], -me[10]);
+    const target = eye.clone().add(forward.normalize().multiplyScalar(10));
+
+    const controls = new OrbitControls(camera, container);
+    this._controls = controls;
+    controls.minDistance = MIN_DISTANCE;
+    controls.maxDistance = MAX_DISTANCE;
+    controls.enableDamping = true;
+    controls.dampingFactor = DAMPING_FACTOR;
+    controls.target.copy(target);
+
+    camera.matrixWorld.copy(matrixWorld);
+    camera.matrixWorldInverse.fromArray(viewMatrix);
+    controls.object.updateMatrixWorld(true);
+
+    controls.addEventListener('change', this._onControlsChange);
+    controls.update();
+
+    this._updateProjectionMatrix();
+  }
+
+  onAnimationFrame(viewer, frameId) {
+    // Workaround until MJS is fixed to not invoke before onActivate
+    if (this._controls) {
+      this._controls.update();
+    }
+  }
+
+  onAttach(viewer, viewMatrixCallback, projectionMatrixCallback) {
+    this._viewMatrixCallback = viewMatrixCallback;
+    this._projectionMatrixCallback = projectionMatrixCallback;
+  }
+
+  onDeactivate(viewer) {
+    this._controls.removeEventListener('change', this._onControlsChange);
+    this._controls.dispose();
+    this._controls = null;
+  }
+
+  onDetach(viewer) {
+    this._projectionMatrixCallback = null;
+    this._viewMatrixCallback = null;
+  }
+
+  onReference(viewer, reference) {
+    const oldReference = this._reference;
+    const camera = this._controls.object;
+    const target = this._controls.target;
+    const targetOffset = target.clone().sub(camera.position);
+
+    const enu = camera.position;
+    const [lng, lat, alt] = enuToGeodetic(
+      enu.x,
+      enu.y,
+      enu.z,
+      oldReference.lng,
+      oldReference.lat,
+      oldReference.alt,
+    );
+    const [e, n, u] = geodeticToEnu(
+      lng,
+      lat,
+      alt,
+      reference.lng,
+      reference.lat,
+      reference.alt,
+    );
+
+    const position = new Vector3(e, n, u);
+    this._controls.object.position.copy(position);
+    this._controls.object.updateMatrixWorld(true);
+    this._controls.target.copy(position.clone().add(targetOffset));
+
+    this._reference = reference;
+  }
+
+  onResize(viewer) {
+    this._updateProjectionMatrix();
+  }
+
+  _calcAspect(element) {
+    const width = element.offsetWidth;
+    const height = element.offsetHeight;
+    return width === 0 || height === 0 ? 0 : width / height;
+  }
+
+  _onControlsChange = () => {
+    this._controls.object.updateMatrixWorld(true);
+    this._viewMatrixCallback(
+      this._controls.object.matrixWorldInverse.toArray(),
+    );
+  };
+
+  _updateProjectionMatrix() {
+    const camera = this._controls.object;
+    camera.aspect = this._calcAspect(this._controls.domElement);
+    camera.updateProjectionMatrix();
+    this._projectionMatrixCallback(camera.projectionMatrix.toArray());
+  }
+}

--- a/viewer/src/ui/modes.js
+++ b/viewer/src/ui/modes.js
@@ -1,0 +1,24 @@
+/**
+ * @format
+ */
+
+import {CameraControls} from '../../node_modules/mapillary-js/dist/mapillary.module.js';
+
+export const CameraControlMode = Object.freeze({
+  EARTH: 'earth',
+  ORBIT: 'orbit',
+  STREET: 'street',
+});
+
+export function convertCameraControlMode(mode) {
+  switch (mode) {
+    case CameraControlMode.EARTH:
+      return CameraControls.Earth;
+    case CameraControlMode.ORBIT:
+      return CameraControls.Custom;
+    case CameraControlMode.STREET:
+      return CameraControls.Street;
+    default:
+      throw new Error('Camera control mode does not exist');
+  }
+}

--- a/viewer/src/util/coords.js
+++ b/viewer/src/util/coords.js
@@ -1,0 +1,11 @@
+/**
+ * @format
+ */
+
+export function pixelToViewport(pixelPoint, container) {
+  const canvasWidth = container.offsetWidth;
+  const canvasHeight = container.offsetHeight;
+  const viewportX = (2 * pixelPoint[0]) / canvasWidth - 1;
+  const viewportY = 1 - (2 * pixelPoint[1]) / canvasHeight;
+  return [viewportX, viewportY];
+}

--- a/viewer/styles/opensfm.css
+++ b/viewer/styles/opensfm.css
@@ -238,6 +238,16 @@ input[type='file'] {
     margin: 2px;
 }
 
+.opensfm-info-text.opensfm-info-text-stat {
+    margin-bottom: 0;
+    margin-top: 0;
+    font-size: 9px;
+    overflow-wrap: initial;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
 .opensfm-info-text.opensfm-info-inline {
     display: inline-block;
 }


### PR DESCRIPTION
Summary:
## Contributions
- Upgrade viewer to MapillaryJS v4.0.0-beta.4
- Fix loading using reconstruction path
- Invent image buffer on client if server returns error (e.g. when no images exist for a dataset). This means the viewer will always work, even when images are missing. Errors will be logged to the browser.
- Increased cell grid depth for more fine grained load
- Do not hide bearing indicator in non street camera control mode
- Add ENU axes visualization
- Add three.js orbit controls as default camera control option using MJS custom camera control API
- Earth surface hover indicator for simplified earth navigation
- Add image and point count stats control
- Improved spatial viz perf in MJS. Logarithmic ray tracing/camera frame intersection. Improved linear rendering logic. Should work with ~10,000 camera frames without considerable lag.

Differential Revision: D28031955

