### PR TITLE
Fix behaviour on PPC64EL

### DIFF
--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -68,7 +68,7 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
 
   const T eps = T(1e-30);
   const T det = A.determinant();
-  if (abs(det) < eps) {
+  if ((det < eps) && (det > -eps)) {
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;


### PR DESCRIPTION
After much combat we ([Dronehub](https://dronehub.ai) managed to get opensfm to work on ppc64el.

Double, while calculating abs(det) is promoted to int on ppc64el, so that the modified condition always held.

Since abs from cmath also returns wrong result, I've fixed it as follows.