### PR TITLE
Warn user if ceres loss function is not available

### DIFF
--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -425,7 +425,7 @@ ceres::LossFunction *CreateLossFunction(std::string name, double threshold) {
   } else if (name.compare("ArctanLoss") == 0) {
     return new ceres::ArctanLoss(threshold);
   }
-  return nullptr;
+  throw std::runtime_error("ceres::LossFunction with name " + name + " not found.");
 }
 
 void BundleAdjuster::AddLinearMotion(const std::string &shot0_id,

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -425,7 +425,7 @@ ceres::LossFunction *CreateLossFunction(std::string name, double threshold) {
   } else if (name.compare("ArctanLoss") == 0) {
     return new ceres::ArctanLoss(threshold);
   }
-  throw std::runtime_error("ceres::LossFunction with name " + name + " not found.");
+  throw std::runtime_error("CreateLossFunction has no implementation for loss " + name + ".");
 }
 
 void BundleAdjuster::AddLinearMotion(const std::string &shot0_id,


### PR DESCRIPTION
I set TukeyLoss without noticing, that it wasn't used. So in this PR `CreateLossFunction` throws a runtime_error if the loss-function is not implemented, instead of silently using nullptr.