### PR TITLE
Remove build warnings

### DIFF
--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -9,6 +9,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set(CMAKE_MODULE_PATH ${opensfm_SOURCE_DIR}/cmake)
 
+cmake_policy(SET CMP0063 NEW)
+cmake_policy(SET CMP0148 NEW)
+
 if (WIN32)
 # Place compilation results in opensfm/ folder, not in Debug/ or Release/
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${opensfm_SOURCE_DIR}/..")
@@ -29,8 +32,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Enable all warnings
 if (NOT WIN32)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare")
 endif()
 
 # For compiling VLFeat
@@ -104,6 +107,10 @@ if (OPENSFM_BUILD_TESTS)
   enable_testing()
   include_directories(third_party/gtest)
   add_definitions(-DCERES_GFLAGS_NAMESPACE=${GFLAGS_NAMESPACE})
+
+  # Gtest if old now and trigger these
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy-with-user-provided-copy")
 
   add_library(gtest
               third_party/gtest/gmock_gtest_all.cc

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -10,7 +10,8 @@ endif()
 set(CMAKE_MODULE_PATH ${opensfm_SOURCE_DIR}/cmake)
 
 cmake_policy(SET CMP0063 NEW)
-cmake_policy(SET CMP0148 NEW)
+# Re-activate once we can have a decent version of CMake (> 3.27)
+# cmake_policy(SET CMP0148 NEW)
 
 if (WIN32)
 # Place compilation results in opensfm/ folder, not in Debug/ or Release/

--- a/opensfm/src/features/src/matching.cc
+++ b/opensfm/src/features/src/matching.cc
@@ -2,6 +2,7 @@
 #include <foundation/optional.h>
 #include <foundation/python_types.h>
 #include <foundation/types.h>
+#include <foundation/python_types.h>
 #include <pybind11/pybind11.h>
 
 #include <cassert>

--- a/opensfm/src/foundation/python_types.h
+++ b/opensfm/src/foundation/python_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 

--- a/opensfm/src/geo/python/pybind.cc
+++ b/opensfm/src/geo/python/pybind.cc
@@ -1,5 +1,6 @@
 #include <foundation/python_types.h>
 #include <geo/geo.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 namespace py = pybind11;

--- a/opensfm/src/geometry/absolute_pose.h
+++ b/opensfm/src/geometry/absolute_pose.h
@@ -15,7 +15,7 @@ Eigen::Matrix3d RotationMatrixAroundAxis(const double cos_theta,
 // Perspective-Three-Point Problem" from Ke and al.
 template <class IT>
 std::vector<Eigen::Matrix<double, 3, 4>> AbsolutePoseThreePoints(IT begin,
-                                                                 IT end) {
+                                                                 IT /* end */) {
   std::vector<Eigen::Matrix<double, 3, 4>> RTs;
 
   const Eigen::Vector3d b1 = begin->first;

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -283,7 +283,7 @@ PYBIND11_MODULE(pygeometry, m) {
           py::return_value_policy::copy)
       .def(
           "__deepcopy__",
-          [](const geometry::Camera& c, const py::dict& d) { return c; },
+          [](const geometry::Camera& c, const py::dict& /* d */) { return c; },
           py::return_value_policy::copy);
   m.def("compute_camera_mapping", geometry::ComputeCameraMapping,
         py::call_guard<py::gil_scoped_release>());
@@ -376,7 +376,7 @@ PYBIND11_MODULE(pygeometry, m) {
           py::return_value_policy::copy)
       .def(
           "__deepcopy__",
-          [](const geometry::Pose& p, const py::dict& d) { return p; },
+          [](const geometry::Pose& p, const py::dict& /* d */) { return p; },
           py::return_value_policy::copy)
       .def("inverse", [](const geometry::Pose& p) {
         geometry::Pose new_pose;

--- a/opensfm/src/geometry/python/pybind.cc
+++ b/opensfm/src/geometry/python/pybind.cc
@@ -6,6 +6,7 @@
 #include <geometry/relative_pose.h>
 #include <geometry/similarity.h>
 #include <geometry/triangulation.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/opensfm/src/geometry/transformations_functions.h
+++ b/opensfm/src/geometry/transformations_functions.h
@@ -304,7 +304,7 @@ struct Normalize : Functor<3, 0, 3> {
   }
 };
 
-static Mat3d VectorToRotationMatrix(const Vec3d& r) {
+inline Mat3d VectorToRotationMatrix(const Vec3d& r) {
   const auto n = r.norm();
   if (n == 0)  // avoid division by 0
   {
@@ -313,7 +313,7 @@ static Mat3d VectorToRotationMatrix(const Vec3d& r) {
     return Eigen::AngleAxisd(n, r / n).toRotationMatrix();
   }
 }
-static Vec3d RotationMatrixToVector(const Mat3d& R) {
+inline Vec3d RotationMatrixToVector(const Mat3d& R) {
   Eigen::AngleAxisd tmp(R);
   return tmp.axis() * tmp.angle();
 }

--- a/opensfm/src/map/pybind_utils.h
+++ b/opensfm/src/map/pybind_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <foundation/python_types.h>
 #include <map/shot.h>
+#include <foundation/python_types.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -11,6 +11,7 @@
 #include <map/pybind_utils.h>
 #include <map/rig.h>
 #include <map/shot.h>
+#include <foundation/python_types.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/opensfm/src/map/shot.h
+++ b/opensfm/src/map/shot.h
@@ -71,8 +71,8 @@ class Shot {
 
   // Pose
   void SetPose(const geometry::Pose& pose);
-  const geometry::Pose* const GetPose() const;
-  geometry::Pose* const GetPose();
+  const geometry::Pose* GetPose() const;
+  geometry::Pose* GetPose();
   Mat4d GetWorldToCam() const { return GetPose()->WorldToCamera(); }
   Mat4d GetCamToWorld() const { return GetPose()->CameraToWorld(); }
 
@@ -134,7 +134,7 @@ class Shot {
   bool operator<=(const Shot& shot) const { return id_ <= shot.id_; }
   bool operator>(const Shot& shot) const { return id_ > shot.id_; }
   bool operator>=(const Shot& shot) const { return id_ >= shot.id_; }
-  const geometry::Camera* const GetCamera() const { return shot_camera_; }
+  const geometry::Camera* GetCamera() const { return shot_camera_; }
 
   // Camera-related
   Vec2d Project(const Vec3d& global_pos) const;

--- a/opensfm/src/map/src/shot.cc
+++ b/opensfm/src/map/src/shot.cc
@@ -152,7 +152,7 @@ geometry::Pose Shot::GetPoseInRig() const {
   return rig_camera_pose.Compose(pose_instance);
 }
 
-const geometry::Pose* const Shot::GetPose() const {
+const geometry::Pose* Shot::GetPose() const {
   *pose_ = GetPoseInRig();
   if (IsSingleShotRig(rig_instance_, rig_camera_)) {
     return &rig_instance_->GetPose();
@@ -160,7 +160,7 @@ const geometry::Pose* const Shot::GetPose() const {
   return pose_.get();
 }
 
-geometry::Pose* const Shot::GetPose() {
+geometry::Pose* Shot::GetPose() {
   *pose_ = GetPoseInRig();
   if (IsSingleShotRig(rig_instance_, rig_camera_)) {
     return &rig_instance_->GetPose();

--- a/opensfm/src/map/test/tracks_manager_test.cc
+++ b/opensfm/src/map/test/tracks_manager_test.cc
@@ -8,7 +8,7 @@ class TempFile {
  public:
   TempFile() {
     char tmpname[L_tmpnam];
-    tmpnam(tmpname);
+    mkstemp(tmpname);
     filename = std::string(tmpname);
   }
 

--- a/opensfm/src/robust/line_model.h
+++ b/opensfm/src/robust/line_model.h
@@ -9,7 +9,7 @@ class Line : public Model<Line, 1, 1> {
   static const int MINIMAL_SAMPLES = 2;
 
   template <class IT>
-  static int Estimate(IT begin, IT end, Type* models) {
+  static int Estimate(IT begin, IT /* end */, Type* models) {
     const auto x1 = *begin;
     const auto x2 = *(++begin);
     const auto b = (x1[0] * x2[1] - x1[1] * x2[0]) / (x1[0] - x2[0]);

--- a/opensfm/src/robust/scorer.h
+++ b/opensfm/src/robust/scorer.h
@@ -23,7 +23,7 @@ class RansacScoring {
   RansacScoring(double threshold) : threshold_(threshold) {}
 
   template <class IT, class T>
-  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& best_score) const {
+  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& /* best_score */) const {
     ScoreInfo<T> score;
     for (IT it = begin; it != end; ++it) {
       if (it->norm() < threshold_) {
@@ -62,7 +62,7 @@ class MSacScoring {
   MSacScoring(double threshold) : threshold_(threshold) {}
 
   template <class IT, class T>
-  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& best_score) const {
+  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& /* best_score */) const {
     ScoreInfo<T> score;
     for (IT it = begin; it != end; ++it) {
       const auto v = (*it).norm();
@@ -87,7 +87,7 @@ class LMedSScoring : public MedianBasedScoring {
       : MedianBasedScoring(0.5), multiplier_(multiplier) {}
 
   template <class IT, class T>
-  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& best_score) const {
+  ScoreInfo<T> Score(IT begin, IT end, const ScoreInfo<T>& /* best_score */) const {
     const auto median = this->ComputeMedian(begin, end);
     const auto mad = 1.4826 * median;
     const auto threshold = this->multiplier_ * mad;

--- a/opensfm/src/third_party/akaze/lib/AKAZE.cpp
+++ b/opensfm/src/third_party/akaze/lib/AKAZE.cpp
@@ -405,7 +405,7 @@ void AKAZE::Find_Scale_Space_Extrema(std::vector<cv::KeyPoint>& kpts) {
       std::vector<std::pair<size_t, float> > radiuses(kpts.size());
 
       for (size_t i = 0; i < kpts.size(); ++i) {
-        float radius = 99999999999;
+        float radius = 99999999999.f;
         for (size_t j = 0; j < kpts.size(); ++j) {
           if (kpts[i].response < kpts[j].response) {
             float dx_ = kpts[j].pt.x - kpts[i].pt.x;

--- a/opensfm/src/third_party/vlfeat/CMakeLists.txt
+++ b/opensfm/src/third_party/vlfeat/CMakeLists.txt
@@ -1,5 +1,10 @@
 file(GLOB VLFEAT_SRCS vl/*.c vl/*.h)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-absolute-value")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-logical-not-parentheses")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-tautological-constant-out-of-range-compare")
+
 if( ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64" )
     add_definitions( -DVL_DISABLE_SSE2 )
 endif()

--- a/opensfm/src/third_party/vlfeat/vl/covdet.c
+++ b/opensfm/src/third_party/vlfeat/vl/covdet.c
@@ -975,19 +975,6 @@ _vl_resize_buffer (void ** buffer, vl_size * bufferSize, vl_size targetSize) {
   }
 }
 
-/** @brief Enlarge buffer
- ** @param buffer
- ** @param bufferSize
- ** @param targetSize
- ** @return error code
- **/
-
-static int
-_vl_enlarge_buffer (void ** buffer, vl_size * bufferSize, vl_size targetSize) {
-  if (*bufferSize >= targetSize) return VL_ERR_OK ;
-  return _vl_resize_buffer(buffer,bufferSize,targetSize) ;
-}
-
 /* ---------------------------------------------------------------- */
 /*                                            Finding local extrema */
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
This PR removes all the annoying build warnings that we had by :
  - Setting CMake policy
  - Add C++ warning ignores in third-party libraries only, since we're very unlikely to touch this code ever again
  - Fix the actual warnings in the rest of OpenSfM code