### PR TITLE
fixed fallback method for image size

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -1245,7 +1245,7 @@ def image_size_from_fileobject(fb):
             return height, width
     except Exception:
         # Slower fallback
-        image = imread(fb)
+        image = imread(fb.name)
         return image.shape[:2]
 
 


### PR DESCRIPTION
Hello all. While using OpenDroneMap/ODM I noticed a presumable bug in OpenSfM. Correct me if I am wrong here!
The following issue has appeared. ODM has called the export_visualsfm command. OpenSfM has tried to open tif images via the method image_size_from_fileobject. Since Pillow doesn't support tif images the slower fallback method via imread is used. The problem is that image_size_from_fileobject gets a file object which is passed one to one in imread. imread expects a path! Therefore my PR to pass the path of the opened file.

To understand the ODM problem more: https://community.opendronemap.org/t/odm-stops-processing-with-cannot-identify-image-file/9739