### PR TITLE
Apple M1 changes

### DIFF
--- a/opensfm/src/foundation/src/numeric.cc
+++ b/opensfm/src/foundation/src/numeric.cc
@@ -30,7 +30,7 @@ static std::complex<double> ComplexCbrt(const std::complex<double>& z) {
 
 std::array<double, 4> SolveQuartic(const std::array<double, 5>& coefficients) {
   constexpr double eps = std::numeric_limits<double>::epsilon();
-  const double a = std::abs(coefficients[4]) > eps
+  const double a = std::abs<double>(coefficients[4]) > eps
                        ? coefficients[4]
                        : eps;  // Avoid division by zero
   const double b = coefficients[3] / a;

--- a/opensfm/src/geometry/test/covariance_test.cc
+++ b/opensfm/src/geometry/test/covariance_test.cc
@@ -118,7 +118,7 @@ TEST_F(CovarianceFixture, EvaluatesPointCovarianceOK) {
 
 TEST_F(CovarianceFixture, EvaluatesPointCovarianceSmallBaseline) {
   const double baseline = 1e-5;
-  const double angle = M_PI_2 - std::abs(std::atan2(point[2], baseline));
+  const double angle = M_PI_2 - std::abs<double>(std::atan2(point[2], baseline));
 
   geometry::Pose pose_rotated_y;
   pose_rotated_y.SetWorldToCamRotation(Vec3d(0, angle, 0));

--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -68,7 +68,7 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
 
   const T eps = T(1e-30);
   const T det = A.determinant();
-  if (abs(det) < eps) {
+  if (std::abs<T>(det) < eps) {
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;

--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -907,7 +907,7 @@ std::string BAHelpers::DetectAlignmentConstraints(
   const Mat3d input = X_zero.transpose() * X_zero;
   Eigen::SelfAdjointEigenSolver<MatXd> ses(input, Eigen::EigenvaluesOnly);
   const Vec3d evals = ses.eigenvalues();
-  const auto ratio_1st_2nd = std::abs(evals[2] / evals[1]);
+  const auto ratio_1st_2nd = std::abs<double>(evals[2] / evals[1]);
   constexpr double epsilon_abs = 1e-10;
   constexpr double epsilon_ratio = 5e3;
   int cond1 = 0;


### PR DESCRIPTION
Hey all :hand: 

While building and running OpenSfM on an Apple M1 I encountered a strange bug, which I narrowed down to to `geometry/triangulation.h:71`. Debugging a reconstruction showed that for some reason the compiler decided to assume std::abs should be of type `int` instead of type `T`, causing values to be truncated to `0` at every computation. 

I've explicitly passed the `<T>` template to that call and for good measure I've added the parameter type to other calls to `std::abs`. I don't think these are strictly required, but to be safe..
