### PR TITLE
Disable SSE2 on aarch64

### DIFF
--- a/opensfm/src/third_party/vlfeat/CMakeLists.txt
+++ b/opensfm/src/third_party/vlfeat/CMakeLists.txt
@@ -1,4 +1,9 @@
 file(GLOB VLFEAT_SRCS vl/*.c vl/*.h)
+
+if( ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64" )
+    add_definitions( -DVL_DISABLE_SSE2 )
+endif()
+
 add_library(vl ${VLFEAT_SRCS})
 target_include_directories(vl
   PRIVATE


### PR DESCRIPTION
Closes #766 (which is also needed to compile on Apple M1 along with #788).