### PR TITLE
Introduce the use of anaconda for dependencies

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -1,0 +1,28 @@
+name: opensfm
+dependencies:
+    - python=3.8
+    - cmake
+    - opencv
+    - ceres-solver=2.1
+    - conda-forge::llvm-openmp
+    - pip
+    - pip:
+        - cloudpickle==0.4.0
+        - exifread==2.1.2
+        - flask==2.3.2
+        - fpdf2==2.4.6
+        - joblib==0.14.1
+        - matplotlib
+        - networkx==2.5
+        - numpy>=1.19
+        - Pillow>=8.1.1
+        - pyproj>=1.9.5.1
+        - pytest==3.0.7
+        - python-dateutil>=2.7
+        - pyyaml>5.4
+        - scipy>=1.10.0
+        - Sphinx==4.2.0
+        - six
+        - xmltodict==0.10.2
+        - wheel
+        - sphinx_rtd_theme

--- a/conda.yml
+++ b/conda.yml
@@ -1,10 +1,13 @@
 name: opensfm
 dependencies:
     - python=3.8
-    - cmake
+    - cmake=3.31
+    - make
+    - libxcrypt
     - opencv
     - ceres-solver=2.1
     - conda-forge::llvm-openmp
+    - conda-forge::cxx-compiler
     - pip
     - pip:
         - cloudpickle==0.4.0

--- a/conda.yml
+++ b/conda.yml
@@ -20,7 +20,7 @@ dependencies:
         - numpy>=1.19
         - Pillow>=8.1.1
         - pyproj>=1.9.5.1
-        - pytest==3.0.7
+        - pytest==6.2.0
         - python-dateutil>=2.7
         - pyyaml>5.4
         - scipy>=1.10.0

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -43,17 +43,20 @@ See this `Dockerfile <https://github.com/mapillary/OpenSfM/blob/main/Dockerfile>
 Installing dependencies on Fedora
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tested on Fedora 33 & 34
+Install conda using dnf with::
 
-    sudo dnf install zlib-devel libjpeg-devel python3-devel g++ ceres-solver-devel opencv-devel python3-opencv eigen3-devel libomp cmake glog-devel
+    sudo dnf install conda
+    conda init
 
-There's an `issue <https://github.com/ceres-solver/ceres-solver/issues/491>`_ with the gflags-config.cmake distributed with Fedora. This quick workaround works::
+Close and re-open your terminal
 
-    sudo sed -i "s^set (GFLAGS_INCLUDE_DIR.*^set (GFLAGS_INCLUDE_DIR "/usr/include")^" /usr/lib64/cmake/gflags/gflags-config.cmake
+Install the conda environment with:
 
-Install python dependencies before building::
+    conda env create --file conda.yml --yes
 
-    cd ~/src/OpenSfM && pip install -r requirements.txt
+Activate the conda environment with::
+
+    conda activate opensfm
 
 Installing dependencies on MacOSX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,6 +66,8 @@ Install conda using brew with::
     brew install --cask anaconda
     export PATH='/Users/USERNAME/anaconda3/bin:$PATH'
     conda init
+
+Close and re-open your terminal
 
 Install the conda environment with:
 

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -24,11 +24,16 @@ OpenSfM depends on the following libraries that need to be installed before buil
 
 * OpenCV_
 * `Ceres Solver`_
+* OpenMP
 
 Python dependencies can be installed with::
 
     pip install -r requirements.txt
 
+Still, we recommand using a full virtual environment manager such as Anaconda, not to mess up with your current setup. Anaconda will take care of installing both systems and python dependencies.
+Anaconda dependencies installation has been tested under MacOS (Sequoia) and Ubuntu 24.04, and can be installed with::
+
+    conda env create --file conda.yml --yes
 
 Installing dependencies on Ubuntu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,22 +58,19 @@ Install python dependencies before building::
 Installing dependencies on MacOSX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install OpenCV and the Ceres solver using::
+Install conda using brew with::
 
-    brew install opencv
-    brew install ceres-solver
-    brew install libomp
-    sudo pip install -r requirements.txt
+    brew install --cask anaconda
+    export PATH='/Users/USERNAME/anaconda3/bin:$PATH'
+    conda init
 
-Make sure you update your ``PYTHONPATH`` to include ``/usr/local/lib/python3.7/site-packages`` where OpenCV have been installed. For example with::
+Install the conda environment with:
 
-    export PYTHONPATH=/usr/local/lib/python3.7/site-packages:$PYTHONPATH
+    conda env create --file conda.yml --yes
 
