### PR TITLE
returning norm_coords instead of px_coords in pixelToNormalizedCoordi…

### DIFF
--- a/opensfm/src/geometry/src/camera.cc
+++ b/opensfm/src/geometry/src/camera.cc
@@ -366,7 +366,7 @@ MatX2d Camera::PixelToNormalizedCoordinatesMany(const MatX2d& px_coords,
     norm_coords.row(i) =
         PixelToNormalizedCoordinates(px_coords.row(i), width, height);
   }
-  return px_coords;
+  return norm_coords;
 }
 
 Vec2d Camera::NormalizedToPixelCoordinates(const Vec2d& norm_coord) const {


### PR DESCRIPTION
…natesMany

Attempting to fix issue create here: [https://github.com/mapillary/OpenSfM/issues/1030#issue-2046628484](https://github.com/mapillary/OpenSfM/issues/1030#issue-2046628484)