### PR TITLE
added lru caching for faster undistortion

### DIFF
--- a/opensfm/src/robust/CMakeLists.txt
+++ b/opensfm/src/robust/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ROBUST_FILES
     src/relative_pose_model.cc
     src/line_model.cc
     src/instanciations.cc
+    src/similarity_model.cc
 )
 add_library(robust ${ROBUST_FILES})
 target_link_libraries(robust

--- a/opensfm/src/robust/src/similarity_model.cc
+++ b/opensfm/src/robust/src/similarity_model.cc
@@ -1,0 +1,4 @@
+#include "robust/similarity_model.h"
+
+
+const int Similarity::MINIMAL_SAMPLES;


### PR DESCRIPTION
In undistortion, computing camera mapping is the most expensive part, but it's only related to the camera model and image size, hence for each camera model and size, it only needs to be calculated once, and all the undistortion can use the same camera mapping. 

This PR introduces a simple thread/process safe LRU cache wrapper to cache the camera mapping results so future undistortion can reuse it. This should greatly speed up the undistortion stage. 

(The cmakelists.txt and similarity_model.cc changes are used to a bug when building c extensions in debug mode, \*\*undefined symbol\*\*)