### PR TITLE
Update fpdf to be compatible with required Pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle==0.4.0
 exifread==2.1.2
 flask==1.1.2
-fpdf2==2.1.0
+fpdf2==2.4.2
 joblib==0.14.1
 matplotlib
 networkx==1.11


### PR DESCRIPTION
The python requirements currently have invalid versions of fpdf and Pillow:

```
The conflict is caused by:
    The user requested Pillow>=8.1.1
    fpdf2 2.1.0 depends on Pillow<=8 and >=4
```

I've updated fpdf here and the library seems to build fine, but if there's a better fix I'm happy to change it!