### PR TITLE
fix map() in python3

### DIFF
--- a/bin/export_gps
+++ b/bin/export_gps
@@ -28,7 +28,7 @@ rows = []
 for reconstruction in reconstructions:
     for shot in reconstruction.shots.values():
         lla = rc.shot_lla_and_compass(shot, reference)
-        rows.append([shot.id, ] + map(str, lla))
+        rows.append([shot.id, ] + list(map(str, lla)))
 rows.sort()
 rows.insert(0, ['image', 'latitude', 'longitude', 'altitude', 'compass_angle'])
 tsv = '\n'.join(['\t'.join(row) for row in rows])


### PR DESCRIPTION
In python3, map() function returns a map object which acts like an iterator, not a list. So, in order to append a map to a list, first we should convert that map into a list, then append the new list. Or else, append() will raise an error.