### PR TITLE
Fix wrong filename in docs

### DIFF
--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -27,7 +27,7 @@ OpenSfM depends on the following libraries that need to be installed before buil
 
 Python dependencies can be installed with::
 
-    pip install -r requirements
+    pip install -r requirements.txt
 
 
 Installing dependencies on Ubuntu


### PR DESCRIPTION
Installation with the specified command fails:
```
pip install -r requirements
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements'
```
