### PR TITLE
fix: build missing OpenMP include through the use of foundation lib's…

### DIFF
--- a/opensfm/src/map/CMakeLists.txt
+++ b/opensfm/src/map/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(map
   PRIVATE
     geo
     geometry
+    foundation
 )
 
 target_include_directories(map
@@ -38,6 +39,7 @@ target_link_libraries(pymap
   PRIVATE
     map
     geometry
+    foundation
     bundle
     pybind11
 )


### PR DESCRIPTION
This PR fixes the MacOS build missing OpenMP include through the use of foundation lib's dependancies