### PR TITLE
Add required opencv requirement for linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ six
 xmltodict==0.10.2
 wheel
 opencv-python==4.5.1.48 ; sys_platform == "win32"
+opencv-python ; sys_platform == "linux"


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'cv2'` when following the [Building](https://opensfm.readthedocs.io/en/latest/building.html) instructions on Ubuntu 20.04 with virtualenv or similar.