### PR TITLE
Add DJI XT2 (Thermal) and DJI ZH20T to sensor_data.json

### DIFF
--- a/opensfm/data/sensor_data.json
+++ b/opensfm/data/sensor_data.json
@@ -3703,5 +3703,7 @@
     "SONY ILCE-5100": 23.5,
     "SONY ILCE-7S": 35.8,
     "SONY SLT-A77V": 23.5,
-    "GITUP GIT2": 6.216
+    "GITUP GIT2": 6.216,
+    "DJI ZH20T": 7.68,
+    "DJI XT2": 10.88
 }


### PR DESCRIPTION
Added sensor information for **DJI Zenmuse XT2 (thermal)** sensor -> https://www.dji.com/es/zenmuse-xt2/specs and **DJI Zenmuse H20T** sensor -> https://www.dji.com/es/zenmuse-h20-series/specs