### PR TITLE
FLANN LSH Indexing for binary descriptors

### DIFF
--- a/opensfm/features.py
+++ b/opensfm/features.py
@@ -630,6 +630,7 @@ def build_flann_index(descriptors: np.ndarray, config: Dict[str, Any]) -> Any:
     # FLANN_INDEX_COMPOSITE = 3
     # FLANN_INDEX_KDTREE_SINGLE = 4
     # FLANN_INDEX_HIERARCHICAL = 5
+    FLANN_INDEX_LSH = 6
 
     if descriptors.dtype.type is np.float32:
         algorithm_type = config["flann_algorithm"].upper()
@@ -645,9 +646,12 @@ def build_flann_index(descriptors: np.ndarray, config: Dict[str, Any]) -> Any:
             "iterations": config["flann_iterations"],
             "tree": config["flann_tree"],
         }
-    else:
-        raise ValueError(
-            "FLANN isn't supported for binary features because of poor-performance. Use BRUTEFORCE instead."
-        )
+    elif descriptors.dtype.type is np.uint8:
+        flann_params = {
+            "algorithm": FLANN_INDEX_LSH,
+            "table_number": 10,
+            "key_size": 24,
+            "multi_probe_level": 1,
+        }
 
     return context.flann_Index(descriptors, flann_params)

--- a/opensfm/matching.py
+++ b/opensfm/matching.py
@@ -369,14 +369,6 @@ def _match_descriptors_impl(
     if d1 is None or d2 is None:
         return dummy_ret
 
-    # Prevent using FLANN + Binary (np.uint8)
-    binary_matcher_override = "BRUTEFORCE"
-    if matcher_type == "FLANN" and d1.dtype == np.uint8:
-        logger.warning(
-            f"{matcher_type} for binary descriptors offers poor performance. Switching to {binary_matcher_override}."
-        )
-        matcher_type = binary_matcher_override
-
     symmetric_matching = overriden_config["symmetric_matching"]
     if matcher_type == "WORDS":
         words1 = feature_loader.instance.load_words(data, im1, masked=True)


### PR DESCRIPTION
Hello :wave:,

this PR adds support for using the FLANN index while using binary descriptors (e.g. `orb`).

