### PR TITLE
Fix Windows memory deallocation problem in load_reconstruction_shots

### DIFF
--- a/opensfm/large/tools.py
+++ b/opensfm/large/tools.py
@@ -7,6 +7,8 @@ import cv2
 import networkx as nx
 import numpy as np
 import scipy.spatial as spatial
+import copy
+import sys
 from networkx.algorithms import bipartite
 from opensfm import align
 from opensfm import context
@@ -235,7 +237,15 @@ def load_reconstruction_shots(meta_data):
         reconstruction = data.load_reconstruction()
         for index, partial_reconstruction in enumerate(reconstruction):
             key = PartialReconstruction(submodel_path, index)
-            reconstruction_shots[key] = partial_reconstruction.shots
+
+            # Fix: https://github.com/mapillary/OpenSfM/pull/750
+            if sys.platform == 'win32':
+                reconstruction_shots[key] = {}
+                for shot_id in partial_reconstruction.shots:
+                    reconstruction_shots[key][shot_id] = copy.deepcopy(partial_reconstruction.shots[shot_id])
+                    reconstruction_shots[key][shot_id].metadata = partial_reconstruction.shots[shot_id].metadata
+            else:
+                reconstruction_shots[key] = partial_reconstruction.shots
 
     return reconstruction_shots
 


### PR DESCRIPTION
For some reason on Windows the ShotView returned by partial_reconstruction.shots contains references to invalid shot objects. I documented this on https://github.com/mapillary/OpenSfM/pull/750 and thought it was resolved in the latest version, but this doesn't seem to be the case.﻿

This PR adds the logic to make explicit copies of the shot objects (on Windows only) to allow the `align_submodels` command to work properly.
