### PR TITLE
feat: add grid viz to opensfm viewer

### DIFF
--- a/viewer/node_modules.sh
+++ b/viewer/node_modules.sh
@@ -39,7 +39,7 @@ curl -fS "$UNPKG/$GLM_V/$PKG" \
 
 # mapillary-js
 MJS_PKG="mapillary-js"
-MJS_V="$MJS_PKG@4.0.0-beta.4"
+MJS_V="$MJS_PKG@4.0.0-beta.5"
 MJS_DIST="dist"
 MJS_JS="mapillary.module.js"
 MJS_CSS="mapillary.css"
@@ -55,7 +55,7 @@ curl -fS "$UNPKG/$MJS_V/$PKG" \
 
 # three
 THR_PKG="three"
-THR_V="$THR_PKG@0.125.2"
+THR_V="$THR_PKG@0.127.0"
 THR_DIST="build"
 THR_JS="three.module.js"
 

--- a/viewer/src/control/StatsControl.js
+++ b/viewer/src/control/StatsControl.js
@@ -26,7 +26,7 @@ export class StatsControl {
   addRawData(rawData) {
     for (const data of Object.values(rawData)) {
       const id = data.id;
-      const url = data.url;
+      const url = data.file.url;
       const cluster = data.cluster;
       const shotCount = Object.keys(cluster.shots).length;
       const pointCount = Object.keys(cluster.points).length;

--- a/viewer/src/control/ThumbnailControl.js
+++ b/viewer/src/control/ThumbnailControl.js
@@ -85,7 +85,7 @@ export class ThumbnailControl {
     const image = this._image;
     this._thumb.src = image.image.src;
     const clusterId = image.clusterId;
-    const clusterURL = this._provider.rawData[clusterId].url;
+    const clusterURL = this._provider.rawData[clusterId].file.url;
     const imageId = uniqueIDToImageID(image.id);
     this._setTextContent(this._clusterURL, clusterURL);
     this._setTextContent(this._clusterText, clusterId);

--- a/viewer/src/controller/DatController.js
+++ b/viewer/src/controller/DatController.js
@@ -135,6 +135,7 @@ export class DatController {
     this._addBooleanOption('cellsVisible', folder);
     this._addBooleanOption('imagesVisible', folder);
     this._addBooleanOption('axesVisible', folder);
+    this._addBooleanOption('gridVisible', folder);
     return folder;
   }
 
@@ -147,6 +148,7 @@ export class DatController {
       case 'axesVisible':
       case 'cellsVisible':
       case 'commandsVisible':
+      case 'gridVisible':
       case 'imagesVisible':
       case 'pointsVisible':
       case 'statsVisible':

--- a/viewer/src/controller/KeyController.js
+++ b/viewer/src/controller/KeyController.js
@@ -19,6 +19,7 @@ export class KeyController {
     this._commands = {
       // visibility
       c: {value: 'axesVisible'},
+      y: {value: 'gridVisible'},
       d: {value: 'cellsVisible'},
       e: {value: 'commandsVisible'},
       r: {value: 'imagesVisible'},
@@ -83,6 +84,7 @@ export class KeyController {
         case 'r':
         case 't':
         case 'v':
+        case 'y':
           const visible = this._toggle(command.value);
           emitter.fire(type, {type, visible});
           break;

--- a/viewer/src/controller/OptionController.js
+++ b/viewer/src/controller/OptionController.js
@@ -26,6 +26,7 @@ export class OptionController {
       cellsVisible: 'cellsvisible',
       commandsVisible: 'commandsvisible',
       datToggle: 'dattoggle',
+      gridVisible: 'gridvisible',
       imagesVisible: 'imagesvisible',
       infoSize: 'infosize',
       originalPositionMode: 'originalpositionmode',

--- a/viewer/src/opensfm.js
+++ b/viewer/src/opensfm.js
@@ -14,7 +14,13 @@ export {KeyController} from './controller/KeyController.js';
 export {ListController} from './controller/ListController.js';
 export {OptionController} from './controller/OptionController.js';
 
+export * as ProviderMath from './provider/math.js';
+export {DataConverter} from './provider/DataConverter.js';
 export {OpensfmDataProvider} from './provider/OpensfmDataProvider.js';
+
+export {AxesRenderer} from './renderer/AxesRenderer.js';
+export {CustomRenderer} from './renderer/CustomRenderer.js';
+export {EarthRenderer} from './renderer/EarthRenderer.js';
 
 export {FileLoader} from './ui/FileLoader.js';
 export {FileSelecter} from './ui/FileSelecter.js';

--- a/viewer/src/provider/OpensfmDataProvider.js
+++ b/viewer/src/provider/OpensfmDataProvider.js
@@ -178,7 +178,11 @@ export class OpensfmDataProvider extends DataProviderBase {
       rawData[clusterId] = {
         cluster,
         id: clusterId,
-        url: file.url,
+        file: {
+          url: file.url,
+          children: file.children,
+          name: file.name,
+        },
       };
       const reference = this._convert.reference(cluster.reference_lla);
       clusters[clusterId] = this._convert.cluster(

--- a/viewer/src/renderer/AxesRenderer.js
+++ b/viewer/src/renderer/AxesRenderer.js
@@ -89,6 +89,7 @@ export class AxesRenderer {
 
     const axes = new Object3D();
     axes.add(east, north, up, origin);
+    axes.position.z = -2;
 
     return axes;
   }

--- a/viewer/src/renderer/CustomRenderer.js
+++ b/viewer/src/renderer/CustomRenderer.js
@@ -58,7 +58,7 @@ export class CustomRenderer extends EventEmitter {
     renderer.autoClear = false;
     this._renderer = renderer;
     for (const child of this._children) {
-      child.onAdd(this.viewer, this._camera, this._reference);
+      child.onAdd(this._viewer, this._camera, this._reference);
     }
     this.fire('add', {target: this});
   }

--- a/viewer/src/ui/OpensfmViewer.js
+++ b/viewer/src/ui/OpensfmViewer.js
@@ -78,6 +78,7 @@ export class OpensfmViewer extends EventEmitter {
       axesVisible: true,
       cameraControlMode,
       commandsVisible,
+      gridVisible: true,
       imagesVisible,
       infoSize,
       statsVisible,
@@ -126,9 +127,12 @@ export class OpensfmViewer extends EventEmitter {
     this._makeCommands();
 
     this._axesRenderer = new AxesRenderer();
-    this._earthRenderer = new EarthRenderer();
+    this._earthRenderer = new EarthRenderer({
+      mode: cameraControlMode,
+    });
     this._customRenderer = new CustomRenderer(this._viewer);
     this._customRenderer.add(this._axesRenderer);
+    this._customRenderer.add(this._earthRenderer);
     this._viewer.addCustomRenderer(this._customRenderer);
   }
 
@@ -199,6 +203,7 @@ export class OpensfmViewer extends EventEmitter {
       this._onThumbnailVisible(event),
     );
     optionController.on('cellsvisible', event => this._onCellsVisible(event));
+    optionController.on('gridvisible', event => this._onGridVisible(event));
     optionController.on('reconstructionsselected', event =>
       this._onReconstructionsSelected(event),
     );
@@ -299,12 +304,7 @@ export class OpensfmViewer extends EventEmitter {
       this._viewer.deactivateComponent(zoom);
     }
 
-    if (mode === CameraControlMode.EARTH) {
-      this._customRenderer.add(this._earthRenderer);
-    } else if (this._earthRenderer.active) {
-      this._customRenderer.remove(this._earthRenderer);
-    }
-
+    this._earthRenderer.configure({mode});
     this._viewer.setCameraControls(convertCameraControlMode(mode));
   }
 
@@ -318,6 +318,15 @@ export class OpensfmViewer extends EventEmitter {
     } catch (error) {
       console.error(error);
     }
+  }
+
+  _onGridVisible(event) {
+    if (event.visible) {
+      this._customRenderer.add(this._earthRenderer);
+    } else {
+      this._customRenderer.remove(this._earthRenderer);
+    }
+    this._viewer.triggerRerender();
   }
 
   _onImagesVisible(event) {

--- a/viewer/src/ui/OrbitCameraControls.js
+++ b/viewer/src/ui/OrbitCameraControls.js
@@ -7,6 +7,7 @@ import {
   PerspectiveCamera,
   Vector3,
 } from '../../node_modules/three/build/three.module.js';
+import * as common from '../../node_modules/gl-matrix/esm/common.js';
 import {OrbitControls} from '../../node_modules/three/examples/jsm/controls/OrbitControls.js';
 
 const DAMPING_FACTOR = 0.1;
@@ -20,7 +21,6 @@ export class OrbitCameraControls {
     this._reference = null;
     this._projectionMatrixCallback = null;
     this._viewMatrixCallback = null;
-    this._viewMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
   }
 
   onActivate(viewer, viewMatrix, projectionMatrix, reference) {
@@ -31,25 +31,26 @@ export class OrbitCameraControls {
     const camera = new PerspectiveCamera(FOV, aspect, 0.1, 10000);
     camera.up.set(0, 0, 1);
 
-    const matrixWorld = new Matrix4().fromArray(viewMatrix).invert();
-    const me = matrixWorld.elements;
-    const eye = new Vector3(me[12], me[13], me[14]);
-    camera.position.copy(eye);
-
-    // Set target to 10 meters distance in front of eye on activation
-    const forward = new Vector3(-me[8], -me[9], -me[10]);
-    const target = eye.clone().add(forward.normalize().multiplyScalar(10));
-
     const controls = new OrbitControls(camera, container);
     this._controls = controls;
     controls.minDistance = MIN_DISTANCE;
     controls.maxDistance = MAX_DISTANCE;
     controls.enableDamping = true;
     controls.dampingFactor = DAMPING_FACTOR;
-    controls.target.copy(target);
 
-    camera.matrixWorld.copy(matrixWorld);
-    camera.matrixWorldInverse.fromArray(viewMatrix);
+    const viewMatrixInverse = new Matrix4().fromArray(viewMatrix).invert();
+    const me = viewMatrixInverse.elements;
+    const invent = this._shouldInventPose(me);
+
+    if (invent) {
+      controls.object.position.set(-50, -50, 40);
+      controls.target.set(0, 0, 0);
+    } else {
+      controls.object.position.set(me[12], me[13], me[14]);
+      controls.target.copy(this._makeTarget(viewMatrixInverse));
+      controls.object.matrixWorld.copy(viewMatrixInverse);
+      controls.object.matrixWorldInverse.fromArray(viewMatrix);
+    }
     controls.object.updateMatrixWorld(true);
 
     controls.addEventListener('change', this._onControlsChange);
@@ -135,5 +136,38 @@ export class OrbitCameraControls {
     camera.aspect = this._calcAspect(this._controls.domElement);
     camera.updateProjectionMatrix();
     this._projectionMatrixCallback(camera.projectionMatrix.toArray());
+  }
+
+  _shouldInventPose(viewMatrixInverse) {
+    const me = viewMatrixInverse;
+    const eye = [me[12], me[13], me[14]];
+    return (
+      common.equals(eye[0], 0) &&
+      common.equals(eye[0], 0) &&
+      common.equals(eye[0], 0)
+    );
+  }
+
+  _makeTarget(viewMatrixInverse) {
+    const me = viewMatrixInverse.elements;
+    const eye = new Vector3(me[12], me[13], me[14]);
+    const forward = new Vector3(-me[8], -me[9], -me[10]);
+    const xy = Math.sqrt(forward.x * forward.x + forward.y * forward.y);
+    const angle = Math.atan2(forward.z, xy);
+
+    if (angle > -Math.PI / 45) {
+      // Target a point 10 meters distance in front of eye
+      return eye.clone().add(forward.normalize().multiplyScalar(10));
+    } else {
+      // Target a point on invented ground
+      const l0 = eye.clone();
+      const n = new Vector3(0, 0, 1);
+      const p0 = new Vector3(0, 0, -2);
+      const d = new Vector3().subVectors(p0, l0).dot(n) / forward.dot(n);
+      const intersection = l0
+        .clone()
+        .add(forward.clone().multiplyScalar(Math.min(MAX_DISTANCE, d)));
+      return intersection;
+    }
   }
 }


### PR DESCRIPTION
Summary:
- Upgrade `mapillary-js` to v4.0.0-beta.5 (fixes image uncaching issue)
- Add ground grid viz in orbit mode
- Add option to activate/deactivate grid viz in all modes
- Set orbit target to invented ground plane if possible when changing camera mode

Differential Revision: D28177610