-Also, in order for Cmake to recognize the libraries installed by Brew, make sure that C_INCLUDE_PATH, CPLUS_INCLUDE_PATH, DYLD_LIBRARY_PATH environment variables are set correctly. For example, you can run::
+Activate the conda environment with::
 
-    export C_INCLUDE_PATH=/usr/local/include
-    export CPLUS_INCLUDE_PATH=/usr/local/include
-    export DYLD_LIBRARY_PATH=$HOME/local/lib64
+    conda activate opensfm
 
 .. note:: Note on OpenCV 3
     When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules are required for extracting SIFT or SURF features.
@@ -106,7 +108,7 @@ Building the library
 
 Once the dependencies have been installed, you can build OpenSfM by running the following command from the main folder::
 
-    python3 setup.py build
+    python setup.py build
 
 Building Docker images
 ----------------------
@@ -124,8 +126,8 @@ Building the documentation
 To build the documentation and browse it locally use::
 
     pip install sphinx_rtd_theme
-    python3 setup.py build_doc
-    python3 -m http.server --directory build/doc/html/
+    python setup.py build_doc
+    python -m http.server --directory build/doc/html/
 
 and browse `http://localhost:8000/ <http://localhost:8000/>`_
 

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -30,8 +30,8 @@ Python dependencies can be installed with::
 
     pip install -r requirements.txt
 
-Still, we recommand using a full virtual environment manager such as Anaconda, not to mess up with your current setup. Anaconda will take care of installing both systems and python dependencies.
-Anaconda dependencies installation has been tested under MacOS (Sequoia) and Ubuntu 24.04, and can be installed with::
+Still, we recommand using a full virtual environment manager such as anaconda, not to mess up with your current setup. Anaconda will take care of installing both systems and python dependencies.
+Anaconda dependencies installation has been tested under MacOS (Sequoia), Ubuntu 24.04 and Fedora 42, and can be installed with::
 
     conda env create --file conda.yml --yes
 
@@ -40,28 +40,42 @@ Installing dependencies on Ubuntu
 
 See this `Dockerfile <https://github.com/mapillary/OpenSfM/blob/main/Dockerfile>`_ for the commands to install all dependencies on Ubuntu 20.04.
 
+Alternatively, you can avoid using a docker image and install dependencies using Anaconda::
+
+    Download and install anaconda from anaconda.org
+
+Close and re-open your terminal
+
+Install the anaconda environment with:
+
+    conda env create --file conda.yml --yes
+
+Activate the anaconda environment with::
+
+    conda activate opensfm
+
 Installing dependencies on Fedora
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install conda using dnf with::
+Install anaconda using dnf with::
 
     sudo dnf install conda
     conda init
 
 Close and re-open your terminal
 
-Install the conda environment with:
+Install the anaconda environment with:
 
     conda env create --file conda.yml --yes
 
-Activate the conda environment with::
+Activate the anaconda environment with::
 
     conda activate opensfm
 
 Installing dependencies on MacOSX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install conda using brew with::
+Install anaconda using brew with::
 
     brew install --cask anaconda
     export PATH='/Users/USERNAME/anaconda3/bin:$PATH'

--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -20,79 +20,35 @@ If you already have the code or you downloaded a release_, make sure to update t
 Install dependencies
 --------------------
 
-OpenSfM depends on the following libraries that need to be installed before building it.
+OpenSfM depends on multiple libraries (OpenCV_, `Ceres Solver`_, ...) and python packages that need to be installed before building it.
 
-* OpenCV_
-* `Ceres Solver`_
-* OpenMP
+The way to install these dependencies depends on your system. We recommend using a virtual environment manager such as anaconda or miniconda, not to mess up with your current setup. Anaconda will take care of installing both systems and python dependencies.
 
