### PR TITLE
Update numpy to 1.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fpdf2==2.4.6
 joblib==0.14.1
 matplotlib
 networkx==2.5
-numpy
+numpy==1.19.0
 Pillow>=8.1.1
 pyproj>=1.9.5.1
 pytest==3.0.7


### PR DESCRIPTION
The default numpy version is too low and running the example in the documentation fails on Matplotlib because it requires 1.19.0 or higher.