### PR TITLE
fix: default to numpy.core if available

### DIFF
--- a/opensfm/dataset.py
+++ b/opensfm/dataset.py
@@ -349,7 +349,7 @@ class DataSet(DataSetBase):
         class MatchingUnpickler(pickle.Unpickler):
             # Handle both numpy <2.0 (np.core) and numpy >=2.0 (np._core)
             _multiarray = (
-                np._core.multiarray if hasattr(np, "_core") else np.core.multiarray
+                np.core.multiarray if hasattr(np, "core") else np._core.multiarray
             )
             modules_map = {
                 "numpy.core.multiarray._reconstruct": _multiarray,


### PR DESCRIPTION
Not sure how to best handle access to `numpy.core` (in numpy 1) and `numpy._core` (in numpy 2). It seems the best would be not to access it at all.

In any case, there are situations in numpy 1 where `numpy._core` exists but does not contain any `multiarray` definition. So we default to use `numpy.core` if it exists and only use `numpy._core` otherwise.

Tested locally using `uv`. Failed before this fix.