-Python dependencies can be installed with::
+Installing dependencies using Conda (recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    pip install -r requirements.txt
-
-Still, we recommand using a full virtual environment manager such as anaconda, not to mess up with your current setup. Anaconda will take care of installing both systems and python dependencies.
-Anaconda dependencies installation has been tested under MacOS (Sequoia), Ubuntu 24.04 and Fedora 42, and can be installed with::
+Creating a conda environment will take care of installing all dependencies. Make sure you have conda or miniconda installed.  From the project root directory, run::
 
     conda env create --file conda.yml --yes
+
+You can then activate the anaconda environment with::
+
+    conda activate opensfm
+
+and you are ready to build OpenSfM.
+
+(Anaconda dependencies installation has been tested under MacOS (Sequoia), Ubuntu 24.04 and Fedora 42.)
 
 Installing dependencies on Ubuntu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See this `Dockerfile <https://github.com/mapillary/OpenSfM/blob/main/Dockerfile>`_ for the commands to install all dependencies on Ubuntu 20.04.
+If you are not using conda, see this `Dockerfile <https://github.com/mapillary/OpenSfM/blob/main/Dockerfile>`_ for the commands to install all dependencies on Ubuntu 20.04.
 
-Alternatively, you can avoid using a docker image and install dependencies using Anaconda::
-
-    Download and install anaconda from anaconda.org
-
-Close and re-open your terminal
-
-Install the anaconda environment with:
-
-    conda env create --file conda.yml --yes
-
-Activate the anaconda environment with::
-
-    conda activate opensfm
-
-Installing dependencies on Fedora
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Install anaconda using dnf with::
-
-    sudo dnf install conda
-    conda init
-
-Close and re-open your terminal
-
-Install the anaconda environment with:
-
-    conda env create --file conda.yml --yes
-
-Activate the anaconda environment with::
-
-    conda activate opensfm
 
 Installing dependencies on MacOSX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install anaconda using brew with::
-
-    brew install --cask anaconda
-    export PATH='/Users/USERNAME/anaconda3/bin:$PATH'
-    conda init
-
-Close and re-open your terminal
-
-Install the conda environment with:
-
-    conda env create --file conda.yml --yes
-
-Activate the conda environment with::
-
-    conda activate opensfm
-
-.. note:: Note on OpenCV 3
-    When running OpenSfM on top of OpenCV version 3.0 the `OpenCV Contrib`_ modules are required for extracting SIFT or SURF features.
+While it is possible to install all dependencies using brew, we recommend using the conda instructions above instead.
 
 
 Installing dependencies on Windows

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 ####### Compilation Options #######
 # Visibility stuff
-cmake_policy(SET CMP0063 NEW)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_INLINES ON)
 
@@ -39,6 +38,9 @@ add_definitions(-DVL_DISABLE_AVX)
 
 # Use the version of vlfeat in ./src/third_party/vlfeat
 add_definitions(-DINPLACE_VLFEAT)
+if(NOT USE_SSE2)
+  add_definitions(-DVL_DISABLE_SSE2)
+endif()
 
 if (WIN32)
     # Missing math constant

--- a/opensfm/src/features/src/matching.cc
+++ b/opensfm/src/features/src/matching.cc
@@ -1,6 +1,7 @@
 #include <features/matching.h>
 #include <foundation/optional.h>
 #include <foundation/types.h>
+#include <foundation/python_types.h>
 #include <pybind11/pybind11.h>
 
 #include <cassert>

--- a/opensfm/src/foundation/python_types.h
+++ b/opensfm/src/foundation/python_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 

--- a/opensfm/src/geo/python/pybind.cc
+++ b/opensfm/src/geo/python/pybind.cc
@@ -1,4 +1,5 @@
 #include <geo/geo.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 namespace py = pybind11;

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -5,6 +5,7 @@
 #include <geometry/relative_pose.h>
 #include <geometry/similarity.h>
 #include <geometry/triangulation.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -94,11 +94,7 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
 
   const T eps = T(1e-30);
   const T det = A.determinant();
-#ifdef __aarch64__
-  if (std::abs<T>(det) < eps) {
-#else
   if (abs(det) < eps) {
-#endif
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;

--- a/opensfm/src/geometry/triangulation.h
+++ b/opensfm/src/geometry/triangulation.h
@@ -92,9 +92,10 @@ std::pair<bool, Eigen::Matrix<T, 3, 1>> TriangulateTwoBearingsMidpointSolve(
   A(0, 1) = -A(1, 0);
   A(1, 1) = -bearings.row(1).dot(bearings.row(1));
 
-  const T eps = T(1e-30);
+  const T eps = T(1e-10);
   const T det = A.determinant();
-  if (abs(det) < eps) {
+
+  if (-eps < det && det < eps) {
     return std::make_pair(false, Eigen::Matrix<T, 3, 1>());
   }
   const auto lambdas = A.inverse() * b;

--- a/opensfm/src/map/pybind_utils.h
+++ b/opensfm/src/map/pybind_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <map/shot.h>
+#include <foundation/python_types.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -10,6 +10,7 @@
 #include <map/pybind_utils.h>
 #include <map/rig.h>
 #include <map/shot.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>


### PR DESCRIPTION
This PR switches the dependencies management to anaconda (C++ + Python deps), while ensuring it works on :
 - Ubuntu 24.04
 - Fedora 42
 - MacOS Sequoia