### PR TITLE
Correct definition of is_fixed in BundleShotPoses

### DIFF
--- a/opensfm/src/sfm/src/ba_helpers.cc
+++ b/opensfm/src/sfm/src/ba_helpers.cc
@@ -498,7 +498,7 @@ py::dict BAHelpers::BundleShotPoses(
       shot_cameras[shot_id] = shot.GetCamera()->id;
       shot_rig_cameras[shot_id] = shot_n_rig_camera.second->id;
 
-      const auto is_fixed = shot_ids.find(shot_id) != shot_ids.end();
+      const auto is_fixed = shot_ids.find(shot_id) == shot_ids.end();
       if (!is_fixed) {
         if (config["bundle_use_gps"].cast<bool>()) {
           const auto pos = shot.GetShotMeasurements().gps_position_;


### PR DESCRIPTION
This is a PR for Issue #1083 

As discussed there, the definition of “is_fixed” in BundleShotPoses is probably incorrect, leading to unnecessary runs of the Ceres optimizer. Although the impact is rather minor, a correct definition is preferable.