### PR TITLE
fixed ply generation to support official ply headers

### DIFF
--- a/opensfm/io.py
+++ b/opensfm/io.py
@@ -1033,9 +1033,9 @@ def ply_header(
             "property float nx",
             "property float ny",
             "property float nz",
-            "property uchar diffuse_red",
-            "property uchar diffuse_green",
-            "property uchar diffuse_blue",
+            "property uchar red",      
+            "property uchar green",     
+            "property uchar blue",      
         ]
     else:
         header = [
@@ -1045,9 +1045,9 @@ def ply_header(
             "property float x",
             "property float y",
             "property float z",
-            "property uchar diffuse_red",
-            "property uchar diffuse_green",
-            "property uchar diffuse_blue",
+            "property uchar red",    
+            "property uchar green",   
+            "property uchar blue", 
         ]
 
     if point_num_views:
@@ -1146,9 +1146,9 @@ def point_cloud_to_ply(
     fp.write("property float nx\n")
     fp.write("property float ny\n")
     fp.write("property float nz\n")
-    fp.write("property uchar diffuse_red\n")
-    fp.write("property uchar diffuse_green\n")
-    fp.write("property uchar diffuse_blue\n")
+    fp.write("property uchar red\n")
+    fp.write("property uchar green\n")
+    fp.write("property uchar blue\n")
     fp.write("property uchar class\n")
     fp.write("end_header\n")
 


### PR DESCRIPTION
This PR is in regards to the issue #741.

As open3D does not currently support user-defined headers, the following command fails to load colors from the ply file because OpenSfM generates ply file with `diffuse_` prefix to the color headers.
```
import open3d as o3d
pcd = o3d.io.read_point_cloud('merged.ply')
print(pcd.colors)

>>pcd.colors => std::vector<Eigen::Vector3d> with 0 elements.
```

To support [official ply headers](http://paulbourke.net/dataformats/ply/), `point_cloud_to_ply` and `ply_header` functions have been modified in the `OpenSfM/opensfm/io.py`.
```
def point_cloud_to_ply(
    points: np.ndarray,
    normals: np.ndarray,
    colors: np.ndarray,
    labels: np.ndarray,
    fp: TextIO,
) -> None:
    ...
    fp.write("property uchar red\n")       # Changed from diffuse_red
    fp.write("property uchar green\n")     # Changed from diffuse_green
    fp.write("property uchar blue\n")      # Changed from diffuse_blue
    fp.write("property uchar class\n")
    fp.write("end_header\n")
    ...
```