### PR TITLE
Apple M1 changes

### DIFF
--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -68,7 +68,11 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
 
   const T eps = T(1e-30);
   const T det = A.determinant();
+  #ifdef __aarch64__
+  if (std::abs<T>(det) < eps) {
+  #else
   if (abs(det) < eps) {
+  #endif
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;


### PR DESCRIPTION
Hey all :hand: 

While building and running OpenSfM on an Apple M1 I encountered a strange bug, which I narrowed down to to `geometry/triangulation.h:71`. Debugging a reconstruction showed that for some reason the compiler decided to assume std::abs should be of type `int` instead of type `T`, causing values to be truncated to `0` at every computation. 