### PR TITLE
fix: correct logger warnings

### DIFF
--- a/opensfm/pairs_selection.py
+++ b/opensfm/pairs_selection.py
@@ -607,7 +607,7 @@ def match_candidates_from_metadata(
 
     if not all(map(has_gps_info, exifs.values())):
         if gps_neighbors != 0:
-            logger.warn(
+            logger.warning(
                 "Not all images have GPS info. " "Disabling matching_gps_neighbors."
             )
         gps_neighbors = 0


### PR DESCRIPTION
## PR Summary
This small PR migrates from the deprecated `logger.warn` to the recommended `logger.warning` method to solve:
```python
/tmp/opensfm/opensfm/pairs_selection.py:610: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```