### PR TITLE
Remove dublicated SIFT-Dectector instance in feature matching

### DIFF
--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -42,6 +42,12 @@ class OpenSfMConfig:
     sift_peak_threshold: float = 0.1
     # See OpenCV doc
     sift_edge_threshold: int = 10
+    # See OpenCV doc
+    sift_nfeatures: int = 0
+    # See OpenCV doc
+    sift_octave_layers: int = 3
+    # See OpenCV doc
+    sift_sigma: float = 1.6
 
     ##################################
     # Params for SURF


### PR DESCRIPTION
It seems to me that the SIFT detector is instantiated, but then not used, because the object is created again in the following while loop. This merge request removes the unnecessary code.
I have also made the missing parameters of the OpenCV-Sift implementation configurable.