### PR TITLE
Windows Support (#735)

### DIFF
--- a/bin/opensfm.bat
+++ b/bin/opensfm.bat
@@ -1,0 +1,8 @@
+@echo off
+
+setlocal
+set OSFMBASE=%~dp0
+
+python "%OSFMBASE%\opensfm_main.py" %*
+
+endlocal

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -78,6 +78,25 @@ Also, in order for Cmake to recognize the libraries installed by Brew, make sure
     When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules are required for extracting SIFT or SURF features.
 
 
+Installing dependencies on Windows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Install vcpkg from the OpenSfM root directory::
+
+    cd OpenSfM
+    git clone https://github.com/microsoft/vcpkg
+    cd vcpkg
+    bootstrap-vcpkg.bat
+
+Then install OpenCV, Ceres, SuiteSparse and LAPACK (this will take a while)::
+
+    vcpkg install opencv4 ceres ceres[suitesparse] lapack suitesparse --triplet x64-windows
+
+Finally install the PIP requirements::
+
+    pip install -r requirements.txt
+
+
 Building the library
 --------------------
 

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -107,8 +107,10 @@ radial_distortion_k1_sd: 0.01   # The standard deviation of the first radial dis
 radial_distortion_k2_sd: 0.01   # The standard deviation of the second radial distortion parameter
 radial_distortion_k3_sd: 0.01   # The standard deviation of the third radial distortion parameter
 radial_distortion_k4_sd: 0.01   # The standard deviation of the fourth radial distortion parameter
-tangential_distortion_p1_sd: 0.01   # The standard deviation of the first tangential distortion parameter
-tangential_distortion_p2_sd: 0.01   # The standard deviation of the second tangential distortion parameter
+tangential_distortion_p1_sd: 0.01  # The standard deviation of the first tangential distortion parameter
+tangential_distortion_p2_sd: 0.01  # The standard deviation of the second tangential distortion parameter
+gcp_horizontal_sd: 0.01            # The default horizontal standard deviation of the GCPs (in meters)
+gcp_vertical_sd: 0.1               # The default vertical standard deviation of the GCPs (in meters)
 rig_translation_sd: 0.1            # The standard deviation of the rig translation
 rig_rotation_sd: 0.1               # The standard deviation of the rig rotation
 bundle_outlier_filtering_type: FIXED    # Type of threshold for filtering outlier : either fixed value (FIXED) or based on actual distribution (AUTO)

--- a/opensfm/context.py
+++ b/opensfm/context.py
@@ -1,7 +1,11 @@
 import logging
 import os
-import resource
+try:
+    import resource
+except ModuleNotFoundError:
+    pass # Windows
 import sys
+import ctypes
 from typing import Optional
 
 import cv2
@@ -56,23 +60,61 @@ def parallel_map(func, args, num_proc, max_batch_size=1):
 
 
 # Memory usage
-if sys.platform == "darwin":
-    rusage_unit = 1
+
+if sys.platform == 'win32':
+    class MEMORYSTATUSEX(ctypes.Structure):
+        _fields_ = [
+            ("dwLength", ctypes.c_ulong),
+            ("dwMemoryLoad", ctypes.c_ulong),
+            ("ullTotalPhys", ctypes.c_ulonglong),
+            ("ullAvailPhys", ctypes.c_ulonglong),
+            ("ullTotalPageFile", ctypes.c_ulonglong),
+            ("ullAvailPageFile", ctypes.c_ulonglong),
+            ("ullTotalVirtual", ctypes.c_ulonglong),
+            ("ullAvailVirtual", ctypes.c_ulonglong),
+            ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+        ]
+
+        def __init__(self):
+            # have to initialize this to the size of MEMORYSTATUSEX
+            self.dwLength = ctypes.sizeof(self)
+            super(MEMORYSTATUSEX, self).__init__()
+
+    def memory_available() -> Optional[int]:
+        """Available memory in MB.
+
+        Only works on Windows
+        """
+        stat = MEMORYSTATUSEX()
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+        return stat.ullAvailPhys / 1024 / 1024
+
+    def current_memory_usage():
+        stat = MEMORYSTATUSEX()
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+        return (stat.ullTotalPhys - stat.ullAvailPhys) / 1024
 else:
-    rusage_unit = 1024
+    if sys.platform == "darwin":
+        rusage_unit = 1
+    else:
+        rusage_unit = 1024
 
 
-def memory_available() -> Optional[int]:
-    """Available memory in MB.
+    def memory_available() -> Optional[int]:
+        """Available memory in MB.
 
-    Only works on linux and returns None otherwise.
-    """
-    with os.popen("free -t -m") as fp:
-        lines = fp.readlines()
-    if not lines:
-        return None
-    available_mem = int(lines[1].split()[6])
-    return available_mem
+        Only works on linux and returns None otherwise.
+        """
+        with os.popen("free -t -m") as fp:
+            lines = fp.readlines()
+        if not lines:
+            return None
+        available_mem = int(lines[1].split()[6])
+        return available_mem
+
+
+    def current_memory_usage():
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit
 
 
 def processes_that_fit_in_memory(desired: int, per_process: int) -> int:
@@ -83,7 +125,3 @@ def processes_that_fit_in_memory(desired: int, per_process: int) -> int:
         return min(desired, fittable)
     else:
         return desired
-
-
-def current_memory_usage():
-    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * rusage_unit

--- a/opensfm/large/metadataset.py
+++ b/opensfm/large/metadataset.py
@@ -1,6 +1,8 @@
 import os
 import os.path
 import shutil
+import sys
+import glob
 
 import numpy as np
 from opensfm import config
@@ -71,15 +73,34 @@ class MetaDataSet:
 
         if not os.path.exists(src):
             return
-
-        if os.path.islink(dst):
-            os.unlink(dst)
+        
+        # Symlinks on Windows require admin privileges,
+        # so we use hard links instead
+        if sys.platform == 'win32':
+            if os.path.isdir(dst):
+                shutil.rmtree(dst)
+            elif os.path.isfile(dst):
+                os.remove(dst)
+        else:
+            if os.path.islink(dst):
+                os.unlink(dst)
 
         subfolders = len(file_path.split(os.path.sep)) - 1
 
-        os.symlink(
-            os.path.join(*[".."] * subfolders, os.path.relpath(src, base_path)), dst
-        )
+        if sys.platform == 'win32':
+            if os.path.isdir(src):
+                # Create directory in destination, then make hard links
+                # to files
+                os.mkdir(dst)
+
+                for f in glob.glob(os.path.join(src, "*")):
+                    filename = os.path.basename(f)
+                    os.link(f, os.path.join(dst, filename))
+            else:
+                # Just make hard link
+                os.link(src, dst)
+        else:
+            os.symlink(os.path.join(*[".."] * subfolders, os.path.relpath(src, base_path)), dst)
 
     def image_groups_exists(self):
         return os.path.isfile(self._image_groups_path())
@@ -158,9 +179,11 @@ class MetaDataSet:
                 for image in cluster:
                     src = data.image_files[image]
                     dst = os.path.join(submodel_images_path, image)
-                    src_relpath = os.path.relpath(src, submodel_images_path)
                     if not os.path.isfile(dst):
-                        os.symlink(src_relpath, dst)
+                        if sys.platform == 'win32':
+                            os.link(src, dst)
+                        else:
+                            os.symlink(os.path.relpath(src, submodel_images_path), dst)
                     dst_relpath = os.path.relpath(dst, submodel_path)
                     txtfile.write(dst_relpath + "\n")
 

--- a/opensfm/pybundle.pyi
+++ b/opensfm/pybundle.pyi
@@ -168,7 +168,8 @@ class BundleAdjuster:
         arg0: str,
         arg1: numpy.ndarray,
         arg2: float,
-        arg3: PositionConstraintType,
+        arg3: float,
+        arg4: PositionConstraintType,
     ) -> None: ...
     def add_point_projection_observation(self, arg0: str, arg1: str, arg2: float, arg3: numpy.ndarray) -> None: ...
     def add_position_prior(

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -66,7 +66,7 @@ def _add_gcp_to_bundle(
         if point.coordinates.has_value:
             point_type = pybundle.XYZ if point.has_altitude else pybundle.XY
             ba.add_point_position_world(
-                point_id, point.coordinates.value, 0.1, point_type
+                point_id, point.coordinates.value, 0.1, 0.1, point_type
             )
 
         for observation in point.observations:

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -9,6 +9,12 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set(CMAKE_MODULE_PATH ${opensfm_SOURCE_DIR}/cmake)
 
+if (WIN32)
+# Place compilation results in opensfm/ folder, not in Debug/ or Release/
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${opensfm_SOURCE_DIR}/..")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${opensfm_SOURCE_DIR}/..")
+endif()
+
 ####### Compilation Options #######
 # Visibility stuff
 cmake_policy(SET CMP0063 NEW)
@@ -22,8 +28,19 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Enable all warnings
+if (NOT WIN32)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 # For compiling VLFeat
 add_definitions(-DVL_DISABLE_AVX)
+
+if (WIN32)
+    # Missing math constant
+    add_definitions(-DM_PI=3.14159265358979323846)
+endif()
 
 ####### Find Dependencies #######
 find_package(OpenMP)

--- a/opensfm/src/bundle/bundle_adjuster.h
+++ b/opensfm/src/bundle/bundle_adjuster.h
@@ -288,7 +288,8 @@ struct PointPositionShot {
 struct PointPositionWorld {
   std::string point_id;
   Vec3d position;
-  double std_deviation;
+  double std_deviation_horizontal;
+  double std_deviation_vertical;
   PositionConstraintType type;
 };
 
@@ -388,7 +389,8 @@ class BundleAdjuster {
                             const Vec3d &position, double std_deviation,
                             const PositionConstraintType &type);
   void AddPointPositionWorld(const std::string &point_id, const Vec3d &position,
-                             double std_deviation,
+                             double std_deviation_horizontal,
+                             double std_deviation_vertical,
                              const PositionConstraintType &type);
 
   // Minimization setup

--- a/opensfm/src/bundle/error/absolute_motion_errors.h
+++ b/opensfm/src/bundle/error/absolute_motion_errors.h
@@ -10,11 +10,14 @@ namespace bundle {
 template <class PosFunc>
 struct AbsolutePositionError {
   AbsolutePositionError(const PosFunc& pos_func, const Vec3d& pos_prior,
-                        double std_deviation, bool has_std_deviation_param,
+                        double std_deviation_horizontal,
+                        double std_deviation_vertical,
+                        bool has_std_deviation_param,
                         const PositionConstraintType& type)
       : pos_func_(pos_func),
         pos_prior_(pos_prior),
-        scale_(1.0 / std_deviation),
+        scale_xy_(1.0 / std_deviation_horizontal),
+        scale_z_(1.0 / std_deviation_vertical),
         has_std_deviation_param_(has_std_deviation_param),
         type_(type) {}
 
@@ -27,7 +30,9 @@ struct AbsolutePositionError {
     if (has_std_deviation_param_) {
       residual /= p[1][0];
     } else {
-      residual *= T(scale_);
+      residual[0] *= T(scale_xy_);
+      residual[1] *= T(scale_xy_);
+      residual[2] *= T(scale_z_);
     }
 
     // filter axises to use
@@ -48,7 +53,8 @@ struct AbsolutePositionError {
 
   PosFunc pos_func_;
   Vec3d pos_prior_;
-  double scale_;
+  double scale_xy_;
+  double scale_z_;
   bool has_std_deviation_param_;
   PositionConstraintType type_;
 };

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -431,12 +431,14 @@ void BundleAdjuster::AddPointPositionShot(const std::string &point_id,
 
 void BundleAdjuster::AddPointPositionWorld(const std::string &point_id,
                                            const Vec3d &position,
-                                           double std_deviation,
+                                           double std_deviation_horizontal,
+                                           double std_deviation_vertical,
                                            const PositionConstraintType &type) {
   PointPositionWorld a;
   a.point_id = point_id;
   a.position = position;
-  a.std_deviation = std_deviation;
+  a.std_deviation_horizontal = std_deviation_horizontal;
+  a.std_deviation_vertical = std_deviation_vertical;
   a.type = type;
   point_positions_world_.push_back(a);
 }
@@ -1018,7 +1020,7 @@ void BundleAdjuster::Run() {
     cost_function = new ceres::DynamicAutoDiffCostFunction<
         AbsolutePositionError<ShotPositionShotParam>>(
         new AbsolutePositionError<ShotPositionShotParam>(
-            pos_func, a.position, 1.0, true, PositionConstraintType::XYZ));
+            pos_func, a.position, 1.0, 1.0, true, PositionConstraintType::XYZ));
 
     // world parametrization
     // ShotPositionWorldParam pos_func(0);
@@ -1135,7 +1137,8 @@ void BundleAdjuster::Run() {
     auto *cost_function = new ceres::DynamicAutoDiffCostFunction<
         AbsolutePositionError<PointPositionScaledShot>>(
         new AbsolutePositionError<PointPositionScaledShot>(
-            pos_func, p.position, p.std_deviation, false, p.type));
+            pos_func, p.position, p.std_deviation, p.std_deviation, false,
+            p.type));
 
     cost_function->AddParameterBlock(6);
     cost_function->AddParameterBlock(1);
@@ -1155,7 +1158,8 @@ void BundleAdjuster::Run() {
     auto *cost_function = new ceres::DynamicAutoDiffCostFunction<
         AbsolutePositionError<PointPositionWorldFunc>>(
         new AbsolutePositionError<PointPositionWorldFunc>(
-            pos_func, p.position, p.std_deviation, false, p.type));
+            pos_func, p.position, p.std_deviation_horizontal,
+            p.std_deviation_vertical, false, p.type));
 
     cost_function->AddParameterBlock(3);
     cost_function->SetNumResiduals(3);

--- a/opensfm/src/dense/depthmap.h
+++ b/opensfm/src/dense/depthmap.h
@@ -107,6 +107,7 @@ class DepthmapEstimator {
   std::mt19937 rng_;
   std::uniform_int_distribution<int> uni_;
   std::normal_distribution<float> unit_normal_;
+  std::vector<float> patch_variance_buffer_;
 };
 
 class DepthmapCleaner {

--- a/opensfm/src/dense/src/depthmap.cc
+++ b/opensfm/src/dense/src/depthmap.cc
@@ -138,7 +138,8 @@ DepthmapEstimator::DepthmapEstimator()
       min_patch_variance_(5 * 5),
       rng_{std::random_device{}()},
       uni_(0, 0),
-      unit_normal_(0, 1) {}
+      unit_normal_(0, 1),
+      patch_variance_buffer_(patch_size_ * patch_size_) {}
 
 void DepthmapEstimator::AddView(const double *pK, const double *pR,
                                 const double *pt, const unsigned char *pimage,
@@ -169,7 +170,10 @@ void DepthmapEstimator::SetPatchMatchIterations(int n) {
   patchmatch_iterations_ = n;
 }
 
-void DepthmapEstimator::SetPatchSize(int size) { patch_size_ = size; }
+void DepthmapEstimator::SetPatchSize(int size) {
+  patch_size_ = size;
+  patch_variance_buffer_.resize(patch_size_ * patch_size_);
+}
 
 void DepthmapEstimator::SetMinPatchSD(float sd) {
   min_patch_variance_ = sd * sd;
@@ -263,7 +267,7 @@ void DepthmapEstimator::ComputeIgnoreMask(DepthmapEstimatorResult *result) {
 }
 
 float DepthmapEstimator::PatchVariance(int i, int j) {
-  float patch[patch_size_ * patch_size_];
+  float *patch = patch_variance_buffer_.data();
   int hpz = (patch_size_ - 1) / 2;
   int counter = 0;
   for (int u = -hpz; u <= hpz; ++u) {

--- a/opensfm/src/sfm/ba_helpers.h
+++ b/opensfm/src/sfm/ba_helpers.h
@@ -56,7 +56,8 @@ class BAHelpers {
   static void AddGCPToBundle(
       bundle::BundleAdjuster& ba,
       const AlignedVector<map::GroundControlPoint>& gcp,
-      const std::unordered_map<map::ShotId, map::Shot>& shots);
+      const std::unordered_map<map::ShotId, map::Shot>& shots,
+      const double& horizontal_sigma, const double& vertical_sigma);
   static bool TriangulateGCP(
       const map::GroundControlPoint& point,
       const std::unordered_map<map::ShotId, map::Shot>& shots,

--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -275,7 +275,9 @@ py::tuple BAHelpers::BundleLocal(
   }
 
   if (config["bundle_use_gcp"].cast<bool>() && !gcp.empty()) {
-    AddGCPToBundle(ba, gcp, map.GetShots());
+    AddGCPToBundle(ba, gcp, map.GetShots(),
+                   config["gcp_horizontal_sd"].cast<double>(),
+                   config["gcp_vertical_sd"].cast<double>());
   }
 
   ba.SetPointProjectionLossFunction(
@@ -385,7 +387,8 @@ bool BAHelpers::TriangulateGCP(
 void BAHelpers::AddGCPToBundle(
     bundle::BundleAdjuster& ba,
     const AlignedVector<map::GroundControlPoint>& gcp,
-    const std::unordered_map<map::ShotId, map::Shot>& shots) {
+    const std::unordered_map<map::ShotId, map::Shot>& shots,
+    const double& horizontal_sigma, const double& vertical_sigma) {
   for (const auto& point : gcp) {
     const auto point_id = "gcp-" + point.id_;
     Vec3d coordinates;
@@ -402,8 +405,8 @@ void BAHelpers::AddGCPToBundle(
       const auto point_type = point.has_altitude_
                                   ? bundle::PositionConstraintType::XYZ
                                   : bundle::PositionConstraintType::XY;
-      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(), 0.1,
-                               point_type);
+      ba.AddPointPositionWorld(point_id, point.coordinates_.Value(),
+                               horizontal_sigma, vertical_sigma, point_type);
     }
 
     // Now iterate through the observations
@@ -752,7 +755,9 @@ py::dict BAHelpers::Bundle(
   }
 
   if (config["bundle_use_gcp"].cast<bool>() && !gcp.empty()) {
-    AddGCPToBundle(ba, gcp, map.GetShots());
+    AddGCPToBundle(ba, gcp, map.GetShots(),
+                   config["gcp_horizontal_sd"].cast<double>(),
+                   config["gcp_vertical_sd"].cast<double>());
   }
 
   if (config["bundle_compensate_gps_bias"].cast<bool>()) {

--- a/opensfm/src/third_party/vlfeat/CMakeLists.txt
+++ b/opensfm/src/third_party/vlfeat/CMakeLists.txt
@@ -4,6 +4,10 @@ if( ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64" )
     add_definitions( -DVL_DISABLE_SSE2 )
 endif()
 
+if(WIN32)
+    add_definitions(-D__SSE2__)
+endif()
+
 add_library(vl ${VLFEAT_SRCS})
 target_include_directories(vl
   PRIVATE

--- a/opensfm/src/third_party/vlfeat/vl/host.h
+++ b/opensfm/src/third_party/vlfeat/vl/host.h
@@ -312,7 +312,9 @@ defined(__DOXYGEN__)
 #if defined(VL_COMPILER_MSC) & ! defined(__DOXYGEN__)
 #  define VL_UNUSED
 #  define VL_INLINE static __inline
+#if _MSC_VER < 1900
 #  define snprintf _snprintf
+#endif
 #  define isnan _isnan
 #  ifdef VL_BUILD_DLL
 #    ifdef __cplusplus
@@ -322,9 +324,9 @@ defined(__DOXYGEN__)
 #    endif
 #  else
 #    ifdef __cplusplus
-#      define VL_EXPORT extern "C" __declspec(dllimport)
+#      define VL_EXPORT extern "C"
 #    else
-#      define VL_EXPORT extern __declspec(dllimport)
+#      define VL_EXPORT extern
 #    endif
 #  endif
 #endif

--- a/opensfm/synthetic_data/synthetic_metrics.py
+++ b/opensfm/synthetic_data/synthetic_metrics.py
@@ -1,9 +1,9 @@
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 
 import cv2
 import numpy as np
 import opensfm.transformations as tf
-from opensfm import align, types
+from opensfm import align, types, pymap, multiview
 
 
 def points_errors(
@@ -37,6 +37,22 @@ def gps_errors(candidate: types.Reconstruction) -> np.ndarray:
         pose1 = bias.transform(shot.metadata.gps_position.value)
         pose2 = shot.pose.get_origin()
         errors.append(pose1 - pose2)
+    return np.array(errors)
+
+
+def gcp_errors(
+    candidate: types.Reconstruction, gcps: Dict[str, pymap.GroundControlPoint]
+) -> np.ndarray:
+    errors = []
+    for gcp in gcps.values():
+        if not gcp.coordinates.has_value:
+            continue
+
+        triangulated = multiview.triangulate_gcp(gcp, candidate.shots, 1.0, 0.1)
+        if triangulated is None:
+            continue
+
+        errors.append(triangulated - gcp.coordinates.value)
     return np.array(errors)
 
 

--- a/opensfm/test/conftest.py
+++ b/opensfm/test/conftest.py
@@ -32,6 +32,7 @@ def scene_synthetic() -> synthetic_scene.SyntheticInputData:
     maximum_depth = 40
     projection_noise = 1.0
     gps_noise = 5.0
+    gcp_noise = (0.01, 0.1)
 
     gcps_count = 10
     gcps_shift = [10.0, 0.0, 100.0]
@@ -43,6 +44,7 @@ def scene_synthetic() -> synthetic_scene.SyntheticInputData:
         maximum_depth,
         projection_noise,
         gps_noise,
+        gcp_noise,
         False,
         gcps_count,
         gcps_shift,
@@ -57,7 +59,7 @@ def scene_synthetic_cube():
     reference = geo.TopocentricConverter(47.0, 6.0, 0)
     reconstruction = data.get_reconstruction()
     input_data = synthetic_scene.SyntheticInputData(
-        reconstruction, reference, 40, 0.0, 0.0, False
+        reconstruction, reference, 40, 0.0, 0.0, (0.0, 0.0), False
     )
     return reconstruction, input_data.tracks_manager
 
@@ -70,6 +72,7 @@ def scene_synthetic_rig() -> synthetic_scene.SyntheticInputData:
     maximum_depth = 40
     projection_noise = 1.0
     gps_noise = 0.1
+    gcp_noise = (0.0, 0.0)
 
     reference = geo.TopocentricConverter(47.0, 6.0, 0)
     return synthetic_scene.SyntheticInputData(
@@ -78,6 +81,7 @@ def scene_synthetic_rig() -> synthetic_scene.SyntheticInputData:
         maximum_depth,
         projection_noise,
         gps_noise,
+        gcp_noise,
         False,
     )
 
@@ -90,7 +94,7 @@ def pairs_and_poses():
     reconstruction = data.get_reconstruction()
     reference = geo.TopocentricConverter(0, 0, 0)
     input_data = synthetic_scene.SyntheticInputData(
-        reconstruction, reference, 40, 0.0, 0.0, False
+        reconstruction, reference, 40, 0.0, 0.0, (0.0, 0.0), False
     )
     features, tracks_manager = input_data.features, input_data.tracks_manager
 

--- a/opensfm/test/test_bundle.py
+++ b/opensfm/test/test_bundle.py
@@ -156,7 +156,7 @@ def test_pair_with_shot_point(bundle_adjuster):
     )
     sa.add_point_position_shot("p1", "1", "12", [1, 0, 0], 1, pybundle.XYZ)
     sa.add_point_position_shot("p1", "2", "12", [-1, 0, 0], 1, pybundle.XYZ)
-    sa.add_point_position_world("p1", [1, 0, 0], 1, pybundle.XYZ)
+    sa.add_point_position_world("p1", [1, 0, 0], 1, 1, pybundle.XYZ)
 
     sa.run()
     s1 = sa.get_shot("1")

--- a/opensfm/test/test_reconstruction_incremental.py
+++ b/opensfm/test/test_reconstruction_incremental.py
@@ -19,7 +19,11 @@ def test_reconstruction_incremental(
     _, reconstructed_scene = reconstruction.incremental_reconstruction(
         dataset, scene_synthetic.tracks_manager
     )
-    errors = synthetic_scene.compare(reference, reconstructed_scene[0])
+    errors = synthetic_scene.compare(
+        reference,
+        scene_synthetic.gcps,
+        reconstructed_scene[0],
+    )
 
     assert reconstructed_scene[0].reference.lat == 47.0
     assert reconstructed_scene[0].reference.lon == 6.0
@@ -33,6 +37,10 @@ def test_reconstruction_incremental(
 
     # Sanity check that GPS error is similar to the generated gps_noise
     assert 4.0 < errors["absolute_gps_rmse"] < 7.0
+
+    # Sanity check that GCP error is similar to the generated gcp_noise
+    assert 0.01 < errors["absolute_gcp_rmse_horizontal"] < 0.02
+    assert 0.08 < errors["absolute_gcp_rmse_vertical"] < 0.12
 
     # Check that the GPS bias (only translation) is recovered
     translation = reconstructed_scene[0].biases["1"].translation
@@ -55,7 +63,7 @@ def test_reconstruction_incremental_rig(
     _, reconstructed_scene = reconstruction.incremental_reconstruction(
         dataset, scene_synthetic_rig.tracks_manager
     )
-    errors = synthetic_scene.compare(reference, reconstructed_scene[0])
+    errors = synthetic_scene.compare(reference, {}, reconstructed_scene[0])
 
     assert reconstructed_scene[0].reference.lat == 47.0
     assert reconstructed_scene[0].reference.lon == 6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ Sphinx==3.4.3
 six
 xmltodict==0.10.2
 wheel
+opencv-python==4.5.1.48 ; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import multiprocessing
 
 import setuptools
 from sphinx.setup_command import BuildDoc
@@ -34,13 +35,21 @@ def configure_c_extension():
         "../opensfm/src",
         "-DPYTHON_EXECUTABLE=" + sys.executable,
     ]
+    if sys.platform == 'win32':
+        cmake_command += [
+            '-DVCPKG_TARGET_TRIPLET=x64-windows',
+            '-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake'
+        ]
     subprocess.check_call(cmake_command, cwd="cmake_build")
 
 
 def build_c_extension():
     """Compile C extension."""
     print("Compiling extension...")
-    subprocess.check_call(["make", "-j4"], cwd="cmake_build")
+    if sys.platform == 'win32':
+        subprocess.check_call(['cmake', '--build', '.', '--config', 'Release'], cwd='cmake_build')
+    else:
+        subprocess.check_call(['make', '-j' + str(multiprocessing.cpu_count())], cwd='cmake_build')
 
 
 configure_c_extension()


### PR DESCRIPTION
Summary:
Hello :hand:

This PR gets OpenSfM to compile and run on Windows!

The main points that have been addressed:
 - [x] Rewrote the memory functions in `context.py` to work on all three platforms (Windows, Mac, Linux). This adds a new small dependency (`vmem`).
 - [x] Added a `bin/opensfm.bat` script for invoking the program.
 - [x] Some minor compilation issues related to Visual Studio are addressed. The definition of `M_PI` is a bit.. hackish, but the alternative is to include:

```
#define _USE_MATH_DEFINES
#include <cmath>
```

In a lot of places where M_PI is referenced. I'm not sure that's better (but I can change it if you want). I'm also unsure of what side effects the `_USE_MATH_DEFINES` macro might do. :bomb:

 - [x] Updated the docs with build instructions for Windows.
 - [x] Installs `opencv-python` as a pip dependency on Windows only; this is because vcpkg builds of OpenCV don't provide a version with OpenCV's Python bindings. This only affects Windows environments (it won't install on Mac or Linux).

I hope this can be useful to others.

Pull Request resolved: https://github.com/mapillary/OpenSfM/pull/735

Differential Revision: D29959025

Pulled By: YanNoun

