### PR TITLE
Add Fisheye624Camera

### DIFF
--- a/opensfm/src/geometry/camera.h
+++ b/opensfm/src/geometry/camera.h
@@ -22,6 +22,10 @@ class Camera {
     AspectRatio,
     Cx,
     Cy,
+    S0,
+    S1,
+    S2,
+    S3,
     None
   };
 
@@ -45,6 +49,9 @@ class Camera {
   static Camera CreateFisheye62Camera(double focal, double aspect_ratio,
                                       const Vec2d& principal_point,
                                       const VecXd& distortion);
+  static Camera CreateFisheye624Camera(double focal, double aspect_ratio,
+                                       const Vec2d& principal_point,
+                                       const VecXd& distortion);
   static Camera CreateDualCamera(double transition, double focal, double k1,
                                  double k2);
   static Camera CreateSphericalCamera();

--- a/opensfm/src/geometry/camera_instances.h
+++ b/opensfm/src/geometry/camera_instances.h
@@ -11,6 +11,7 @@ enum class ProjectionType {
   FISHEYE,
   FISHEYE_OPENCV,
   FISHEYE62,
+  FISHEYE624,
   SPHERICAL,
   DUAL,
   RADIAL,
@@ -178,6 +179,7 @@ using FisheyeCamera = ProjectGeneric<FisheyeProjection, Disto24, UniformScale>;
 using FisheyeOpencvCamera =
     ProjectGeneric<FisheyeProjection, Disto2468, Affine>;
 using Fisheye62Camera = ProjectGeneric<FisheyeProjection, Disto62, Affine>;
+using Fisheye624Camera = ProjectGeneric<FisheyeProjection, Disto624, Affine>;
 using DualCamera = ProjectGeneric<DualProjection, Disto24, UniformScale>;
 using SphericalCamera = ProjectGeneric<SphericalProjection, Identity, Identity>;
 
@@ -201,6 +203,9 @@ void Dispatch(const ProjectionType& type, IN&&... args) {
       break;
     case ProjectionType::FISHEYE62:
       FUNC::template Apply<Fisheye62Camera>(std::forward<IN>(args)...);
+      break;
+    case ProjectionType::FISHEYE624:
+      FUNC::template Apply<Fisheye624Camera>(std::forward<IN>(args)...);
       break;
     case ProjectionType::RADIAL:
       FUNC::template Apply<RadialCamera>(std::forward<IN>(args)...);

--- a/opensfm/src/geometry/src/camera.cc
+++ b/opensfm/src/geometry/src/camera.cc
@@ -93,6 +93,36 @@ Camera Camera::CreateFisheye62Camera(double focal, double aspect_ratio,
   return camera;
 }
 
+/**
+  Create a Fisheye624 camera with 15 parameters:
+  - params: f, cx, cy, (radial) k1, k2, k3, k4, k5, k6 (tangential) p1, p2 (thin prism) s0, s1, s2, s3
+  Note that in arvr, the parameters start at 0 and p1/p2 are reversed
+  See: https://fburl.com/diffusion/xnhraa2z
+*/
+Camera Camera::CreateFisheye624Camera(double focal, double aspect_ratio,
+                                      const Vec2d& principal_point,
+                                      const VecXd& distortion) {
+  if (distortion.size() != 12) {
+    throw std::runtime_error("Invalid distortion coefficients size");
+  }
+  Camera camera;
+  camera.type_ = ProjectionType::FISHEYE624;
+  camera.types_ = {Camera::Parameters::K1,    Camera::Parameters::K2,
+                   Camera::Parameters::K3,    Camera::Parameters::K4,
+                   Camera::Parameters::K5,    Camera::Parameters::K6,
+                   Camera::Parameters::P1,    Camera::Parameters::P2,
+                   Camera::Parameters::S0,    Camera::Parameters::S1,
+                   Camera::Parameters::S2,    Camera::Parameters::S3,
+                   Camera::Parameters::Focal, Camera::Parameters::AspectRatio,
+                   Camera::Parameters::Cx,    Camera::Parameters::Cy};
+  camera.values_.resize(16);
+  camera.values_ << distortion[0], distortion[1], distortion[2], distortion[3],
+      distortion[4], distortion[5], distortion[6], distortion[7],
+      distortion[8], distortion[9], distortion[10], distortion[11],
+      focal, aspect_ratio, principal_point[0], principal_point[1];
+  return camera;
+}
+
 Camera Camera::CreateDualCamera(double transition, double focal, double k1,
                                 double k2) {
   Camera camera;
@@ -197,6 +227,8 @@ std::string Camera::GetProjectionString(const ProjectionType& type) {
       return "fisheye_opencv";
     case ProjectionType::FISHEYE62:
       return "fisheye62";
+    case ProjectionType::FISHEYE624:
+      return "fisheye624";
     case ProjectionType::DUAL:
       return "dual";
     case ProjectionType::SPHERICAL:

--- a/opensfm/src/geometry/test/camera_functions_test.cc
+++ b/opensfm/src/geometry/test/camera_functions_test.cc
@@ -243,6 +243,9 @@ class CameraDerivativesFixture : public ::testing::Test {
     distortion_fisheye62.resize(8);
     distortion_fisheye62 << -0.1, 0.03, 0.001, 0.005, 0.02, 0.001, 0.0007,
         -0.01;
+    distortion_fisheye624.resize(12);
+    distortion_fisheye624 << -0.1, 0.03, 0.001, 0.005, 0.02, 0.001, 0.0007,
+        -0.01, 0.01, -0.007, -0.03, 0.0053;
     distortion_radial << 0.1, 0.03;
     principal_point << 0.1, -0.05;
 
@@ -282,7 +285,9 @@ class CameraDerivativesFixture : public ::testing::Test {
     for (int i = 0; i < 2; ++i) {
       for (int j = 0; j < size_params; ++j) {
         ASSERT_NEAR(projection_expected[i].derivatives()(j), jacobian(i, j),
-                    eps);
+                    eps)
+          << "where (i, j) = (" << testing::PrintToString(i)
+          << ", " << testing::PrintToString(j) << ')';
       }
       ASSERT_NEAR(projection_expected[i].value(), projected[i], eps);
     }
@@ -295,6 +300,7 @@ class CameraDerivativesFixture : public ::testing::Test {
   VecXd distortion_brown;
   VecXd distortion_fisheye;
   VecXd distortion_fisheye62;
+  VecXd distortion_fisheye624;
   Vec2d distortion_radial;
   Vec2d principal_point;
 
@@ -352,6 +358,18 @@ TEST_F(CameraDerivativesFixture, ComputeFisheye62AnalyticalDerivatives) {
 
   Eigen::Matrix<double, 2, 15, Eigen::RowMajor> jacobian;
   RunJacobianEval(camera, geometry::ProjectionType::FISHEYE62, &jacobian);
+  CheckJacobian(jacobian, size_params);
+}
+
+TEST_F(CameraDerivativesFixture, ComputeFisheye624AnalyticalDerivatives) {
+  const geometry::Camera camera = geometry::Camera::CreateFisheye624Camera(
+      focal, 1.0, principal_point, distortion_fisheye624);
+
+  const VecXd camera_params = camera.GetParametersValues();
+  const int size_params = 3 + camera_params.size();
+
+  Eigen::Matrix<double, 2, 19, Eigen::RowMajor> jacobian;
+  RunJacobianEval(camera, geometry::ProjectionType::FISHEYE624, &jacobian);
   CheckJacobian(jacobian, size_params);
 }
 

--- a/opensfm/src/geometry/test/camera_test.cc
+++ b/opensfm/src/geometry/test/camera_test.cc
@@ -27,6 +27,9 @@ class CameraFixture : public ::testing::Test {
     distortion_fisheye62.resize(8);
     distortion_fisheye62 << -0.1, 0.03, 0.001, 0.005, 0.02, 0.001, 0.0007,
         -0.01;
+    distortion_fisheye624.resize(12);
+    distortion_fisheye624 << -0.1, 0.03, 0.001, 0.005, 0.02, 0.001, 0.0007,
+        -0.01, 0.01, -0.007, -0.03, 0.0053;
     distortion_radial << 0.1, 0.03;
     principal_point << 0.1, -0.05;
   }
@@ -54,6 +57,7 @@ class CameraFixture : public ::testing::Test {
   VecXd distortion_brown;
   VecXd distortion_fisheye;
   VecXd distortion_fisheye62;
+  VecXd distortion_fisheye624;
   Vec2d distortion_radial;
   Vec2d principal_point;
 
@@ -100,6 +104,13 @@ TEST_F(CameraFixture, FisheyeOpencvIsConsistent) {
 TEST_F(CameraFixture, Fisheye62IsConsistent) {
   geometry::Camera camera = geometry::Camera::CreateFisheye62Camera(
       focal, 1.0, principal_point, distortion_fisheye62);
+  const auto projected = camera.ProjectMany(camera.BearingsMany(pixels));
+  ASSERT_LT(ComputeError(projected), 2e-7);
+}
+
+TEST_F(CameraFixture, Fisheye624IsConsistent) {
+  geometry::Camera camera = geometry::Camera::CreateFisheye624Camera(
+      focal, 1.0, principal_point, distortion_fisheye624);
   const auto projected = camera.ProjectMany(camera.BearingsMany(pixels));
   ASSERT_LT(ComputeError(projected), 2e-7);
 }
@@ -181,6 +192,23 @@ TEST_F(CameraFixture, Fisheye62ReturnCorrectTypes) {
        geometry::Camera::Parameters::K3, geometry::Camera::Parameters::K4,
        geometry::Camera::Parameters::K5, geometry::Camera::Parameters::K6,
        geometry::Camera::Parameters::P1, geometry::Camera::Parameters::P2,
+       geometry::Camera::Parameters::Focal,
+       geometry::Camera::Parameters::AspectRatio,
+       geometry::Camera::Parameters::Cx, geometry::Camera::Parameters::Cy});
+  ASSERT_THAT(expected, ::testing::ContainerEq(types));
+}
+
+TEST_F(CameraFixture, Fisheye624ReturnCorrectTypes) {
+  geometry::Camera camera = geometry::Camera::CreateFisheye624Camera(
+      focal, 1.0, principal_point, distortion_fisheye624);
+  const auto types = camera.GetParametersTypes();
+  const auto expected = std::vector<geometry::Camera::Parameters>(
+      {geometry::Camera::Parameters::K1, geometry::Camera::Parameters::K2,
+       geometry::Camera::Parameters::K3, geometry::Camera::Parameters::K4,
+       geometry::Camera::Parameters::K5, geometry::Camera::Parameters::K6,
+       geometry::Camera::Parameters::P1, geometry::Camera::Parameters::P2,
+       geometry::Camera::Parameters::S0, geometry::Camera::Parameters::S1,
+       geometry::Camera::Parameters::S2, geometry::Camera::Parameters::S3,
        geometry::Camera::Parameters::Focal,
        geometry::Camera::Parameters::AspectRatio,
        geometry::Camera::Parameters::Cx, geometry::Camera::Parameters::Cy});
@@ -272,6 +300,16 @@ TEST_F(CameraFixture, Fisheye62ReturnCorrectValues) {
 
   VecXd expected(12);
   expected << distortion_fisheye62, focal, 1.0, principal_point;
+  ASSERT_EQ(expected, values);
+}
+
+TEST_F(CameraFixture, Fisheye624ReturnCorrectValues) {
+  geometry::Camera camera = geometry::Camera::CreateFisheye624Camera(
+      focal, 1.0, principal_point, distortion_fisheye624);
+  const auto values = camera.GetParametersValues();
+
+  VecXd expected(16);
+  expected << distortion_fisheye624, focal, 1.0, principal_point;
   ASSERT_EQ(expected, values);
 }
 
@@ -411,6 +449,22 @@ TEST_F(CameraFixture, FisheyeOpencvAsFisheye62) {
   ASSERT_TRUE(proj1.isApprox(proj2, 1e-6));
 }
 
+TEST_F(CameraFixture, FisheyeOpencvAsFisheye624) {
+  Eigen::Matrix<double, 12, 1> dist_624;
+  dist_624 << distortion_fisheye[0], distortion_fisheye[1],
+      distortion_fisheye[2], distortion_fisheye[3], 0, 0, 0, 0, 0, 0, 0, 0;
+  geometry::Camera cam624 = geometry::Camera::CreateFisheye624Camera(
+      focal, 1.0, principal_point, dist_624);
+  geometry::Camera camcv = geometry::Camera::CreateFisheyeOpencvCamera(
+      focal, 1.0, principal_point, distortion_fisheye);
+  const MatX3d bear1 = cam624.BearingsMany(pixels);
+  const MatX3d bear2 = camcv.BearingsMany(pixels);
+  ASSERT_TRUE(bear1.isApprox(bear2, 1e-6));
+  const auto proj1 = cam624.ProjectMany(bear1);
+  const auto proj2 = camcv.ProjectMany(bear2);
+  ASSERT_TRUE(proj1.isApprox(proj2, 1e-6));
+}
+
 TEST_F(CameraFixture, SimpleRadialAsRadial) {
   const double k1 = distortion_radial[0];
   geometry::Camera cam_simple = geometry::Camera::CreateSimpleRadialCamera(
@@ -470,6 +524,9 @@ TEST(Camera, TestCameraProjectionTypes) {
   ASSERT_EQ(geometry::Camera::GetProjectionString(
                 geometry::ProjectionType::FISHEYE62),
             "fisheye62");
+  ASSERT_EQ(geometry::Camera::GetProjectionString(
+                geometry::ProjectionType::FISHEYE624),
+            "fisheye624");
   ASSERT_EQ(geometry::Camera::GetProjectionString(
                 geometry::ProjectionType::SPHERICAL),
             "spherical");


### PR DESCRIPTION
Summary: Combine the existing Fisheye62Camera model with an additional thin prism distortion

Differential Revision: D32279669

