### PR TITLE
Bug: fix memory deallocation error in load_reconstruction_shots

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -235,7 +235,10 @@ def load_reconstruction_shots(meta_data):
         reconstruction = data.load_reconstruction()
         for index, partial_reconstruction in enumerate(reconstruction):
             key = PartialReconstruction(submodel_path, index)
-            reconstruction_shots[key] = partial_reconstruction.shots
+            reconstruction_shots[key] = {}
+
+            for shot_id in partial_reconstruction.shots:
+                reconstruction_shots[key][shot_id] = partial_reconstruction.shots[shot_id]
 
     return reconstruction_shots
 


### PR DESCRIPTION
Hello :hand:

I've found a memory deallocation issue in the `load_reconstruction_shots` method. Strangely this seems to only show up on Windows.

The key issue is that the `ShotView` object (`partial_reconstruction.shots`) is assigned by reference to the `reconstruction_shots`  dictionary. When the `reconstruction` object gets deallocated (when exiting the for loop scope), the ShotView object remains in existance, but the shots referenced by it do not, causing a crash.

The fix involves manually making copies of each shot.

To reproduce the error, on Windows, executing the `align_submodels` command will fail (reference #735 for running split-merge on Windows).