### PR TITLE
Fix GCP handling

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -6,9 +6,12 @@ dependencies:
     - libxcrypt
     - libopencv *=headless*
     - py-opencv
-    - ceres-solver=2.1
+    - conda-forge::ceres-solver=2.2
     - conda-forge::llvm-openmp
     - conda-forge::cxx-compiler
+    - anaconda::suitesparse
+    - conda-forge::openblas
+    - anaconda::metis
     - pip
     - pip:
         - cloudpickle==3.1.1

--- a/opensfm/actions/create_tracks.py
+++ b/opensfm/actions/create_tracks.py
@@ -13,9 +13,10 @@ def run_dataset(data: DataSetBase) -> None:
         data, data.images()
     )
     features_end = timer()
-    matches = tracking.load_matches(data, data.images())
+    matches = lambda: tracking.load_matches(data, data.images())
     matches_end = timer()
-    tracks_manager = tracking.create_tracks_manager(
+
+    tracks_manager = tracking.create_tracks_manager_from_matches_iter(
         features,
         colors,
         segmentations,

--- a/opensfm/actions/reconstruct.py
+++ b/opensfm/actions/reconstruct.py
@@ -1,4 +1,5 @@
 # pyre-strict
+import gc
 from opensfm import io, reconstruction
 from opensfm.dataset_base import DataSetBase
 
@@ -21,5 +22,8 @@ def run_dataset(
     else:
         raise RuntimeError(f"Unsupported algorithm for reconstruction {algorithm}")
 
-    data.save_reconstruction(reconstructions)
+    del tracks_manager
+    gc.collect()
+
     data.save_report(io.json_dumps(report), "reconstruction.json")
+    data.save_reconstruction(reconstructions)

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -276,6 +276,8 @@ class OpenSfMConfig:
     # Maximum optimizer iterations.
     bundle_max_iterations: int = 100
 
+    # Ratio of (resection candidates / total tracks) of a given image so that it is culled at resection and resected later
+    resect_redundancy_threshold: float = 0.7
     # Retriangulate all points from time to time
     retriangulation: bool = True
     # Retriangulate when the number of points grows by this ratio

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -292,6 +292,10 @@ class OpenSfMConfig:
     local_bundle_min_common_points: int = 20
     # Max number of shots to optimize during local bundle adjustment
     local_bundle_max_shots: int = 30
+    # Number of grid division for seleccting tracks in local bundle adjustment
+    local_bundle_grid: int = 8
+    # Number of grid division for selecting tracks in final bundle adjustment
+    final_bundle_grid: int = 32
 
     # Save reconstructions at every iteration
     save_partial_reconstructions: bool = False

--- a/opensfm/config.py
+++ b/opensfm/config.py
@@ -260,7 +260,7 @@ class OpenSfMConfig:
     # The default vertical standard deviation of the GCPs (in meters)
     gcp_vertical_sd: float = 0.1
     # Global weight for GCPs, expressed a ratio of the sum of (# projections) + (# shots) + (# relative motions)
-    gcp_global_weight: float = 0.01
+    gcp_global_weight: float = 0.02
     # The standard deviation of the rig translation
     rig_translation_sd: float = 0.1
     # The standard deviation of the rig rotation
@@ -303,7 +303,7 @@ class OpenSfMConfig:
     save_partial_reconstructions: bool = False
 
     ##################################
-    # Params for GPS alignment
+    # Params for GPS/GCP alignment
     ##################################
     # Use or ignore EXIF altitude tag
     use_altitude_tag: bool = True
@@ -317,6 +317,8 @@ class OpenSfMConfig:
     bundle_use_gcp: bool = True
     # Compensate GPS with a per-camera similarity transform
     bundle_compensate_gps_bias: bool = False
+    # Thrershold for the reprojection error of GCPs to be considered outliers
+    gcp_reprojection_error_threshold: float = 0.05
 
     ##################################
     # Params for rigs

--- a/opensfm/dense.py
+++ b/opensfm/dense.py
@@ -30,7 +30,7 @@ def compute_depthmaps(
     num_neighbors = config["depthmap_num_neighbors"]
 
     neighbors = {}
-    common_tracks = common_tracks_double_dict(graph)
+    common_tracks = common_tracks_double_dict(graph, processes)
     for shot in reconstruction.shots.values():
         neighbors[shot.id] = find_neighboring_images(
             shot, common_tracks, reconstruction, num_neighbors
@@ -394,13 +394,14 @@ def compute_depth_range(
 
 def common_tracks_double_dict(
     tracks_manager: pymap.TracksManager,
+    processes: int,
 ) -> Dict[str, Dict[str, List[str]]]:
     """List of track ids observed by each image pair.
 
     Return a dict, ``res``, such that ``res[im1][im2]`` is the list of
     common tracks between ``im1`` and ``im2``.
     """
-    common_tracks_per_pair = tracking.all_common_tracks_without_features(tracks_manager)
+    common_tracks_per_pair = tracking.all_common_tracks_without_features(tracks_manager, processes=processes)
     res = {image: {} for image in tracks_manager.get_shot_ids()}
     for (im1, im2), v in common_tracks_per_pair.items():
         res[im1][im2] = v

--- a/opensfm/multiview.py
+++ b/opensfm/multiview.py
@@ -533,6 +533,7 @@ def triangulate_gcp(
     reproj_threshold: float = 0.02,
     min_ray_angle_degrees: float = 1.0,
     min_depth: float = 0.001,
+    iterations: int = 10,
 ) -> Optional[NDArray]:
     """Compute the reconstructed position of a GCP from observations."""
 
@@ -550,13 +551,17 @@ def triangulate_gcp(
 
     if len(os) >= 2:
         thresholds = len(os) * [reproj_threshold]
+        os = np.asarray(os)
+        bs = np.asarray(bs)
         valid_triangulation, X = pygeometry.triangulate_bearings_midpoint(
-            np.asarray(os),
-            np.asarray(bs),
+            os,
+            bs,
             thresholds,
             np.radians(min_ray_angle_degrees),
             min_depth,
         )
+        
         if valid_triangulation:
+            X = pygeometry.point_refinement(os, bs, X, iterations)
             return X
     return None

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -52,7 +52,7 @@ def _get_camera_from_bundle(
 
 def log_bundle_stats(bundle_type: str, bundle_report: Dict[str, Any]) -> None:
     times = bundle_report["wall_times"]
-    time_secs = times["run"] + times["setup"] + times["teardown"]
+    time_secs = times["run"] + times["setup"] + times["teardown"] + times["triangulate"]
     num_images, num_points, num_reprojections = (
         bundle_report["num_images"],
         bundle_report["num_points"],
@@ -72,6 +72,7 @@ def bundle(
     camera_priors: Dict[str, pygeometry.Camera],
     rig_camera_priors: Dict[str, pymap.RigCamera],
     gcp: Optional[List[pymap.GroundControlPoint]],
+    grid_size: int,
     config: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Bundle adjust a reconstruction."""
@@ -80,6 +81,7 @@ def bundle(
         dict(camera_priors),
         dict(rig_camera_priors),
         gcp if gcp is not None else [],
+        grid_size,
         config,
     )
     log_bundle_stats("GLOBAL", report)
@@ -110,6 +112,7 @@ def bundle_local(
     camera_priors: Dict[str, pygeometry.Camera],
     rig_camera_priors: Dict[str, pymap.RigCamera],
     gcp: Optional[List[pymap.GroundControlPoint]],
+    grid_size: int,
     central_shot_id: str,
     config: Dict[str, Any],
 ) -> Tuple[Dict[str, Any], List[int]]:
@@ -120,6 +123,7 @@ def bundle_local(
         dict(rig_camera_priors),
         gcp if gcp is not None else [],
         central_shot_id,
+        grid_size,
         config,
     )
     log_bundle_stats("LOCAL", report)
@@ -1510,7 +1514,7 @@ def grow_reconstruction(
     paint_reconstruction(data, tracks_manager, reconstruction)
     align_reconstruction(reconstruction, gcp, config)
 
-    bundle(reconstruction, camera_priors, rig_camera_priors, None, config)
+    bundle(reconstruction, camera_priors, rig_camera_priors, None, -1, config)
     remove_outliers(reconstruction, config)
     paint_reconstruction(data, tracks_manager, reconstruction)
 
@@ -1523,6 +1527,10 @@ def grow_reconstruction(
         list(reconstruction.points.keys()),
     )
     
+    local_ba_radius = config["local_bundle_radius"]
+    local_ba_grid = config["local_bundle_grid"]
+    final_bundle_grid = config["final_bundle_grid"]
+
     while True:
         if config["save_partial_reconstructions"]:
             paint_reconstruction(data, tracks_manager, reconstruction)
@@ -1580,12 +1588,12 @@ def grow_reconstruction(
                 logger.info("Re-triangulating")
                 align_reconstruction(reconstruction, gcp, config)
                 b1rep = bundle(
-                    reconstruction, camera_priors, rig_camera_priors, None, config
+                    reconstruction, camera_priors, rig_camera_priors, None, local_ba_grid, config
                 )
                 rrep = retriangulate(tracks_manager, reconstruction, config)
                 resection_candidates.update(reconstruction)
                 b2rep = bundle(
-                    reconstruction, camera_priors, rig_camera_priors, None, config
+                    reconstruction, camera_priors, rig_camera_priors, None, local_ba_grid, config
                 )
                 resection_candidates.remove(*remove_outliers(reconstruction, config))
                 step["bundle"] = b1rep
@@ -1596,17 +1604,18 @@ def grow_reconstruction(
             elif should_bundle.should():
                 align_reconstruction(reconstruction, gcp, config)
                 brep = bundle(
-                    reconstruction, camera_priors, rig_camera_priors, None, config
+                    reconstruction, camera_priors, rig_camera_priors, None, local_ba_grid, config
                 )
                 resection_candidates.remove(*remove_outliers(reconstruction, config))
                 step["bundle"] = brep
                 should_bundle.done()
-            elif config["local_bundle_radius"] > 0:
+            elif local_ba_radius > 0:
                 bundled_points, brep = bundle_local(
                     reconstruction,
                     camera_priors,
                     rig_camera_priors,
                     None,
+                    local_ba_grid,
                     image,
                     config,
                 )
@@ -1628,7 +1637,7 @@ def grow_reconstruction(
         overidden_config["bundle_compensate_gps_bias"] = False
         config = overidden_config
 
-    bundle(reconstruction, camera_priors, rig_camera_priors, gcp, config)
+    bundle(reconstruction, camera_priors, rig_camera_priors, gcp, final_bundle_grid, config)
     resection_candidates.remove(*remove_outliers(reconstruction, config))
     paint_reconstruction(data, tracks_manager, reconstruction)
     return reconstruction, report

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -236,7 +236,6 @@ def _pair_reconstructability_arguments(
 
 
 def _compute_pair_reconstructability(args: TPairArguments) -> Tuple[str, str, float]:
-    log.setup()
     im1, im2, p1, p2, camera1, camera2, threshold = args
     R, inliers = two_view_reconstruction_rotation_only(
         p1, p2, camera1, camera2, threshold
@@ -1676,7 +1675,7 @@ def incremental_reconstruction(
         # pairs of image. Features of an image can be stored
         # repeatedly in multiple image pairs.
         # Pros: fast; Cons: high memory usage
-        common_tracks = tracking.all_common_tracks_with_features(tracks_manager)
+        common_tracks = tracking.all_common_tracks_with_features(tracks_manager, processes=data.config["processes"])
         pairs = compute_image_pairs(common_tracks, data)
     else:
         # Get pairs sequentially, load features lazily.

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -1522,14 +1522,16 @@ def grow_reconstruction(
     should_bundle = ShouldBundle(data, reconstruction)
     should_retriangulate = ShouldRetriangulate(data, reconstruction)
 
+    local_ba_radius = config["local_bundle_radius"]
+    local_ba_grid = config["local_bundle_grid"]
+    final_bundle_grid = config["final_bundle_grid"]
+
     resection_candidates.add(
         list(reconstruction.shots.keys()),
         list(reconstruction.points.keys()),
     )
-    
-    local_ba_radius = config["local_bundle_radius"]
-    local_ba_grid = config["local_bundle_grid"]
-    final_bundle_grid = config["final_bundle_grid"]
+    redundant_shots = set()
+    ratio_redundant = config["resect_redundancy_threshold"]
 
     while True:
         if config["save_partial_reconstructions"]:
@@ -1548,7 +1550,17 @@ def grow_reconstruction(
         logger.info("-------------------------------------------------------")
         threshold = data.config["resection_threshold"]
         min_inliers = data.config["resection_min_inliers"]
-        for image, _ in candidates:
+
+        for image, resect_points in candidates:
+
+            new_tracks = {t for t in tracks_manager.get_shot_observations(image)}
+            ratio_existing = resect_points / len(new_tracks) if new_tracks else 1.0
+            logger.info("Ratio of resected tracks in {}: {:.2f}".format(image, ratio_existing))
+            if ratio_existing > ratio_redundant:
+                redundant_shots.add(image)
+                images.remove(image)
+                continue
+
             ok, new_shots, resected_tracks, resrep = resect(
                 data,
                 tracks_manager,
@@ -1626,8 +1638,14 @@ def grow_reconstruction(
 
             break
         else:
-            logger.info("Some images can not be added")
-            break
+            if redundant_shots:
+                images.update(redundant_shots)
+                redundant_shots.clear()
+                ratio_redundant = 1
+                local_ba_radius = 0
+            else:
+                logger.info("Some images can not be added")
+                break
 
     logger.info("-------------------------------------------------------")
 

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -706,7 +706,7 @@ def resect(
     bs = np.array(bs)
     Xs = np.array(Xs)
     if len(bs) < 5:
-        return False, set(), {"num_common_points": len(bs)}
+        return False, set(), set(), {"num_common_points": len(bs)}
 
     T = multiview.absolute_pose_ransac(bs, Xs, threshold, 1000, 0.999)
 
@@ -737,15 +737,17 @@ def resect(
             triangulate_shot_features(
                 tracks_manager, reconstruction, new_shots, data.config
             )
+        tracks = set()
         for i, succeed in enumerate(inliers):
             if succeed:
                 add_observation_to_reconstruction(
                     tracks_manager, reconstruction, shot_id, ids[i]
                 )
+                tracks.add(ids[i])
         report["shots"] = list(new_shots)
-        return True, new_shots, report
+        return True, new_shots, tracks, report
     else:
-        return False, set(), report
+        return False, set(), set(), report
 
 
 def corresponding_tracks(
@@ -912,7 +914,7 @@ class TrackTriangulator:
         min_ray_angle_degrees: float,
         min_depth: float,
         iterations: int,
-    ) -> None:
+    ) -> bool:
         """Triangulate track in a RANSAC way and add point to reconstruction."""
         os, bs, ids = [], [], []
         for shot_id, obs in self.tracks_handler.get_observations(track).items():
@@ -924,7 +926,7 @@ class TrackTriangulator:
             ids.append(shot_id)
 
         if len(ids) < 2:
-            return
+            return False
 
         os = np.array(os)
         bs = np.array(bs)
@@ -1004,6 +1006,7 @@ class TrackTriangulator:
             self.tracks_handler.store_track_coordinates(track, best_point)
             for i in best_inliers:
                 self.tracks_handler.store_inliers_observation(track, ids[i])
+        return len(best_inliers) > 1
 
     def triangulate(
         self,
@@ -1012,7 +1015,7 @@ class TrackTriangulator:
         min_ray_angle_degrees: float,
         min_depth: float,
         iterations: int,
-    ) -> None:
+    ) -> bool:
         """Triangulate track and add point to reconstruction."""
         os, bs, ids = [], [], []
         for shot_id, obs in self.tracks_handler.get_observations(track).items():
@@ -1040,6 +1043,9 @@ class TrackTriangulator:
                 self.tracks_handler.store_track_coordinates(track, X.tolist())
                 for shot_id in ids:
                     self.tracks_handler.store_inliers_observation(track, shot_id)
+                return True
+
+        return False            
 
     def triangulate_dlt(
         self,
@@ -1048,7 +1054,7 @@ class TrackTriangulator:
         min_ray_angle_degrees: float,
         min_depth: float,
         iterations: int,
-    ) -> None:
+    ) -> bool:
         """Triangulate track using DLT and add point to reconstruction."""
         Rts, bs, os, ids = [], [], [], []
         for shot_id, obs in self.tracks_handler.get_observations(track).items():
@@ -1076,6 +1082,8 @@ class TrackTriangulator:
                 self.tracks_handler.store_track_coordinates(track, X.tolist())
                 for shot_id in ids:
                     self.tracks_handler.store_inliers_observation(track, shot_id)
+                return True
+        return False
 
     def _shot_origin(self, shot: pymap.Shot) -> NDArray:
         if shot.id in self.origins:
@@ -1107,7 +1115,7 @@ def triangulate_shot_features(
     reconstruction: types.Reconstruction,
     shot_ids: Set[str],
     config: Dict[str, Any],
-) -> None:
+) -> List[str]:
     """Reconstruct as many tracks seen in shot_id as possible."""
     reproj_threshold = config["triangulation_threshold"]
     min_ray_angle = config["triangulation_min_ray_angle"]
@@ -1125,24 +1133,29 @@ def triangulate_shot_features(
         if s in all_shots_ids
         for t in tracks_manager.get_shot_observations(s)
     }
+
+    created_tracks = []
     for track in tracks_ids:
         if track not in reconstruction.points:
             if config["triangulation_type"] == "ROBUST":
-                triangulator.triangulate_robust(
+                if(triangulator.triangulate_robust(
                     track,
                     reproj_threshold,
                     min_ray_angle,
                     min_depth,
                     refinement_iterations,
-                )
+                )):
+                    created_tracks.append(track)
             elif config["triangulation_type"] == "FULL":
-                triangulator.triangulate(
+                if(triangulator.triangulate(
                     track,
                     reproj_threshold,
                     min_ray_angle,
                     min_depth,
                     refinement_iterations,
-                )
+                )):
+                    created_tracks.append(track)
+    return created_tracks
 
 
 def retriangulate(
@@ -1215,7 +1228,7 @@ def remove_outliers(
     reconstruction: types.Reconstruction,
     config: Dict[str, Any],
     points: Optional[Dict[str, pymap.Landmark]] = None,
-) -> int:
+) -> Tuple[List[Tuple[str, str]], Set[str]]:
     """Remove points with large reprojection error.
 
     A list of point ids to be processed can be given in ``points``.
@@ -1237,14 +1250,16 @@ def remove_outliers(
         reconstruction.map.remove_observation(shot_id, track)
         track_ids.add(track)
 
+    removed_tracks = set()
     for track in track_ids:
         if track in reconstruction.points:
             lm = reconstruction.points[track]
             if lm.number_of_observations() < 2:
                 reconstruction.map.remove_landmark(lm)
+                removed_tracks.add(track)
 
     logger.info("Removed outliers: {}".format(len(outliers)))
-    return len(outliers)
+    return outliers, removed_tracks
 
 
 def shot_lla_and_compass(
@@ -1408,6 +1423,75 @@ class ShouldRetriangulate:
     def done(self) -> None:
         self.num_points_last = len(self.reconstruction.points)
 
+class ResectionCandidates:
+    """Helper to keep track of resection candidates."""
+
+    def __init__(self, tracks_manager: pymap.TracksManager, reconstruction: types.Reconstruction) -> None:
+        self.tracks_manager = tracks_manager
+        self.reconstruction = reconstruction
+        self.candidates: Dict[str, Set[str]] = {}
+        self.tracks = set()
+
+    def update(self, reconstruction: types.Reconstruction) -> None:
+        """Update candidates based on a new reconstruction."""
+        self.reconstruction = reconstruction
+        rec_tracks = set(reconstruction.points.keys())
+
+        # add new tracks
+        for track_id in rec_tracks:
+            if track_id not in self.tracks:
+                self.tracks.add(track_id)
+                for shot_id in self.tracks_manager.get_track_observations(track_id):
+                    if shot_id not in self.candidates:
+                        self.candidates[shot_id] = set()
+                    self.candidates[shot_id].add(track_id)
+
+        # remove tracks that are not in the reconstruction
+        to_remove = set()
+        for track_id in self.tracks:
+            if track_id not in rec_tracks:
+                for shot_id, shot_candidates in self.candidates.items():
+                    if track_id in shot_candidates:
+                        shot_candidates.remove(track_id)
+                to_remove.add(track_id)
+
+        for track_id in to_remove:
+            self.tracks.remove(track_id)
+                
+    def add(self, shots: List[str], tracks: Set[str]) -> None:
+        """Add newly resected tracks and the shots they belong to."""
+        for shot_id in shots:
+            if shot_id in self.candidates:
+                del self.candidates[shot_id]
+
+        for track_id in tracks:
+            self.tracks.add(track_id)
+            for shot_id in self.tracks_manager.get_track_observations(track_id):
+                if shot_id in self.reconstruction.shots:
+                    continue
+                if shot_id not in self.candidates:
+                    self.candidates[shot_id] = set()
+                self.candidates[shot_id].add(track_id)
+
+    def remove(self, outliers: List[Tuple[str, str]], removed_tracks: List[str]) -> None:
+        """Remove outliers from candidates."""
+        for shot_id, track_id in outliers:
+            if shot_id in self.candidates and track_id in self.candidates[shot_id]:
+                self.candidates[shot_id].remove(track_id)
+                if not self.candidates[shot_id]:
+                    del self.candidates[shot_id]
+
+        for track_id in removed_tracks:
+            for shot_id, shot_candidates in self.candidates.items():
+                if track_id in shot_candidates:
+                    shot_candidates.remove(track_id)
+            self.tracks.remove(track_id)
+
+
+    def get_candidates(self, images: Set[str]) -> List[Tuple[str, int]]:
+        """Get sorted candidates for resection."""
+        return [(k, len(v)) for k,v in filter(lambda x: x[0] in images, sorted(self.candidates.items(), key=lambda x: -len(x[1])))]
+
 
 def grow_reconstruction(
     data: DataSetBase,
@@ -1430,8 +1514,15 @@ def grow_reconstruction(
     remove_outliers(reconstruction, config)
     paint_reconstruction(data, tracks_manager, reconstruction)
 
+    resection_candidates = ResectionCandidates(tracks_manager, reconstruction)
     should_bundle = ShouldBundle(data, reconstruction)
     should_retriangulate = ShouldRetriangulate(data, reconstruction)
+
+    resection_candidates.add(
+        list(reconstruction.shots.keys()),
+        list(reconstruction.points.keys()),
+    )
+    
     while True:
         if config["save_partial_reconstructions"]:
             paint_reconstruction(data, tracks_manager, reconstruction)
@@ -1442,9 +1533,7 @@ def grow_reconstruction(
                 ),
             )
 
-        candidates = reconstructed_points_for_images(
-            tracks_manager, reconstruction, images
-        )
+        candidates = resection_candidates.get_candidates(images)
         if not candidates:
             break
 
@@ -1452,7 +1541,7 @@ def grow_reconstruction(
         threshold = data.config["resection_threshold"]
         min_inliers = data.config["resection_min_inliers"]
         for image, _ in candidates:
-            ok, new_shots, resrep = resect(
+            ok, new_shots, resected_tracks, resrep = resect(
                 data,
                 tracks_manager,
                 reconstruction,
@@ -1471,6 +1560,7 @@ def grow_reconstruction(
                 rig_camera_priors,
                 data.config,
             )
+            resection_candidates.add(new_shots, resected_tracks)
 
             logger.info(f"Adding {' and '.join(new_shots)} to the reconstruction")
             step: Dict[str, Union[List[int], List[str], int, List[int], Any]] = {
@@ -1481,7 +1571,8 @@ def grow_reconstruction(
             report["steps"].append(step)
 
             np_before = len(reconstruction.points)
-            triangulate_shot_features(tracks_manager, reconstruction, new_shots, config)
+            new_tracks = triangulate_shot_features(tracks_manager, reconstruction, new_shots, config)
+            resection_candidates.add([], new_tracks)
             np_after = len(reconstruction.points)
             step["triangulated_points"] = np_after - np_before
 
@@ -1492,10 +1583,11 @@ def grow_reconstruction(
                     reconstruction, camera_priors, rig_camera_priors, None, config
                 )
                 rrep = retriangulate(tracks_manager, reconstruction, config)
+                resection_candidates.update(reconstruction)
                 b2rep = bundle(
                     reconstruction, camera_priors, rig_camera_priors, None, config
                 )
-                remove_outliers(reconstruction, config)
+                resection_candidates.remove(*remove_outliers(reconstruction, config))
                 step["bundle"] = b1rep
                 step["retriangulation"] = rrep
                 step["bundle_after_retriangulation"] = b2rep
@@ -1506,7 +1598,7 @@ def grow_reconstruction(
                 brep = bundle(
                     reconstruction, camera_priors, rig_camera_priors, None, config
                 )
-                remove_outliers(reconstruction, config)
+                resection_candidates.remove(*remove_outliers(reconstruction, config))
                 step["bundle"] = brep
                 should_bundle.done()
             elif config["local_bundle_radius"] > 0:
@@ -1518,7 +1610,7 @@ def grow_reconstruction(
                     image,
                     config,
                 )
-                remove_outliers(reconstruction, config, bundled_points)
+                resection_candidates.remove(*remove_outliers(reconstruction, config, bundled_points))
                 step["local_bundle"] = brep
 
             logger.info(f"Reconstruction now has {len(reconstruction.shots)} shots.")
@@ -1537,7 +1629,7 @@ def grow_reconstruction(
         config = overidden_config
 
     bundle(reconstruction, camera_priors, rig_camera_priors, gcp, config)
-    remove_outliers(reconstruction, config)
+    resection_candidates.remove(*remove_outliers(reconstruction, config))
     paint_reconstruction(data, tracks_manager, reconstruction)
     return reconstruction, report
 

--- a/opensfm/reconstruction.py
+++ b/opensfm/reconstruction.py
@@ -1512,7 +1512,7 @@ def grow_reconstruction(
     rig_camera_priors = data.load_rig_cameras()
 
     paint_reconstruction(data, tracks_manager, reconstruction)
-    align_reconstruction(reconstruction, gcp, config)
+    align_reconstruction(reconstruction, [], config)
 
     bundle(reconstruction, camera_priors, rig_camera_priors, None, -1, config)
     remove_outliers(reconstruction, config)
@@ -1598,7 +1598,7 @@ def grow_reconstruction(
 
             if should_retriangulate.should():
                 logger.info("Re-triangulating")
-                align_reconstruction(reconstruction, gcp, config)
+                align_reconstruction(reconstruction, [], config)
                 b1rep = bundle(
                     reconstruction, camera_priors, rig_camera_priors, None, local_ba_grid, config
                 )
@@ -1614,7 +1614,7 @@ def grow_reconstruction(
                 should_retriangulate.done()
                 should_bundle.done()
             elif should_bundle.should():
-                align_reconstruction(reconstruction, gcp, config)
+                align_reconstruction(reconstruction, [], config)
                 brep = bundle(
                     reconstruction, camera_priors, rig_camera_priors, None, local_ba_grid, config
                 )

--- a/opensfm/src/CMakeLists.txt
+++ b/opensfm/src/CMakeLists.txt
@@ -40,6 +40,9 @@ endif()
 # For compiling VLFeat
 add_definitions(-DVL_DISABLE_AVX)
 
+# We're not using an inplace Glog
+add_definitions(-DGLOG_USE_GLOG_EXPORT)
+
 # Use the version of vlfeat in ./src/third_party/vlfeat
 add_definitions(-DINPLACE_VLFEAT)
 if(NOT USE_SSE2)

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -1109,6 +1109,7 @@ void BundleAdjuster::Run() {
   }
   options.num_threads = num_threads_;
   options.max_num_iterations = max_num_iterations_;
+  options.sparse_linear_algebra_library_type = ceres::SUITE_SPARSE;
 
   ceres::Solve(options, &problem, &last_run_summary_);
 

--- a/opensfm/src/bundle/src/bundle_adjuster.cc
+++ b/opensfm/src/bundle/src/bundle_adjuster.cc
@@ -809,8 +809,7 @@ void BundleAdjuster::Run() {
         projection_type, use_analytic_, observation, projection_loss, &problem);
 
     // Add relative depth error blocks
-    geometry::Dispatch<AddRelativeDepthError>(projection_type, observation,
-                                              projection_loss, &problem);
+    geometry::Dispatch<AddRelativeDepthError>(projection_type, observation, projection_loss, &problem);
   }
 
   // Add relative motion errors

--- a/opensfm/src/bundle/test/reprojection_errors_test.cc
+++ b/opensfm/src/bundle/test/reprojection_errors_test.cc
@@ -1,8 +1,24 @@
-#include <bundle/error/projection_errors.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
+#include <unsupported/Eigen/AutoDiff>
+
+using TEigenDiff = Eigen::AutoDiffScalar<Eigen::Matrix<double, -1, 1>>;
+
+namespace std {
+constexpr int fpclassify(const TEigenDiff& x) {
+  return std::fpclassify(x.value());
+}
+
+inline TEigenDiff hypot(const TEigenDiff& x, const TEigenDiff& y,
+                        const TEigenDiff& z) {
+  return sqrt(x * x + y * y + z * z);
+}
+}  // namespace std
+
+// Has to be included AFTER std:: maths overloads for Eigen Autodiff above
+#include <bundle/error/projection_errors.h>
 
 class ReprojectionError2DFixtureBase : public ::testing::Test {
  public:

--- a/opensfm/src/map/python/pybind.cc
+++ b/opensfm/src/map/python/pybind.cc
@@ -305,6 +305,9 @@ PYBIND11_MODULE(pymap, m) {
       .def("get_all_common_observations",
            &map::TracksManager::GetAllCommonObservations,
            py::call_guard<py::gil_scoped_release>())
+      .def("get_all_common_observations_arrays",
+           &map::TracksManager::GetAllCommonObservationsArrays,
+           py::call_guard<py::gil_scoped_release>())     
       .def("get_all_pairs_connectivity",
            &map::TracksManager::GetAllPairsConnectivity,
            py::arg("shots") = std::vector<map::ShotId>(),

--- a/opensfm/src/map/shot.h
+++ b/opensfm/src/map/shot.h
@@ -141,6 +141,7 @@ class Shot {
   MatX2d ProjectMany(const MatX3d& points) const;
   Vec3d Bearing(const Vec2d& point) const;
   MatX3d BearingMany(const MatX2d& points) const;
+  Vec3d LandmarkBearing(const Landmark* landmark) const;
 
   // Covariance
   MatXd GetCovariance() const { return covariance_.Value(); }

--- a/opensfm/src/map/src/shot.cc
+++ b/opensfm/src/map/src/shot.cc
@@ -185,6 +185,15 @@ Vec3d Shot::Bearing(const Vec2d& point) const {
   return GetPose()->RotationCameraToWorld() * shot_camera_->Bearing(point);
 }
 
+Vec3d Shot::LandmarkBearing(const Landmark* landmark) const {
+  auto it = landmark_observations_.find(const_cast<Landmark*>(landmark));
+  if (it == landmark_observations_.end()) {
+    throw std::runtime_error("Landmark not observed in this shot");
+  }
+  const Observation& obs = it->second;
+  return Bearing(obs.point);
+}
+
 MatX3d Shot::BearingMany(const MatX2d& points) const {
   MatX3d bearings(points.rows(), 3);
   for (int i = 0; i < points.rows(); ++i) {

--- a/opensfm/src/map/src/tracks_manager.cc
+++ b/opensfm/src/map/src/tracks_manager.cc
@@ -1,4 +1,5 @@
 #include <foundation/union_find.h>
+#include <foundation/types.h>
 #include <map/tracks_manager.h>
 
 #include <optional>
@@ -303,6 +304,23 @@ TracksManager::GetAllCommonObservations(const ShotId& shot1,
     }
   }
   return tuples;
+}
+
+std::tuple<std::vector<map::TrackId>, MatX2f, MatX2f>
+TracksManager::GetAllCommonObservationsArrays(const ShotId& shot1,
+                                              const ShotId& shot2) const {
+  const auto tuples = GetAllCommonObservations(shot1, shot2);
+
+  std::vector<map::TrackId> track_ids(tuples.size());
+  MatX2f points1(tuples.size(), 2);
+  MatX2f points2(tuples.size(), 2);
+  for (int i = 0; i < tuples.size(); ++i) {
+    const auto& [track_id, obs1, obs2] = tuples[i];
+    track_ids[i] = track_id;
+    points1.row(i) = obs1.point.cast<float>();
+    points2.row(i) = obs2.point.cast<float>();
+  }
+  return {track_ids, points1, points2};
 }
 
 std::unordered_map<TracksManager::ShotPair, int, HashPair>

--- a/opensfm/src/map/tracks_manager.h
+++ b/opensfm/src/map/tracks_manager.h
@@ -33,6 +33,9 @@ class TracksManager {
   using KeyPointTuple = std::tuple<TrackId, Observation, Observation>;
   std::vector<KeyPointTuple> GetAllCommonObservations(
       const ShotId& shot1, const ShotId& shot2) const;
+  std::tuple<std::vector<map::TrackId>, MatX2f, MatX2f> GetAllCommonObservationsArrays(
+    const ShotId& shot1,
+    const ShotId& shot2) const;
 
   using ShotPair = std::pair<ShotId, ShotId>;
   std::unordered_map<ShotPair, int, HashPair> GetAllPairsConnectivity(

--- a/opensfm/src/sfm/CMakeLists.txt
+++ b/opensfm/src/sfm/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(sfm
   PRIVATE
     foundation
     map
+    geometry
     bundle
 )
 target_include_directories(sfm PUBLIC ${CMAKE_SOURCE_DIR})

--- a/opensfm/src/sfm/ba_helpers.h
+++ b/opensfm/src/sfm/ba_helpers.h
@@ -18,6 +18,7 @@ class BAHelpers {
       const std::unordered_map<map::RigCameraId, map::RigCamera>&
           rig_camera_priors,
       const AlignedVector<map::GroundControlPoint>& gcp,
+      int grid_size,
       const py::dict& config);
 
   static py::tuple BundleLocal(
@@ -26,7 +27,9 @@ class BAHelpers {
       const std::unordered_map<map::RigCameraId, map::RigCamera>&
           rig_camera_priors,
       const AlignedVector<map::GroundControlPoint>& gcp,
-      const map::ShotId& central_shot_id, const py::dict& config);
+      const map::ShotId& central_shot_id, 
+      int grid_size,
+      const py::dict& config);
 
   static py::dict BundleShotPoses(
       map::Map& map, const std::unordered_set<map::ShotId>& shot_ids,
@@ -56,6 +59,11 @@ class BAHelpers {
       bundle::BundleAdjuster& ba, const map::Map& map,
       const AlignedVector<map::GroundControlPoint>& gcp,
       const py::dict& config);
+
+  static std::unordered_set<map::TrackId> SelectTracksGrid(
+    map::Map& map,
+    const std::unordered_set<map::ShotId>& shot_ids,
+    size_t grid_size);
 
  private:
   static std::unordered_set<map::Shot*> DirectShotNeighbors(

--- a/opensfm/src/sfm/ba_helpers.h
+++ b/opensfm/src/sfm/ba_helpers.h
@@ -72,6 +72,7 @@ class BAHelpers {
   static bool TriangulateGCP(
       const map::GroundControlPoint& point,
       const std::unordered_map<map::ShotId, map::Shot>& shots,
+      float reproj_threshold,
       Vec3d& coordinates);
 
   static void AlignmentConstraints(

--- a/opensfm/src/sfm/retriangulation.h
+++ b/opensfm/src/sfm/retriangulation.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <unordered_set>
+
 #include <map/map.h>
 #include <map/tracks_manager.h>
 
 namespace sfm::retriangulation {
 void RealignMaps(const map::Map& reference, map::Map& to_align,
                  bool update_points);
+int Triangulate(map::Map& map, const std::unordered_set<map::TrackId>& track_ids, float min_angle, float min_depth, int processing_threads);
 }  // namespace sfm::retriangulation

--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -351,8 +351,8 @@ py::tuple BAHelpers::BundleLocal(
 bool BAHelpers::TriangulateGCP(
     const map::GroundControlPoint& point,
     const std::unordered_map<map::ShotId, map::Shot>& shots,
+    float reproj_threshold,
     Vec3d& coordinates) {
-  constexpr auto reproj_threshold{1.0};
   constexpr auto min_ray_angle = 0.1 * M_PI / 180.0;
   constexpr auto min_depth = 1e-3;  // Assume GCPs 1mm+ away from the camera
   MatX3d os, bs;
@@ -394,31 +394,38 @@ size_t BAHelpers::AddGCPToBundle(
                               ba.GetProjectionsCount() +
                               ba.GetRelativeMotionsCount();
 
-  size_t total_terms = 0;
-  for (const auto& point : gcp) {
-    Vec3d coordinates;
-    if (TriangulateGCP(point, shots, coordinates) || !point.lla_.empty()) {
-      ++total_terms;
-    }
-    for (const auto& obs : point.observations_) {
-      total_terms += (shots.count(obs.shot_id_) > 0);
-    }
-  }
-
-  double global_weight = config["gcp_global_weight"].cast<double>() *
-                         dominant_terms / std::max<size_t>(1, total_terms);
+  const float reproj_threshold =
+      config["gcp_reprojection_error_threshold"].cast<float>();
 
   size_t added_gcp_observations = 0;
   for (const auto& point : gcp) {
     const auto point_id = "gcp-" + point.id_;
     Vec3d coordinates;
-    if (!TriangulateGCP(point, shots, coordinates)) {
+    if (!TriangulateGCP(point, shots, reproj_threshold, coordinates)) {
       if (!point.lla_.empty()) {
         coordinates = reference.ToTopocentric(point.GetLlaVec3d());
       } else {
         continue;
       }
     }
+
+    double avg_observations = 0.;
+    int valid_shots = 0;
+    for (const auto& obs : point.observations_) {
+      const auto shot_it = shots.find(obs.shot_id_);
+      if (shot_it != shots.end()) {
+        const auto& shot = (shot_it->second);
+        avg_observations += shot.GetLandmarkObservations().size();
+        ++valid_shots;
+      }
+    }
+
+    if(!valid_shots) {
+      continue;
+    }
+    avg_observations /= valid_shots;
+
+    const double prior_weight = config["gcp_global_weight"].cast<double>() * avg_observations;
     constexpr auto point_constant{false};
     ba.AddPoint(point_id, coordinates, point_constant);
     if (!point.lla_.empty()) {
@@ -426,16 +433,17 @@ size_t BAHelpers::AddGCPToBundle(
                                    config["gcp_horizontal_sd"].cast<double>(),
                                    config["gcp_vertical_sd"].cast<double>());
       ba.AddPointPrior(point_id, reference.ToTopocentric(point.GetLlaVec3d()),
-                       point_std / global_weight, point.has_altitude_);
+                       point_std / prior_weight, point.has_altitude_);
     }
 
     // Now iterate through the observations
+    const double obs_weight = config["gcp_global_weight"].cast<double>() * avg_observations;
     for (const auto& obs : point.observations_) {
       const auto& shot_id = obs.shot_id_;
       if (shots.count(shot_id) > 0) {
         constexpr double scale{0.001};
         ba.AddPointProjectionObservation(shot_id, point_id, obs.projection_,
-                                         scale / global_weight);
+                                         scale / obs_weight);
         ++added_gcp_observations;
       }
     }
@@ -829,7 +837,7 @@ py::dict BAHelpers::Bundle(
     AddGCPToBundle(ba, map, gcp, config);
   }
 
-  if (config["bundle_compensate_gps_bias"].cast<bool>()) {
+  if (config["bundle_compensate_gps_bias"].cast<bool>() && !gcp.empty()) {
     const auto& biases = map.GetBiases();
     for (const auto& camera : map.GetCameras()) {
       ba.SetCameraBias(camera.first, biases.at(camera.first));
@@ -989,7 +997,7 @@ void BAHelpers::AlignmentConstraints(
         continue;
       }
       Vec3d coordinates;
-      if (TriangulateGCP(point, shots, coordinates)) {
+      if (TriangulateGCP(point, shots, config["gcp_reprojection_error_threshold"].cast<float>(), coordinates)) {
         Xp.row(idx) = topocentricConverter.ToTopocentric(point.GetLlaVec3d());
         X.row(idx) = coordinates;
         ++idx;

--- a/opensfm/src/sfm/src/tracks_helpers.cc
+++ b/opensfm/src/sfm/src/tracks_helpers.cc
@@ -11,8 +11,15 @@ std::unordered_map<map::ShotId, int> CountTracksPerShot(
   for (const auto& track : tracks) {
     tracks_set.insert(track);
   }
+  
   std::unordered_map<map::ShotId, int> counts;
-  for (const auto& shot : shots) {
+
+#pragma omp parallel
+{
+  std::vector<int> thread_counts(shots.size(), 0);
+#pragma omp for
+  for (int i = 0; i < shots.size(); ++i) {
+    const auto& shot = shots[i];
     const auto& observations = manager.GetShotObservations(shot);
 
     int sum = 0;
@@ -23,8 +30,19 @@ std::unordered_map<map::ShotId, int> CountTracksPerShot(
       }
       ++sum;
     }
-    counts[shot] = sum;
+    thread_counts[i] = sum;
   }
+
+#pragma omp critical
+  {
+    for (int i = 0; i < shots.size(); ++i) {
+      if (thread_counts[i] > 0) {
+        counts[shots[i]] = thread_counts[i];
+      }
+    }
+  }
+}
+
   return counts;
 }
 

--- a/opensfm/stats.py
+++ b/opensfm/stats.py
@@ -94,7 +94,9 @@ def gcp_errors(
 
         triangulated = None
         for rec in reconstructions:
-            triangulated = multiview.triangulate_gcp(gcp, rec.shots, 1.0, 0.1)
+            triangulated = multiview.triangulate_gcp(
+                gcp, rec.shots, data.config["gcp_reprojection_error_threshold"]
+            )
             if triangulated is None:
                 continue
             else:
@@ -583,7 +585,9 @@ def save_residual_histogram(
         n,
         _,
         p_angular,
-    ) = axs[2].hist(b_angular[:-1], b_angular, weights=h_angular)
+    ) = axs[
+        2
+    ].hist(b_angular[:-1], b_angular, weights=h_angular)
     n = n.astype("int")
     for i in range(len(p_angular)):
         p_angular[i].set_facecolor(plt.cm.viridis(n[i] / max(n)))

--- a/opensfm/vlad.py
+++ b/opensfm/vlad.py
@@ -41,8 +41,14 @@ def vlad_distances(
     Returns the image, the order of the other images,
     and the other images.
     """
+
+    # avoid passing a gigantic VLAD dictionary in case of preemption : copy instead
+    ratio_copy = 0.5
+    need_copy = len(other_images) < ratio_copy*len(histograms)
+    candidates = {k: histograms[k] for k in other_images + [image]} if need_copy else histograms
+
     distances, others = pyfeatures.compute_vlad_distances(
-        histograms, image, set(other_images)
+        candidates, image, set(other_images)
     )
     return image, distances, others
 


### PR DESCRIPTION
This PR fixes the GCP handling which was not great : 
 - Quality report and triangulation used different sets of thresholds. We now use 0.050 consistently, which makes room for "enforcing" GCPs while allowing removal of complete outliers.
  - Bias compensation is now only activated in BA if there's GCPs
  - LS Alignment uses GCPs OR GPS but NOT BOTH together as there's usually no guarantee of consistency between their respective  coordinate system
  - GCP weighting has been tweaked a bit

Branch is on top of optim-large