### PR TITLE
Add variant for Olympus SP-720UZ

### DIFF
--- a/opensfm/data/sensor_data.json
+++ b/opensfm/data/sensor_data.json
@@ -2106,6 +2106,7 @@
     "Olympus SP-610UZ": 6.16,
     "Olympus SP-620 UZ": 6.16,
     "Olympus SP-720UZ": 6.16,
+    "OLYMPUS IMAGING CORP. SP-720UZ": 6.16,
     "Olympus SZ-10": 6.16,
     "Olympus SZ-11": 6.16,
     "Olympus SZ-12": 6.16,


### PR DESCRIPTION
Hello,

I have a Olympus SP-720UZ camera, and I found that its EXIF tags uses as `Make` value `OLYMPUS IMAGING CORP.` (see below for a full EXIF dump). So to ensure that this camera is recognized, I added a new entry with same value as `Olympus SP-720UZ` but changing the make.

Best regards.


```
ExifToolVersion: 12.42
FileName: P4250059.JPG
Directory: /home/adrien/Stockage/Documents/OpenStreetMap/Photos/Montfort
FileSize: 3.0 MB
FileModifyDate: 2015:04:25 15:36:12+02:00
FileAccessDate: 2021:03:11 01:13:49+01:00
FileInodeChangeDate: 2019:01:04 12:01:32+01:00
FilePermissions: -rw-r--r--
FileType: JPEG
FileTypeExtension: jpg
MIMEType: image/jpeg
ExifByteOrder: Little-endian (Intel, II)
ImageDescription: OLYMPUS DIGITAL CAMERA
Make: OLYMPUS IMAGING CORP.
Model: SP-720UZ
Orientation: Horizontal (normal)
XResolution: 72
YResolution: 72
ResolutionUnit: inches
Software: Version 1.0
ModifyDate: 2015:04:25 15:36:11
YCbCrPositioning: Co-sited
ExposureTime: 1/250
FNumber: 7.5
ExposureProgram: Creative (Slow speed)
ISO: 100
SensitivityType: Standard Output Sensitivity
ExifVersion: 0230
DateTimeOriginal: 2015:04:25 15:36:11
CreateDate: 2015:04:25 15:36:11
ComponentsConfiguration: Y, Cb, Cr, -
ExposureCompensation: 0
MaxApertureValue: 3.2
MeteringMode: Multi-segment
LightSource: Unknown
Flash: Off, Did not fire
FocalLength: 4.7 mm
SpecialMode: Normal, Sequence: 0, Panorama: (none)
CameraID: OLYMPUS DIGITAL CAMERA
EquipmentVersion: 0100
CameraType2: SP-720UZ
FocalPlaneDiagonal: 7.74 mm
BodyFirmwareVersion: 1.004
CameraSettingsVersion: 0100
PreviewImageValid: Yes
PreviewImageStart: 2845380
PreviewImageLength: 150880
MacroMode: Off
FlashMode: Off
WhiteBalance2: Auto
WhiteBalanceBracket: 0 0
SceneMode: Landscape
MagicFilter: Off; 0; 0; 0
DriveMode: Single Shot
PanoramaMode: Off
ImageProcessingVersion: 0112
DistortionCorrection2: On
FacesDetected: 0 0 0
FaceDetectArea: (Binary data 191 bytes, use -b option to extract)
MaxFaces: 8 8 8
FaceDetectFrameSize: 0 0 0 0 0 0
Warning: [minor] MakerNotes tag 0x6000 IFD format not handled
UserComment: 
FlashpixVersion: 0100
ColorSpace: sRGB
ExifImageWidth: 4288
ExifImageHeight: 3216
InteropIndex: R98 - DCF basic file (sRGB)
InteropVersion: 0100
FileSource: Digital Camera
CustomRendered: Normal
ExposureMode: Auto
WhiteBalance: Auto
DigitalZoomRatio: 0
FocalLengthIn35mmFormat: 26 mm
SceneCaptureType: Landscape
GainControl: None
Contrast: Normal
Saturation: Normal
Sharpness: Normal
PrintIMVersion: 0300
Compression: JPEG (old-style)
ThumbnailOffset: 4096
ThumbnailLength: 11535
ImageWidth: 4288
ImageHeight: 3216
EncodingProcess: Baseline DCT, Huffman coding
BitsPerSample: 8
ColorComponents: 3
YCbCrSubSampling: YCbCr4:2:2 (2 1)
Aperture: 7.5
ImageSize: 4288x3216
Megapixels: 13.8
PreviewImage: (Binary data 150880 bytes, use -b option to extract)
ScaleFactor35efl: 5.6
ShutterSpeed: 1/250
ThumbnailImage: (Binary data 11535 bytes, use -b option to extract)
CircleOfConfusion: 0.005 mm
FOV: 69.4 deg
FocalLength35efl: 4.7 mm (35 mm equivalent: 26.0 mm)
HyperfocalDistance: 0.54 m
LightValue: 13.8
```